### PR TITLE
2C-12 follow-up: co-locate pairing tests next to source

### DIFF
--- a/src/lib/pairing.test.ts
+++ b/src/lib/pairing.test.ts
@@ -16,7 +16,7 @@ import {
   loadPairing,
   savePairing,
   subscribePairing,
-} from '../../src/lib/pairing';
+} from './pairing';
 
 const store = new Map<string, string>();
 


### PR DESCRIPTION
## Summary
Follow-up to #29 — moves the pairing unit tests from `tests/unit/pairing.spec.ts` to `src/lib/pairing.test.ts` so the test file lives next to its source module. Co-located is the canonical convention; this brings 2C-12's tests in line with it. No production code changes.

Refs #7 (the 2C-12 ticket), follows up on #29 (caught after merge).

## Changes
- `src/lib/pairing.test.ts` (renamed from `tests/unit/pairing.spec.ts`) — git rename preserves history; updated the relative import from `../../src/lib/pairing` to `./pairing`.
- `tests/unit/` and `tests/` directories removed (now empty).

## How to Verify
1. `npm install` (no new deps).
2. `npx vitest run` — expect `Test Files 2 passed (2)`, `Tests 9 passed (9)`.
3. Confirm `tests/` no longer exists at the repo root and `src/lib/pairing.test.ts` is present.

## Deviations
None — pure relocation to satisfy the co-location convention.

## Test Results
```
$ npx vitest run
✓ src/lib/pairing.test.ts (8 tests) 3ms
✓ src/App.test.tsx (1 test) 100ms

Test Files  2 passed (2)
     Tests  9 passed (9)
```

## Acceptance Checklist
- [x] Pairing tests live next to `src/lib/pairing.ts`
- [x] Import paths updated and resolving
- [x] Full vitest suite passes (9/9)
- [x] No orphaned `tests/` directory left behind