### PR TITLE
[2C-06] Install @capacitor/push-notifications, configure Android notification channel, render canned actions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     namespace "com.fluxmeridian.brain3companion"
@@ -47,8 +48,10 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
+    testImplementation 'org.json:json:20240303'
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-preferences')
+    implementation project(':capacitor-push-notifications')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application
+        android:name=".BrainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -27,6 +29,32 @@
             android:grantUriPermissions="true">
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
         </provider>
+
+        <!--
+            Replace the @capacitor/push-notifications MessagingService so FCM
+            delivers data-only messages directly to BrainFirebaseMessagingService.
+            The native handler renders the notification with action buttons; the
+            JS layer is not in the path. See [2C-06] spec.
+        -->
+        <service
+            android:name="com.capacitorjs.plugins.pushnotifications.MessagingService"
+            tools:node="remove" />
+
+        <service
+            android:name=".BrainFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <receiver
+            android:name=".CannedResponseReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.fluxmeridian.brain3companion.action.CANNED_RESPONSE" />
+            </intent-filter>
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainApplication.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainApplication.kt
@@ -1,0 +1,10 @@
+package com.fluxmeridian.brain3companion
+
+import android.app.Application
+
+class BrainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        Notifications.registerChannels(this)
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainFirebaseMessagingService.kt
@@ -1,0 +1,64 @@
+package com.fluxmeridian.brain3companion
+
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.capacitorjs.plugins.pushnotifications.MessagingService
+import com.fluxmeridian.brain3companion.push.NotificationTitleMap
+import com.fluxmeridian.brain3companion.push.PushPayload
+import com.fluxmeridian.brain3companion.push.PushPayloadParser
+import com.google.firebase.messaging.RemoteMessage
+
+/**
+ * Native FCM handler for BRAIN data-only pushes.
+ *
+ * Extends the @capacitor/push-notifications plugin's MessagingService so the
+ * plugin's `onNewToken` token-refresh path stays intact for [2C-08]. Overrides
+ * `onMessageReceived` and intentionally does NOT call super — for canned-response
+ * notifications the native layer is authoritative; the JS layer does not see
+ * the message. See [2C-06] spec.
+ */
+class BrainFirebaseMessagingService : MessagingService() {
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        val payload = PushPayloadParser.parse(remoteMessage.data) ?: return
+        showNotification(payload)
+    }
+
+    private fun showNotification(payload: PushPayload) {
+        val builder = NotificationCompat.Builder(this, Notifications.CANNED_CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(NotificationTitleMap.titleFor(payload.notificationType))
+            .setContentText(payload.message)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .extend(NotificationCompat.WearableExtender())
+
+        payload.cannedResponses.forEach { response ->
+            builder.addAction(buildAction(payload, response))
+        }
+
+        NotificationManagerCompat.from(this)
+            .notify(payload.notificationId.hashCode(), builder.build())
+    }
+
+    private fun buildAction(payload: PushPayload, response: String): NotificationCompat.Action {
+        val intent = Intent(this, CannedResponseReceiver::class.java).apply {
+            action = CannedResponseReceiver.ACTION_RESPOND
+            putExtra(CannedResponseReceiver.EXTRA_NOTIFICATION_ID, payload.notificationId)
+            putExtra(CannedResponseReceiver.EXTRA_NOTIFICATION_TYPE, payload.notificationType)
+            putExtra(CannedResponseReceiver.EXTRA_RESPONSE, response)
+            putExtra(CannedResponseReceiver.EXTRA_SCHEDULED_DATE, payload.scheduledDate)
+            putExtra(CannedResponseReceiver.EXTRA_RULE_ID, payload.ruleId)
+        }
+        val requestCode = (payload.notificationId + "|" + response).hashCode()
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Action.Builder(0, response, pendingIntent).build()
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
@@ -1,0 +1,40 @@
+package com.fluxmeridian.brain3companion
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * Receives canned-response action taps from the notification surface (phone or
+ * watch). [2C-06] dismisses the notification and logs the chosen response —
+ * the HTTP POST to BRAIN and offline-queue handling land in [2C-07].
+ */
+class CannedResponseReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_RESPOND) return
+        val notificationId = intent.getStringExtra(EXTRA_NOTIFICATION_ID) ?: return
+        val response = intent.getStringExtra(EXTRA_RESPONSE) ?: return
+        val notificationType = intent.getStringExtra(EXTRA_NOTIFICATION_TYPE)
+
+        Log.i(
+            TAG,
+            "Canned response tapped: notification_id=$notificationId " +
+                "type=$notificationType response=$response",
+        )
+
+        NotificationManagerCompat.from(context).cancel(notificationId.hashCode())
+    }
+
+    companion object {
+        private const val TAG = "CannedResponseReceiver"
+        const val ACTION_RESPOND = "com.fluxmeridian.brain3companion.action.CANNED_RESPONSE"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+        const val EXTRA_NOTIFICATION_TYPE = "notification_type"
+        const val EXTRA_RESPONSE = "response"
+        const val EXTRA_SCHEDULED_DATE = "scheduled_date"
+        const val EXTRA_RULE_ID = "rule_id"
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/Notifications.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/Notifications.kt
@@ -1,0 +1,25 @@
+package com.fluxmeridian.brain3companion
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object Notifications {
+    const val CANNED_CHANNEL_ID = "brain_canned"
+
+    fun registerChannels(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = ContextCompat.getSystemService(context, NotificationManager::class.java)
+            ?: return
+        val channel = NotificationChannel(
+            CANNED_CHANNEL_ID,
+            context.getString(R.string.notification_channel_canned_name),
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = context.getString(R.string.notification_channel_canned_description)
+        }
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/push/NotificationTitleMap.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/push/NotificationTitleMap.kt
@@ -1,0 +1,12 @@
+package com.fluxmeridian.brain3companion.push
+
+object NotificationTitleMap {
+    private val TITLES = mapOf(
+        "habit_nudge" to "Habit Nudge",
+        "routine_check" to "Routine Check",
+        "rule_trigger" to "Rule Trigger",
+    )
+
+    fun titleFor(notificationType: String): String =
+        TITLES[notificationType] ?: "BRAIN"
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/push/PushPayload.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/push/PushPayload.kt
@@ -1,0 +1,10 @@
+package com.fluxmeridian.brain3companion.push
+
+data class PushPayload(
+    val notificationId: String,
+    val notificationType: String,
+    val message: String,
+    val cannedResponses: List<String>,
+    val scheduledDate: String?,
+    val ruleId: String?,
+)

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/push/PushPayloadParser.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/push/PushPayloadParser.kt
@@ -1,0 +1,38 @@
+package com.fluxmeridian.brain3companion.push
+
+import org.json.JSONArray
+import org.json.JSONException
+
+/**
+ * Parses the FCM data-only push payload sent by brain3.
+ *
+ * Carry-forward from [2C-05] PR #213 D-23: FCM v1 `data` is map<string, string>.
+ * Server JSON-encodes `canned_responses` as a string and substitutes "" for null
+ * `rule_id`. This parser inverts both transforms.
+ */
+object PushPayloadParser {
+
+    fun parse(data: Map<String, String>): PushPayload? {
+        val notificationId = data["notification_id"]?.takeIf { it.isNotEmpty() } ?: return null
+        val notificationType = data["notification_type"]?.takeIf { it.isNotEmpty() } ?: return null
+        val message = data["message"] ?: return null
+        return PushPayload(
+            notificationId = notificationId,
+            notificationType = notificationType,
+            message = message,
+            cannedResponses = parseCannedResponses(data["canned_responses"]),
+            scheduledDate = data["scheduled_date"]?.takeIf { it.isNotEmpty() },
+            ruleId = data["rule_id"]?.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    private fun parseCannedResponses(raw: String?): List<String> {
+        if (raw.isNullOrEmpty()) return emptyList()
+        return try {
+            val array = JSONArray(raw)
+            (0 until array.length()).map { array.getString(it) }
+        } catch (_: JSONException) {
+            emptyList()
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="title_activity_main">BRAIN Companion</string>
     <string name="package_name">com.fluxmeridian.brain3companion</string>
     <string name="custom_url_scheme">com.fluxmeridian.brain3companion</string>
+    <string name="notification_channel_canned_name">BRAIN Reminders</string>
+    <string name="notification_channel_canned_description">Habit nudges, routine checks, and rule triggers with quick canned responses.</string>
 </resources>

--- a/android/app/src/test/java/com/fluxmeridian/brain3companion/push/PushPayloadParserTest.kt
+++ b/android/app/src/test/java/com/fluxmeridian/brain3companion/push/PushPayloadParserTest.kt
@@ -1,0 +1,114 @@
+package com.fluxmeridian.brain3companion.push
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Mirrors the server-side payload contract enforced by
+ * `tests/test_delivery_dispatch.py::test_dispatch_payload_contract` in brain3.
+ * See [2C-05] PR #213 D-23.
+ */
+class PushPayloadParserTest {
+
+    @Test
+    fun `parses a fully-populated habit nudge payload`() {
+        val data = mapOf(
+            "notification_id" to "notif-abc",
+            "notification_type" to "habit_nudge",
+            "message" to "Time to take your meds",
+            "canned_responses" to """["Done","Snooze 10m","Skip"]""",
+            "scheduled_date" to "2026-04-28",
+            "rule_id" to "rule-xyz",
+        )
+
+        val payload = PushPayloadParser.parse(data)!!
+
+        assertEquals("notif-abc", payload.notificationId)
+        assertEquals("habit_nudge", payload.notificationType)
+        assertEquals("Time to take your meds", payload.message)
+        assertEquals(listOf("Done", "Snooze 10m", "Skip"), payload.cannedResponses)
+        assertEquals("2026-04-28", payload.scheduledDate)
+        assertEquals("rule-xyz", payload.ruleId)
+    }
+
+    @Test
+    fun `treats empty-string rule_id as null per server D-23 contract`() {
+        val data = baseData() + ("rule_id" to "")
+        val payload = PushPayloadParser.parse(data)!!
+        assertNull(payload.ruleId)
+    }
+
+    @Test
+    fun `treats missing rule_id as null`() {
+        val data = baseData()
+        val payload = PushPayloadParser.parse(data)!!
+        assertNull(payload.ruleId)
+    }
+
+    @Test
+    fun `parses canned_responses from JSON-encoded string per server D-23 contract`() {
+        val data = baseData() + ("canned_responses" to """["Yes","No"]""")
+        val payload = PushPayloadParser.parse(data)!!
+        assertEquals(listOf("Yes", "No"), payload.cannedResponses)
+    }
+
+    @Test
+    fun `treats missing canned_responses as empty list`() {
+        val data = baseData()
+        val payload = PushPayloadParser.parse(data)!!
+        assertTrue(payload.cannedResponses.isEmpty())
+    }
+
+    @Test
+    fun `treats empty-string canned_responses as empty list`() {
+        val data = baseData() + ("canned_responses" to "")
+        val payload = PushPayloadParser.parse(data)!!
+        assertTrue(payload.cannedResponses.isEmpty())
+    }
+
+    @Test
+    fun `treats malformed canned_responses JSON as empty list rather than crashing`() {
+        val data = baseData() + ("canned_responses" to "not-valid-json")
+        val payload = PushPayloadParser.parse(data)!!
+        assertTrue(payload.cannedResponses.isEmpty())
+    }
+
+    @Test
+    fun `returns null when notification_id is missing`() {
+        val data = baseData() - "notification_id"
+        assertNull(PushPayloadParser.parse(data))
+    }
+
+    @Test
+    fun `returns null when notification_id is empty string`() {
+        val data = baseData() + ("notification_id" to "")
+        assertNull(PushPayloadParser.parse(data))
+    }
+
+    @Test
+    fun `returns null when notification_type is missing`() {
+        val data = baseData() - "notification_type"
+        assertNull(PushPayloadParser.parse(data))
+    }
+
+    @Test
+    fun `returns null when message is missing`() {
+        val data = baseData() - "message"
+        assertNull(PushPayloadParser.parse(data))
+    }
+
+    @Test
+    fun `treats empty-string scheduled_date as null`() {
+        val data = baseData() + ("scheduled_date" to "")
+        val payload = PushPayloadParser.parse(data)!!
+        assertNull(payload.scheduledDate)
+    }
+
+    private fun baseData(): Map<String, String> = mapOf(
+        "notification_id" to "notif-1",
+        "notification_type" to "habit_nudge",
+        "message" to "hello",
+    )
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'
         classpath 'com.google.gms:google-services:4.4.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
 
+include ':capacitor-push-notifications'
+project(':capacitor-push-notifications').projectDir = new File('../node_modules/@capacitor/push-notifications/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -3,6 +3,7 @@ ext {
     compileSdkVersion = 34
     targetSdkVersion = 34
     buildToolsVersion = "35.0.0"
+    kotlinVersion = '1.9.22'
     androidxActivityVersion = '1.8.0'
     androidxAppCompatVersion = '1.6.1'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -15,6 +15,9 @@ const config: CapacitorConfig = {
       splashFullScreen: true,
       splashImmersive: false,
     },
+    PushNotifications: {
+      presentationOptions: ['badge', 'sound', 'alert'],
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/haptics": "^6.0.0",
         "@capacitor/keyboard": "^6.0.0",
         "@capacitor/preferences": "^6.0.0",
+        "@capacitor/push-notifications": "^6.0.5",
         "@capacitor/splash-screen": "^6.0.4",
         "@capacitor/status-bar": "^6.0.0",
         "@ionic/react": "^8.0.0",
@@ -1932,6 +1933,15 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-6.0.4.tgz",
       "integrity": "sha512-ziauSI1pgdyl+gduvvf8lInvzF3Wdyu/ok+u7NlnhKp8XOj9plJgtnXZWFiR8CiCK5wMvo+gFaNh3zhMyEUwpA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/push-notifications": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-6.0.5.tgz",
+      "integrity": "sha512-CsRmb0cnZd9Uwx24ym4My5fNKrQvwI4D51aMEph5pUZy+LAjp6q0y4NJe8DEgwaVdAqVLbb4rqn75AZ4WSiFYg==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/haptics": "^6.0.0",
     "@capacitor/keyboard": "^6.0.0",
     "@capacitor/preferences": "^6.0.0",
+    "@capacitor/push-notifications": "^6.0.5",
     "@capacitor/splash-screen": "^6.0.4",
     "@capacitor/status-bar": "^6.0.0",
     "@ionic/react": "^8.0.0",


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (clean, no output)
- `npm run test.unit` — ✅ Pass (16 passed, 3 files: existing `health`, `pairing`, `App` suites — no new TS tests; the new parser test is JVM-Kotlin)
- `npm run build` — ✅ Pass (chunk-size warning is pre-existing, see PR #35 deviation note)
- `npx cap sync android` — ✅ Pass (push-notifications plugin registered; capacitor.build.gradle / capacitor.settings.gradle regenerated)

Ran locally against develop HEAD at `a472f60` immediately before opening this PR.

**Agent-environment caveat — L verification required:** the agent's runtime has no `JAVA_HOME` / Android SDK, so the Gradle Kotlin compile, the JVM unit test for `PushPayloadParserTest`, and the APK build cannot be run here. Those checks are listed in the **Manual verification by L** section below — they are the spec's acceptance criteria and must pass on L's workstation before merge.

## Summary

Wires the native push surface for BRAIN: installs `@capacitor/push-notifications@^6.0.5`, registers the `brain_canned` Android notification channel at app launch, and adds a Kotlin FCM service that renders data-only pushes from brain3 with one tappable action per canned response. The handler is native-authoritative (does not forward to the JS layer) and uses `NotificationCompat.WearableExtender()` so paired Wear OS devices mirror the action buttons. Action taps fan out to a `CannedResponseReceiver` that — for [2C-06] scope — dismisses the notification and logs the response. The HTTP POST to BRAIN and offline queue land in [2C-07]; FCM registration / token flow lands in [2C-08].

Closes #1

## Changes

**Dependencies (commit `e5a5f00`)**
- `@capacitor/push-notifications@^6.0.5` added to `package.json`.
- Kotlin Gradle plugin `1.9.22` added (classpath in root `android/build.gradle`, `kotlin-android` plugin applied in `android/app/build.gradle`, `kotlin-stdlib` dep on the same version, `kotlinVersion` declared in `variables.gradle`). The repo was Java-only before this ticket — see Deviation D-1.
- `org.json:json:20240303` added as a `testImplementation` so `PushPayloadParserTest` can resolve `JSONArray` on the JVM (built into Android at runtime).
- `capacitor.config.ts` adds a `PushNotifications` plugin block. `capacitor.build.gradle` / `capacitor.settings.gradle` regenerated by `npx cap sync android` to include the `:capacitor-push-notifications` module.

**Native push surface (commit `0001208`)**
- `android/app/src/main/res/values/strings.xml` — adds `notification_channel_canned_name` ("BRAIN Reminders") + `notification_channel_canned_description` strings.
- `Notifications.kt` — single-channel registration helper. Channel id `brain_canned`, importance `IMPORTANCE_HIGH` (heads-up, required for watch mirroring per Android docs), idempotent across launches.
- `BrainApplication.kt` — minimal `Application` subclass. `onCreate()` calls `Notifications.registerChannels(this)`. Wired in via `android:name=".BrainApplication"` on `<application>`. See Finding F-1 — first `Application` subclass for this project.
- `push/PushPayload.kt` + `push/PushPayloadParser.kt` — data class + pure parser, extracted for testability. Inverts both server transforms from [2C-05] D-23: JSON-decodes `canned_responses`, treats empty-string `rule_id` / `scheduled_date` as `null`. Returns `null` (drop) when required fields (`notification_id`, `notification_type`, `message`) are absent or empty rather than crashing. Malformed JSON in `canned_responses` falls back to an empty list.
- `push/NotificationTitleMap.kt` — small `notification_type` → display title mapping (`habit_nudge` → "Habit Nudge", etc.) with a "BRAIN" fallback. Easy to extend as new types land.
- `BrainFirebaseMessagingService.kt` — extends the plugin's `MessagingService` (so its `onNewToken` token-refresh path stays intact for [2C-08]) and overrides `onMessageReceived`. Builds the `NotificationCompat.Builder` with channel `brain_canned`, mapped title, message text, `PRIORITY_HIGH`, `setAutoCancel(true)`, `extend(WearableExtender())`, and one `addAction` per canned response. Action `PendingIntent`s use `FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE` and target `CannedResponseReceiver` with the full payload as extras. **Does not call `super.onMessageReceived`** — the native layer is authoritative for canned-response notifications per the spec; the JS layer is not in the path.
- `CannedResponseReceiver.kt` — `BroadcastReceiver` for the action taps. For [2C-06] scope it `Log.i`s the response (so on-device verification can confirm the receiver fires from the watch via `adb logcat`) and `cancel`s the notification by id. The HTTP POST + offline queue is [2C-07].
- `AndroidManifest.xml` — adds `xmlns:tools`, sets `android:name=".BrainApplication"` on `<application>`, declares `BrainFirebaseMessagingService` with the FCM `MESSAGING_EVENT` intent filter, declares `CannedResponseReceiver` (`exported="false"`, internal action), and uses `tools:node="remove"` on the plugin's `MessagingService` so FCM does not double-deliver. See Deviation D-3.

**Test (commit `2d877e5`)**
- `android/app/src/test/java/com/fluxmeridian/brain3companion/push/PushPayloadParserTest.kt` — 12 JUnit cases mirroring brain3's `tests/test_delivery_dispatch.py::test_dispatch_payload_contract`. Covers fully-populated parse, empty-string `rule_id` → null (D-23 contract), missing `rule_id` → null, JSON-decode of `canned_responses`, missing / empty / malformed `canned_responses` → empty list, missing or empty `notification_id` / `notification_type` / `message` → drop (returns null), empty-string `scheduled_date` → null.

## How to Verify

JS-side (works in any env):
1. `npm install` — pulls `@capacitor/push-notifications@6.0.5` and the Kotlin / JSON test deps.
2. `npm run lint` → clean.
3. `npm run test.unit` → 16/16.
4. `npm run build` → green (chunk-size warning is pre-existing).
5. `npx cap sync android` → registers the plugin (already up to date if `npm install` ran).

Android-side and on-device — see **Manual verification by L** below.

## Manual verification by L (required before merge)

The issue body has no `#### Manual verification` section, but the Acceptance Criteria themselves require Gradle / APK / on-device steps. Per repo CLAUDE.md, no MV obligations apply for the agent — surfacing here for L's workstation:

1. `npm run android:sync` then `cd android && .\gradlew.bat :app:testDebugUnitTest` — runs `PushPayloadParserTest` on the JVM (12 cases).
2. `npm run android:build:debug` — produces the signed debug APK (or `npx cap build android` per spec wording).
3. Drop `google-services.json` at `android/app/` (gitignored — provisioned via Firebase Console per the FCM checklist) and sideload on the reference Galaxy Watch + paired Android phone.
4. Firebase Console → Cloud Messaging → "Send test message" with a data-only payload matching the [2C-05] dispatch shape:
   ```
   notification_id:    notif-test-01
   notification_type:  habit_nudge
   message:            Time to take your meds
   canned_responses:   ["Done","Snooze 10m","Skip"]
   scheduled_date:     2026-04-28
   rule_id:            rule-xyz
   ```
5. Verify:
   - Phone notification: title "Habit Nudge", body "Time to take your meds", three action buttons.
   - Watch face: mirrored notification with the three action buttons tappable.
   - Cold start (force-stop the app, send another push): notification still appears.
   - Tap an action on the watch: `adb logcat -s CannedResponseReceiver` shows `Canned response tapped: notification_id=notif-test-01 type=habit_nudge response=Snooze 10m` on the phone.

If the watch does NOT show actions despite the native `NotificationCompat` path, that is the v0.9 R1 falsification flagged in the spec — surface immediately rather than hacking around.

## Deviations

**D-1: Project lacked Kotlin Gradle setup; added it.** The spec requires Kotlin source files (`BrainFirebaseMessagingService.kt`, `MainActivity.kt or BrainApplication.kt`), but the working tree was Java-only — only `MainActivity.java` existed and the root Gradle had no Kotlin classpath. Added the `kotlin-android` Gradle plugin at `1.9.22` (compatible with AGP `8.2.1` and Capacitor 6's Java 17 target), `kotlin-stdlib` of the same version as a dependency, and `kotlinVersion` in `variables.gradle`. `MainActivity.java` is left as-is — Java and Kotlin coexist in the same module. Honoring spec intent (Kotlin source); flagging because the spec assumed Kotlin was already wired.

**D-2: Spec referenced `com.getcapacitor.plugins.pushnotifications.MessagingService`; actual class in v6.0.5 is `com.capacitorjs.plugins.pushnotifications.MessagingService`.** Verified by reading `node_modules/@capacitor/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/MessagingService.java`. Used the actual class name; spec acknowledged version-sensitivity ("Verify the exact override hook for the pinned plugin version before starting").

**D-3: Plugin's `MessagingService` removed via `tools:node="remove"` rather than co-existing.** FCM behavior with two services bound to `com.google.firebase.MESSAGING_EVENT` is undefined — only one is delivered to. Removing the plugin's registration is the deterministic path. Our service still extends the plugin's `MessagingService` class so its `onNewToken` token-refresh forwarding to `PushNotificationsPlugin` stays intact for [2C-08]. JS-layer features that depend on the plugin (`PushNotifications.register()`, `addListener`) are unaffected — those don't depend on the service registration.

**D-4: `capacitor.config.ts` `PushNotifications.presentationOptions` is iOS-only.** Per the plugin docs, that key only affects iOS notification presentation. The project is Android-only per CLAUDE.md ("Do not add iOS platform, iOS-specific code paths, or iOS-conditional logic"). Configured the block anyway (with `['badge', 'sound', 'alert']`) so the plugin block exists for forward consistency and is harmless on Android. The Android channel id is set in `Notifications.kt` at runtime, not in `capacitor.config.ts` (the plugin config has no Android channel-id key). Honoring spec intent ("configure `pushNotifications` plugin"); noting the iOS / Android asymmetry.

**D-5: Spec said "Add the app icon, a simple splash, and enough theming to look intentional" — already satisfied by [2C-14] PR #34, no work done here.** Launcher icon, adaptive icons, splash screen, and theming all landed in Group 1.

**D-6: `BrainFirebaseMessagingService.onMessageReceived` does not call `super`.** Calling `super` would forward the message to the JS layer via `PushNotificationsPlugin.sendRemoteMessage(...)`. Spec says native handles the notification entirely for canned-response pushes. Skipping `super` keeps the JS layer free of duplicate notification work. If [2C-09]'s "recent notifications view" needs in-process visibility into received messages, the cleaner shape is for [2C-09] to read from a local store the receiver populates, not to receive a duplicate FCM event in JS.

## Findings (out-of-scope, surfacing per CLAUDE.md "log it, don't fix it")

**F-1: First `Application` subclass for this project — "first consumer instantiates" pattern.** Before this ticket, `<application>` had no `android:name`, so the default `android.app.Application` was used. `BrainApplication` is the first explicit subclass. Per the brief's Group 2 watch-item, surfacing for BRAIN's codification call. The Group 1 instance was the `QueryClientProvider` in [2C-13] PR #35; this is the second. Per the brief's rule, the second instance triggers CLAUDE.md codification. Suggested rule of thumb if it lands in CLAUDE.md: "When wiring something for the first time that conventions name but never instantiated (Application class, QueryClientProvider, logger wrapper, HTTP client wrapper), surface in the PR Findings section."

**F-2: `D:\_DEVELOPMENT\CLAUDE.md` is stale relative to BRAIN canonical (`a2fbaab5` v5).** The local file shown in the agent's session-reminder context still ends `*Last updated: April 2026*` and is missing the v5 "CLAUDE.md Inheritance and Source of Truth" section that BRAIN landed on 2026-04-27. Per directive `4ea28266` (CLAUDE.md is PO-controlled), agents flag rather than fix. BRAIN won this session per the inheritance rule.

**F-3: `brain3-companion/CLAUDE.md` working copy is escape-corrupted.** Every markdown character has a literal backslash escape (`\#\#`, `\*\*`, `\_\_`, `\-`, etc.). Content matches BRAIN canonical (`908baa66` v1) once the escapes are stripped, but the file is unrenderable as markdown in this state. Looks like a one-time encoding artifact when the working copy was first synced from BRAIN. Per directive `4ea28266`, flagging only — for L to overwrite from BRAIN canonical.

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint
(clean — no output)

$ npm run test.unit -- --run
> brain3-companion@0.0.1 test.unit
> vitest --run

 ✓ src/lib/health.test.ts  (7 tests)
 ✓ src/lib/pairing.test.ts (8 tests)
 ✓ src/App.test.tsx        (1 test)

 Test Files  3 passed (3)
      Tests  16 passed (16)

$ npm run build
> brain3-companion@0.0.1 build
> tsc && vite build

✓ built in 6.83s
(chunk-size warning unchanged from PR #35 — pre-existing)

$ npx cap sync android
✓ Sync finished in 0.212s
[info] Found 7 Capacitor plugins for android:
       @capacitor/app@6.0.3
       @capacitor/haptics@6.0.3
       @capacitor/keyboard@6.0.4
       @capacitor/preferences@6.0.4
       @capacitor/push-notifications@6.0.5
       @capacitor/splash-screen@6.0.4
       @capacitor/status-bar@6.0.3
```

JVM Kotlin tests + APK build + on-device validation: see **Manual verification by L** above.

## Acceptance Checklist

- [ ] (L) `npx cap build android` (or `npm run android:build:debug`) produces a signed debug APK.
- [ ] (L) Test FCM push from Firebase Console → phone notification with title, message, and one action button per canned response.
- [ ] (L) Same notification mirrored to the watch with action buttons tappable from the watch face.
- [ ] (L) Cold start: app force-stopped → push still produces the notification with actions.
- [ ] (L) Action button tap on the watch → `CannedResponseReceiver.onReceive` fires on the phone (logcat entry confirms).
