### PR TITLE
[2C-12]: Settings — URL + token entry, atomic storage, re-pair flow

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist', 'cypress.config.ts'] },
+  { ignores: ['dist', 'android', 'cypress.config.ts'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,24 @@
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import App from './App';
 
-test('renders the scaffold message on the home route', () => {
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(async () => ({ value: null })),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('mounts and redirects first-run users to the Settings screen', async () => {
   render(<App />);
-  expect(screen.getByText(/BRAIN Companion · Phase 2 scaffold/)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Server URL')).toBeInTheDocument();
+    expect(screen.getByText('Bearer Token')).toBeInTheDocument();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
-import { Redirect, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Route, useHistory } from 'react-router-dom';
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import HomePage from './pages/HomePage';
+import SettingsPage from './pages/SettingsPage';
+import PairedPlaceholderPage from './pages/PairedPlaceholderPage';
+import { loadPairing } from './lib/pairing';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -28,15 +32,36 @@ import './theme/tailwind.css';
 
 setupIonicReact();
 
+const RootRedirect: React.FC = () => {
+  const history = useHistory();
+  useEffect(() => {
+    let cancelled = false;
+    loadPairing().then((pairing) => {
+      if (cancelled) return;
+      history.replace(pairing ? '/paired-placeholder' : '/settings');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [history]);
+  return null;
+};
+
 const App: React.FC = () => (
   <IonApp>
     <IonReactRouter>
       <IonRouterOutlet>
+        <Route exact path="/settings">
+          <SettingsPage />
+        </Route>
+        <Route exact path="/paired-placeholder">
+          <PairedPlaceholderPage />
+        </Route>
         <Route exact path="/home">
           <HomePage />
         </Route>
         <Route exact path="/">
-          <Redirect to="/home" />
+          <RootRedirect />
         </Route>
       </IonRouterOutlet>
     </IonReactRouter>

--- a/src/lib/pairing.ts
+++ b/src/lib/pairing.ts
@@ -1,0 +1,62 @@
+import { Preferences } from '@capacitor/preferences';
+
+export interface Pairing {
+  url: string;
+  token: string;
+}
+
+export const PAIRING_URL_KEY = 'brain.serverUrl';
+export const PAIRING_TOKEN_KEY = 'brain.bearerToken';
+
+type Listener = (pairing: Pairing | null) => void;
+
+const listeners = new Set<Listener>();
+
+function notify(pairing: Pairing | null): void {
+  for (const listener of listeners) {
+    listener(pairing);
+  }
+}
+
+/**
+ * Persist URL + token together. Pseudo-atomic: on token-write failure,
+ * the URL is removed so the keys remain in a both-or-neither state.
+ */
+export async function savePairing(url: string, token: string): Promise<void> {
+  await Preferences.set({ key: PAIRING_URL_KEY, value: url });
+  try {
+    await Preferences.set({ key: PAIRING_TOKEN_KEY, value: token });
+  } catch (error) {
+    await Preferences.remove({ key: PAIRING_URL_KEY });
+    throw error;
+  }
+  notify({ url, token });
+}
+
+export async function loadPairing(): Promise<Pairing | null> {
+  const [urlResult, tokenResult] = await Promise.all([
+    Preferences.get({ key: PAIRING_URL_KEY }),
+    Preferences.get({ key: PAIRING_TOKEN_KEY }),
+  ]);
+  const url = urlResult.value;
+  const token = tokenResult.value;
+  if (!url || !token) {
+    return null;
+  }
+  return { url, token };
+}
+
+export async function clearPairing(): Promise<void> {
+  await Promise.all([
+    Preferences.remove({ key: PAIRING_URL_KEY }),
+    Preferences.remove({ key: PAIRING_TOKEN_KEY }),
+  ]);
+  notify(null);
+}
+
+export function subscribePairing(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/pages/PairedPlaceholderPage.tsx
+++ b/src/pages/PairedPlaceholderPage.tsx
@@ -1,0 +1,21 @@
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+
+const PairedPlaceholderPage: React.FC = () => {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Paired</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen className="ion-padding">
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-center text-neutral-50">
+          <p className="text-xl font-medium">Paired</p>
+          <p className="text-sm text-neutral-300">Notifications view coming soon.</p>
+        </div>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default PairedPlaceholderPage;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  IonButton,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonNote,
+  IonPage,
+  IonText,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+} from '@ionic/react';
+import { eye, eyeOff } from 'ionicons/icons';
+import {
+  clearPairing,
+  loadPairing,
+  savePairing,
+  type Pairing,
+} from '../lib/pairing';
+
+const MIN_TOKEN_LENGTH = 8;
+
+function isValidUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function maskToken(token: string): string {
+  return `****${token.slice(-4)}`;
+}
+
+const SettingsPage: React.FC = () => {
+  const history = useHistory();
+  const [storedPairing, setStoredPairing] = useState<Pairing | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadPairing().then((pairing) => {
+      if (cancelled) return;
+      setStoredPairing(pairing);
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const trimmedUrl = url.trim();
+  const trimmedToken = token.trim();
+  const urlValid = trimmedUrl.length > 0 && isValidUrl(trimmedUrl);
+  const tokenValid = trimmedToken.length >= MIN_TOKEN_LENGTH;
+  const canConnect = urlValid && tokenValid && !submitting;
+
+  const handleUrlBlur = () => {
+    if (trimmedUrl.length === 0) {
+      setUrlError(null);
+      return;
+    }
+    setUrlError(isValidUrl(trimmedUrl) ? null : 'Enter a valid http:// or https:// URL');
+  };
+
+  const handleTokenBlur = () => {
+    if (trimmedToken.length === 0) {
+      setTokenError(null);
+      return;
+    }
+    setTokenError(
+      trimmedToken.length < MIN_TOKEN_LENGTH
+        ? `Token must be at least ${MIN_TOKEN_LENGTH} characters`
+        : null,
+    );
+  };
+
+  const handleConnect = async () => {
+    if (!canConnect) return;
+    setSubmitting(true);
+    try {
+      await savePairing(trimmedUrl, trimmedToken);
+      // [2C-13] hooks the validation ping in here before navigation; until
+      // then we route directly to the post-pair landing screen.
+      history.replace('/paired-placeholder');
+    } catch {
+      setToastMessage('Could not save pairing. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRepair = async () => {
+    await clearPairing();
+    setStoredPairing(null);
+    setUrl('');
+    setToken('');
+    setShowToken(false);
+    setUrlError(null);
+    setTokenError(null);
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Settings</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen className="ion-padding">
+        {!loaded ? null : storedPairing ? (
+          <section aria-label="Pairing">
+            <IonItem>
+              <IonLabel>
+                <h2>Server URL</h2>
+                <IonText color="medium">
+                  <p>{storedPairing.url}</p>
+                </IonText>
+              </IonLabel>
+            </IonItem>
+            <IonItem>
+              <IonLabel>
+                <h2>Bearer Token</h2>
+                <IonText color="medium">
+                  <p>{maskToken(storedPairing.token)}</p>
+                </IonText>
+              </IonLabel>
+            </IonItem>
+            <IonButton
+              expand="block"
+              color="medium"
+              className="ion-margin-top"
+              onClick={handleRepair}
+            >
+              Re-pair
+            </IonButton>
+          </section>
+        ) : (
+          <section aria-label="Pairing form">
+            <IonItem>
+              <IonLabel position="stacked">Server URL</IonLabel>
+              <IonInput
+                type="url"
+                inputMode="url"
+                autocapitalize="off"
+                spellcheck={false}
+                placeholder="https://brain.local:8000"
+                value={url}
+                onIonInput={(event) => setUrl(event.detail.value ?? '')}
+                onIonBlur={handleUrlBlur}
+              />
+            </IonItem>
+            {urlError ? (
+              <IonNote color="danger" className="ion-padding-start">
+                {urlError}
+              </IonNote>
+            ) : null}
+
+            <IonItem>
+              <IonLabel position="stacked">Bearer Token</IonLabel>
+              <IonInput
+                type={showToken ? 'text' : 'password'}
+                placeholder="Paste token from brain3 token generate"
+                value={token}
+                onIonInput={(event) => setToken(event.detail.value ?? '')}
+                onIonBlur={handleTokenBlur}
+              />
+              <IonButton
+                slot="end"
+                fill="clear"
+                size="small"
+                onClick={() => setShowToken((value) => !value)}
+                aria-label={showToken ? 'Hide token' : 'Show token'}
+              >
+                <IonIcon icon={showToken ? eyeOff : eye} />
+              </IonButton>
+            </IonItem>
+            {tokenError ? (
+              <IonNote color="danger" className="ion-padding-start">
+                {tokenError}
+              </IonNote>
+            ) : null}
+
+            <IonButton
+              expand="block"
+              className="ion-margin-top"
+              disabled={!canConnect}
+              onClick={handleConnect}
+            >
+              Connect
+            </IonButton>
+          </section>
+        )}
+
+        {/* Device section — [2C-08] anchor: render FCM token preview + Re-register button here. */}
+        <IonItem className="ion-margin-top" aria-label="Device section placeholder" />
+
+        <IonToast
+          isOpen={toastMessage !== null}
+          message={toastMessage ?? ''}
+          duration={4000}
+          onDidDismiss={() => setToastMessage(null)}
+        />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default SettingsPage;

--- a/tests/unit/pairing.spec.ts
+++ b/tests/unit/pairing.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  PAIRING_TOKEN_KEY,
+  PAIRING_URL_KEY,
+  clearPairing,
+  loadPairing,
+  savePairing,
+  subscribePairing,
+} from '../../src/lib/pairing';
+
+const store = new Map<string, string>();
+
+beforeEach(() => {
+  store.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: store.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    store.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    store.delete(key);
+  });
+});
+
+describe('savePairing', () => {
+  it('persists URL and token under the brain. namespace', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    expect(store.get(PAIRING_URL_KEY)).toBe('https://brain.local:8000');
+    expect(store.get(PAIRING_TOKEN_KEY)).toBe('abcdef1234');
+  });
+
+  it('rolls back the URL write if the token write fails (both-or-neither)', async () => {
+    vi.mocked(Preferences.set).mockReset();
+    vi.mocked(Preferences.set)
+      .mockImplementationOnce(async ({ key, value }) => {
+        store.set(key, value);
+      })
+      .mockImplementationOnce(async () => {
+        throw new Error('write failure');
+      });
+
+    await expect(
+      savePairing('https://brain.local:8000', 'abcdef1234'),
+    ).rejects.toThrow('write failure');
+
+    expect(store.has(PAIRING_URL_KEY)).toBe(false);
+    expect(store.has(PAIRING_TOKEN_KEY)).toBe(false);
+  });
+});
+
+describe('loadPairing', () => {
+  it('returns the pairing when both keys are present', async () => {
+    store.set(PAIRING_URL_KEY, 'https://brain.local:8000');
+    store.set(PAIRING_TOKEN_KEY, 'abcdef1234');
+    expect(await loadPairing()).toEqual({
+      url: 'https://brain.local:8000',
+      token: 'abcdef1234',
+    });
+  });
+
+  it('returns null if only the URL is stored', async () => {
+    store.set(PAIRING_URL_KEY, 'https://brain.local:8000');
+    expect(await loadPairing()).toBeNull();
+  });
+
+  it('returns null if only the token is stored', async () => {
+    store.set(PAIRING_TOKEN_KEY, 'abcdef1234');
+    expect(await loadPairing()).toBeNull();
+  });
+
+  it('returns null if neither key is stored', async () => {
+    expect(await loadPairing()).toBeNull();
+  });
+});
+
+describe('clearPairing', () => {
+  it('removes both the URL and the token', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    await clearPairing();
+    expect(store.has(PAIRING_URL_KEY)).toBe(false);
+    expect(store.has(PAIRING_TOKEN_KEY)).toBe(false);
+  });
+});
+
+describe('subscribePairing', () => {
+  it('notifies subscribers on save and clear, and stops after unsubscribe', async () => {
+    const events: Array<{ url: string; token: string } | null> = [];
+    const unsubscribe = subscribePairing((pairing) => events.push(pairing));
+
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    await clearPairing();
+
+    unsubscribe();
+    await savePairing('https://brain.local:8000', 'zzzzzzzz');
+
+    expect(events).toEqual([
+      { url: 'https://brain.local:8000', token: 'abcdef1234' },
+      null,
+    ]);
+  });
+});


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors, no warnings after android/ ignore — see Deviations)
- `npm run build` (tsc + vite) — ✅ Pass (chunk-size warning is pre-existing scaffold noise)
- `npx vitest run` — ✅ Pass (9 passed, 0 failed across 2 test files)

Ran locally against develop HEAD at `b950657` immediately before opening this PR.

## Summary

Implements `[2C-12]`: the first interactive screen in the Companion app. Adds the `/settings` route, an atomic URL + bearer-token pairing storage layer, and first-run redirect logic in `App.tsx` so users without stored credentials land on Settings on app launch. Wires the Connect button up to the pairing save (the validation ping itself is `[2C-13]`'s job — this PR routes straight to the post-pair landing once credentials are saved). Adds a `/paired-placeholder` screen as the pre-Chunk-2 default landing so post-pair users do not white-screen.

## Changes

- `src/lib/pairing.ts` — new. Exposes `savePairing` / `loadPairing` / `clearPairing` / `subscribePairing` against `@capacitor/preferences` under the `brain.` key namespace. `savePairing` is pseudo-atomic: on token-write failure the URL write is rolled back so the keys stay in a both-or-neither state, honoring Pass 2 boundary-crossing flag #1.
- `src/pages/SettingsPage.tsx` — new. Two-state UI:
  - **Unpaired:** URL + masked token inputs (with a show/hide toggle), inline validation (URL must parse as `http://` or `https://`; token must be ≥ 8 chars), Connect button disabled until both are valid; on Connect saves the pairing and navigates to `/paired-placeholder`. `IonToast` shown on save failure without clearing the form.
  - **Paired:** displays stored URL + `****<last4>` masked token + Re-pair button that clears storage and returns to the empty form.
  - Empty `IonItem` left below as the `[2C-08]` anchor for FCM token preview + Re-register button.
- `src/pages/PairedPlaceholderPage.tsx` — new. Pre-Chunk-2 default landing with "Notifications view coming soon" copy.
- `src/App.tsx` — new `RootRedirect` component reads pairing on mount and replaces history with `/settings` or `/paired-placeholder`. New routes registered.
- `src/App.test.tsx` — rewritten to cover the new first-run redirect flow (the original asserted the `/home` scaffold message, which no path now leads to).
- `tests/unit/pairing.spec.ts` — new. 8 cases covering save / load / clear / both-or-neither rollback / subscribe semantics with a mocked `@capacitor/preferences`.
- `eslint.config.js` — adds `android/` to the ignores list (see Deviations).

## How to Verify

1. `npm install` (already in tree).
2. `npm run lint` — expect zero errors, zero warnings.
3. `npm run build` — expect `tsc` clean and `vite build` to emit `dist/`.
4. `npx vitest run` — expect 9 / 9 tests passing across `tests/unit/pairing.spec.ts` and `src/App.test.tsx`.
5. `npm run dev` — open the app:
   - Fresh state → page redirects to `/settings`. URL + token fields visible, Connect disabled.
   - Type a malformed URL (e.g. `not a url`), blur → inline error shown, Connect stays disabled.
   - Type `https://brain.local:8000` and an 8+ char token → Connect enables.
   - Click Connect → routes to `/paired-placeholder`.
   - Refresh the browser → app boots straight onto `/paired-placeholder` (no settings redirect because pairing is stored).
   - Manually navigate to `/settings` → stored-pairing view renders with masked token (`****<last4>`) and Re-pair button.
   - Click Re-pair → form returns; refresh boots back onto `/settings`.

## Deviations

- **D-1 — Test file location.** Spec calls for `tests/unit/pairing.spec.ts`. The `[2C-10]` scaffold convention is co-located tests (`src/App.test.tsx`). I followed the spec literally and placed the new test at `tests/unit/pairing.spec.ts`, creating the directory. Vitest's default include pattern picks it up. Flagging so the codebase convention can be revisited if the scaffold pattern should win going forward.
- **D-2 — `App.test.tsx` rewritten.** The pre-existing scaffold test asserted "BRAIN Companion · Phase 2 scaffold" appears at `/home`. With the first-run redirect added in this ticket, mounting `<App />` at `/` no longer lands on `/home`; it lands on `/settings`. The original mount-smoke intent is preserved by the rewritten test (App still mounts cleanly and hits the new landing).
- **D-3 — `HomePage.tsx` left orphaned.** The `/home` route still exists but no path leads there after this ticket. I left it intact rather than delete because deletion is outside `[2C-12]`'s scope and may need revisiting in `[2C-13]`+. Flagging for L's call on whether to file a follow-up cleanup ticket.
- **D-4 — eslint config: ignore `android/`.** `npm run lint` was failing on develop before this branch — the Android platform added in `[2C-11]` puts generated artifacts under `android/app/build/intermediates/.../native-bridge.js`, which eslint's flat config picked up and choked on (no `@typescript-eslint/no-unused-vars` rule definition). The directory is already gitignored and contains no TypeScript that needs linting. Added `'android'` to the ignore list as the minimal fix to unblock verification on this PR. Surfacing as a deviation because the fix conceptually belongs to `[2C-11]`'s cleanup; resolving it inline because the verification directive (`55e13fd1`) requires lint to pass before opening a PR.
- **D-5 — Default landing page path name.** Spec mentions both "Paired" placeholder and `/paired-placeholder` as the route. Used `/paired-placeholder` literally with a "Paired" header.

## Acceptance Checklist

- [x] Fresh install → app launches → redirects to `/settings` (no pairing stored).
- [x] Enter URL + token → Connect enabled → tap → savePairing fires (validation ping arrives in `[2C-13]`).
- [x] Store + relaunch app → app launches → NOT redirected to settings → lands on `/paired-placeholder`.
- [x] Re-pair button → preferences cleared → form re-appears.
- [x] Re-entering an invalid URL (no scheme, malformed) → inline validation error, Connect stays disabled.
- [x] Token masked by default; toggle-show reveals.
- [x] Last-four chars shown in Re-pair section when pairing is stored.
- [x] `tests/unit/pairing.spec.ts` covers save / load / clear / atomic-both-or-neither behavior (and subscribe semantics).

Closes #7