### PR TITLE
[2C-Bug-01] dev-release workflow: setup-android packages input parses as one concatenated string

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: |
-            platforms;android-34
-            build-tools;35.0.0
+          # `packages` is a single string parsed as space-separated entries.
+          # A multi-line block scalar (`|`) embeds the newline literally and
+          # sdkmanager treats the value as one concatenated package name —
+          # see #31. Keep this on one line.
+          packages: 'platforms;android-34 build-tools;35.0.0'
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
## Verification

Ran locally against develop HEAD at **`312e35f`** immediately before opening this PR.

- `npm run lint` — ✅ Pass (clean exit, no output)
- `npm run test.unit -- --run` — ✅ Pass (2 test files, 9 tests, vitest 1.6.1)
- `.github/workflows/dev-release.yml` YAML parse — ✅ Pass; the `packages` value now parses to `'platforms;android-34 build-tools;35.0.0'` and `.split()` yields `['platforms;android-34', 'build-tools;35.0.0']` — two distinct entries, which is what `sdkmanager` expects.
- End-to-end workflow run on `develop` — ⏳ Will validate on the merge of this PR (the fix lives in the workflow itself, so the only way to confirm it works is to trigger it).

## Summary

Fixes the `Set up Android SDK` step in the new `Dev Release` workflow, which failed on its very first run (run [#24935297804](https://github.com/WilliM233/brain3-companion/actions/runs/24935297804) on the merge of [2C-15] PR #30). Root cause is in the `[2C-15]` workflow file I just merged — multi-line YAML block scalar (`packages: |`) embedded a literal newline into a single string that `sdkmanager` then treated as one concatenated package name.

## Changes

- **`.github/workflows/dev-release.yml`** — `packages:` input on the `android-actions/setup-android@v3` step changed from a `|` block scalar (two lines, embedded newline preserved) to a single-line space-separated string. Added a 4-line comment above it explaining why this needs to stay on one line, with an inline reference to issue #31, so the next agent who edits this step does not re-introduce the same mistake.

## How to Verify

```sh
git checkout fix/2C-Bug-01-setup-android-packages-input
npm install
npm run lint
npm run test.unit -- --run

# Confirm the YAML parses and `packages` resolves to two entries:
python -c "import yaml; d=yaml.safe_load(open('.github/workflows/dev-release.yml')); p=d['jobs']['build-and-release']['steps'][3]['with']['packages']; print(repr(p)); print(p.split())"
```

Expected output:

```
'platforms;android-34 build-tools;35.0.0'
['platforms;android-34', 'build-tools;35.0.0']
```

Post-merge: the `Dev Release` workflow fires on the merge to `develop`. The `Set up Android SDK` step should now install both packages cleanly, the workflow should reach the `assembleDebug` step, and a fresh `develop-{short-sha}` pre-release should land on the [Releases page](https://github.com/WilliM233/brain3-companion/releases) with `app-debug.apk` attached.

## Deviations

None — straight one-line fix. Spec for the workflow lives in the [2C-15] issue body; this fix restores the workflow to actually meet that spec.

## Test Results

Local run against `develop@312e35f`:

| Check | Result | Evidence |
|---|---|---|
| `npm run lint` | PASS | Exit 0, no output. |
| `npm run test.unit -- --run` | PASS | `Test Files  2 passed (2)` · `Tests  9 passed (9)` (vitest 1.6.1). |
| YAML parse + `packages` value check | PASS | Loads cleanly; `packages` now parses to two entries (`platforms;android-34` and `build-tools;35.0.0`). |

## Acceptance Checklist

- [x] `Dev Release` workflow YAML is valid and the `packages` input parses to the two intended SDK package entries.
- [ ] `Set up Android SDK` step succeeds on the next push to `develop`. — Will validate on the merge of this PR; the fix only takes effect once the corrected workflow file is on `develop`.
- [ ] The full workflow completes end-to-end and a `develop-{short-sha}` pre-release with `app-debug.apk` is published. — Same — validates on the merge of this PR. This re-tests acceptance criterion #2 of [2C-15], which was unmet at PR #30 merge time due to this bug.

Closes #31
