### PR TITLE
[2C-08] Device registration flow on first pair and on FCM token refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/android": "^6.2.1",
         "@capacitor/app": "^6.0.0",
         "@capacitor/core": "^6.0.0",
+        "@capacitor/device": "^6.0.3",
         "@capacitor/haptics": "^6.0.0",
         "@capacitor/keyboard": "^6.0.0",
         "@capacitor/preferences": "^6.0.0",
@@ -1909,6 +1910,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/device": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/device/-/device-6.0.3.tgz",
+      "integrity": "sha512-AmPtVuWeW31Ui+UMIl5zgCzwMU4fL4hIvYYvbAhXXyKWjxi1nk+CAh9B3k4OYUQLJI5nan0PoJ4GiiJ7x6DT/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/haptics": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@capacitor/android": "^6.2.1",
     "@capacitor/app": "^6.0.0",
     "@capacitor/core": "^6.0.0",
+    "@capacitor/device": "^6.0.3",
     "@capacitor/haptics": "^6.0.0",
     "@capacitor/keyboard": "^6.0.0",
     "@capacitor/preferences": "^6.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,11 @@ import { IonReactRouter } from '@ionic/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SettingsPage from './pages/SettingsPage';
 import PairedPlaceholderPage from './pages/PairedPlaceholderPage';
-import { loadPairing } from './lib/pairing';
+import { loadPairing, subscribePairing } from './lib/pairing';
+import {
+  clearDeviceRegistration,
+  runDeviceRegistration,
+} from './lib/device-registration';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -49,9 +53,32 @@ const RootRedirect: React.FC = () => {
   return null;
 };
 
+const DeviceRegistrar: React.FC = () => {
+  useEffect(() => {
+    let cancelled = false;
+    loadPairing().then((pairing) => {
+      if (cancelled || !pairing) return;
+      void runDeviceRegistration(pairing);
+    });
+    const unsubscribe = subscribePairing((pairing) => {
+      if (pairing) {
+        void runDeviceRegistration(pairing);
+      } else {
+        void clearDeviceRegistration();
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+  return null;
+};
+
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
     <IonApp>
+      <DeviceRegistrar />
       <IonReactRouter>
         <IonRouterOutlet>
           <Route exact path="/settings">

--- a/src/lib/device-registration.test.ts
+++ b/src/lib/device-registration.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/device', () => ({
+  Device: {
+    getInfo: vi.fn(async () => ({ model: 'Pixel 8' })),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => true),
+    getPlatform: vi.fn(() => 'android'),
+  },
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn(),
+    register: vi.fn(),
+    addListener: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PushNotifications } from '@capacitor/push-notifications';
+import {
+  REGISTERED_TOKEN_KEY,
+  __resetForTests,
+  clearDeviceRegistration,
+  getRegistrationStatus,
+  postDeviceRegistration,
+  reRegisterDevice,
+  runDeviceRegistration,
+  subscribeRegistration,
+  syncFcmToken,
+} from './device-registration';
+
+const PAIRING = {
+  url: 'https://brain.local:8000',
+  token: 'bearer-abc-123',
+} as const;
+
+const FCM_TOKEN_A = 'fcm-token-aaaaaaaa-1111';
+const FCM_TOKEN_B = 'fcm-token-bbbbbbbb-2222';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  __resetForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('postDeviceRegistration — server contract', () => {
+  // Mirrors brain3 [2C-05] DeviceRegisterRequest schema:
+  //   { fcm_token: str, platform: "android"|"ios", label: str | None }
+  // and the bearer-auth requirement on /api/app/devices.
+
+  it('POSTs the contract body to /api/app/devices with bearer auth', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await postDeviceRegistration(PAIRING, FCM_TOKEN_A, 'Pixel 8');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const firstCall = fetchSpy.mock.calls[0]!;
+    const [url, init] = firstCall;
+    expect(url).toBe('https://brain.local:8000/api/app/devices');
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer bearer-abc-123');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      fcm_token: FCM_TOKEN_A,
+      platform: 'android',
+      label: 'Pixel 8',
+    });
+  });
+
+  it('serialises a missing label as JSON null', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await postDeviceRegistration(PAIRING, FCM_TOKEN_A, null);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]?.body as string);
+    expect(body).toEqual({
+      fcm_token: FCM_TOKEN_A,
+      platform: 'android',
+      label: null,
+    });
+  });
+
+  it('strips a trailing slash from pairing.url before joining', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await postDeviceRegistration(
+      { url: 'https://brain.local:8000/', token: 'tok' },
+      FCM_TOKEN_A,
+      null,
+    );
+
+    expect(fetchSpy.mock.calls[0]![0]).toBe(
+      'https://brain.local:8000/api/app/devices',
+    );
+  });
+});
+
+describe('syncFcmToken — registered-flag and token-refresh logic', () => {
+  it('POSTs and persists the token on first registration', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_A);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(prefsStore.get(REGISTERED_TOKEN_KEY)).toBe(FCM_TOKEN_A);
+    expect(getRegistrationStatus()).toEqual({
+      kind: 'registered',
+      fcmToken: FCM_TOKEN_A,
+    });
+  });
+
+  it('skips POST when the stored token matches (registered flag honored)', async () => {
+    prefsStore.set(REGISTERED_TOKEN_KEY, FCM_TOKEN_A);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_A);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getRegistrationStatus()).toEqual({
+      kind: 'registered',
+      fcmToken: FCM_TOKEN_A,
+    });
+  });
+
+  it('re-POSTs when the FCM token rotates (token-refresh case)', async () => {
+    prefsStore.set(REGISTERED_TOKEN_KEY, FCM_TOKEN_A);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_B);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.parse(fetchSpy.mock.calls[0]![1]?.body as string),
+    ).toMatchObject({ fcm_token: FCM_TOKEN_B });
+    expect(prefsStore.get(REGISTERED_TOKEN_KEY)).toBe(FCM_TOKEN_B);
+  });
+
+  it('surfaces server errors and does NOT persist on non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_A);
+
+    expect(prefsStore.has(REGISTERED_TOKEN_KEY)).toBe(false);
+    const status = getRegistrationStatus();
+    expect(status.kind).toBe('error');
+  });
+
+  it('surfaces network failures and does NOT persist (retry-next-launch)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_A);
+
+    expect(prefsStore.has(REGISTERED_TOKEN_KEY)).toBe(false);
+    const status = getRegistrationStatus();
+    expect(status.kind).toBe('error');
+  });
+});
+
+describe('runDeviceRegistration — permission and listener wiring', () => {
+  it('marks status permission_denied and skips register() when not granted', async () => {
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'denied',
+    });
+
+    await runDeviceRegistration(PAIRING);
+
+    expect(PushNotifications.register).not.toHaveBeenCalled();
+    expect(getRegistrationStatus()).toEqual({ kind: 'permission_denied' });
+  });
+
+  it('installs the registration listener exactly once across re-runs', async () => {
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    await runDeviceRegistration(PAIRING);
+
+    const registrationCalls = (
+      vi.mocked(PushNotifications.addListener).mock.calls as Array<[string, unknown]>
+    ).filter(([event]) => event === 'registration');
+    expect(registrationCalls).toHaveLength(1);
+  });
+});
+
+describe('clearDeviceRegistration', () => {
+  it('removes the persisted token and emits idle', async () => {
+    prefsStore.set(REGISTERED_TOKEN_KEY, FCM_TOKEN_A);
+    const events: string[] = [];
+    subscribeRegistration((s) => events.push(s.kind));
+
+    await clearDeviceRegistration();
+
+    expect(prefsStore.has(REGISTERED_TOKEN_KEY)).toBe(false);
+    expect(events).toContain('idle');
+  });
+});
+
+describe('reRegisterDevice', () => {
+  it('clears stored token and re-runs registration against the active pairing', async () => {
+    prefsStore.set(REGISTERED_TOKEN_KEY, FCM_TOKEN_A);
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+
+    await runDeviceRegistration(PAIRING);
+    expect(PushNotifications.register).toHaveBeenCalledTimes(1);
+
+    await reRegisterDevice();
+
+    expect(prefsStore.has(REGISTERED_TOKEN_KEY)).toBe(false);
+    expect(PushNotifications.register).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('subscribeRegistration', () => {
+  it('notifies listeners on status changes and stops after unsubscribe', async () => {
+    const events: string[] = [];
+    const unsubscribe = subscribeRegistration((s) => events.push(s.kind));
+
+    await clearDeviceRegistration(); // idle
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 201 }),
+    );
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'granted',
+    });
+    await runDeviceRegistration(PAIRING);
+    await syncFcmToken(FCM_TOKEN_A); // pending → registered
+
+    unsubscribe();
+    await clearDeviceRegistration(); // listener should not see this
+
+    // runDeviceRegistration emits pending before register(); syncFcmToken
+    // emits pending again before the POST. Two pendings is the truth.
+    expect(events).toEqual(['idle', 'pending', 'pending', 'registered']);
+  });
+});

--- a/src/lib/device-registration.ts
+++ b/src/lib/device-registration.ts
@@ -1,0 +1,187 @@
+/**
+ * Device registration flow for [2C-08].
+ *
+ * Mirrors the server contract from [2C-05] (`brain3` POST /api/app/devices):
+ * `{ fcm_token, platform, label }` with bearer auth. The server handles
+ * upsert on `fcm_token` uniqueness — first registration returns 201, a
+ * matching token returns 200 with `last_seen_at` refreshed. FCM token
+ * rotation surfaces as a fresh `registration` event from the plugin and
+ * triggers a re-POST; the server treats the new value as a new row.
+ */
+
+import { Capacitor } from '@capacitor/core';
+import { Device } from '@capacitor/device';
+import { Preferences } from '@capacitor/preferences';
+import {
+  PushNotifications,
+  type Token,
+} from '@capacitor/push-notifications';
+import type { Pairing } from './pairing';
+
+export const REGISTERED_TOKEN_KEY = 'brain.deviceRegisteredToken';
+
+export type RegistrationStatus =
+  | { kind: 'idle' }
+  | { kind: 'pending' }
+  | { kind: 'registered'; fcmToken: string }
+  | { kind: 'permission_denied' }
+  | { kind: 'error'; message: string };
+
+type Listener = (status: RegistrationStatus) => void;
+
+const listeners = new Set<Listener>();
+let currentStatus: RegistrationStatus = { kind: 'idle' };
+let listenersInstalled = false;
+let activePairing: Pairing | null = null;
+
+function setStatus(next: RegistrationStatus): void {
+  currentStatus = next;
+  for (const l of listeners) l(next);
+}
+
+export function getRegistrationStatus(): RegistrationStatus {
+  return currentStatus;
+}
+
+export function subscribeRegistration(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadRegisteredToken(): Promise<string | null> {
+  const { value } = await Preferences.get({ key: REGISTERED_TOKEN_KEY });
+  return value ?? null;
+}
+
+async function persistRegisteredToken(token: string): Promise<void> {
+  await Preferences.set({ key: REGISTERED_TOKEN_KEY, value: token });
+}
+
+export async function clearDeviceRegistration(): Promise<void> {
+  await Preferences.remove({ key: REGISTERED_TOKEN_KEY });
+  setStatus({ kind: 'idle' });
+}
+
+export async function postDeviceRegistration(
+  pairing: Pairing,
+  fcmToken: string,
+  label: string | null,
+): Promise<Response> {
+  const base = pairing.url.replace(/\/$/, '');
+  return await fetch(`${base}/api/app/devices`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${pairing.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      fcm_token: fcmToken,
+      platform: 'android',
+      label,
+    }),
+  });
+}
+
+async function getDeviceLabel(): Promise<string | null> {
+  try {
+    const info = await Device.getInfo();
+    return info.model ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare the current FCM token against the persisted registration marker.
+ * Skip the POST when they match (don't re-register every launch). When the
+ * value differs — first registration or FCM token rotation — POST and
+ * persist on success.
+ */
+export async function syncFcmToken(fcmToken: string): Promise<void> {
+  if (!activePairing) return;
+  const stored = await loadRegisteredToken();
+  if (stored === fcmToken) {
+    setStatus({ kind: 'registered', fcmToken });
+    return;
+  }
+  setStatus({ kind: 'pending' });
+  let response: Response;
+  try {
+    const label = await getDeviceLabel();
+    response = await postDeviceRegistration(activePairing, fcmToken, label);
+  } catch (err) {
+    setStatus({
+      kind: 'error',
+      message: err instanceof Error ? err.message : 'Network error',
+    });
+    return;
+  }
+  if (!response.ok) {
+    setStatus({
+      kind: 'error',
+      message: `Device registration failed (${response.status})`,
+    });
+    return;
+  }
+  await persistRegisteredToken(fcmToken);
+  setStatus({ kind: 'registered', fcmToken });
+}
+
+function installPushListeners(): void {
+  if (listenersInstalled) return;
+  PushNotifications.addListener('registration', (token: Token) => {
+    void syncFcmToken(token.value);
+  });
+  PushNotifications.addListener('registrationError', (error: unknown) => {
+    let message = 'Push registration error';
+    if (typeof error === 'string') {
+      message = error;
+    } else if (
+      error &&
+      typeof error === 'object' &&
+      'error' in error &&
+      typeof (error as { error?: unknown }).error === 'string'
+    ) {
+      message = (error as { error: string }).error;
+    }
+    setStatus({ kind: 'error', message });
+  });
+  listenersInstalled = true;
+}
+
+export async function runDeviceRegistration(pairing: Pairing): Promise<void> {
+  activePairing = pairing;
+  if (!Capacitor.isNativePlatform()) {
+    return;
+  }
+  installPushListeners();
+  try {
+    const permission = await PushNotifications.requestPermissions();
+    if (permission.receive !== 'granted') {
+      setStatus({ kind: 'permission_denied' });
+      return;
+    }
+    setStatus({ kind: 'pending' });
+    await PushNotifications.register();
+  } catch (err) {
+    setStatus({
+      kind: 'error',
+      message: err instanceof Error ? err.message : 'Push registration failed',
+    });
+  }
+}
+
+export async function reRegisterDevice(): Promise<void> {
+  if (!activePairing) return;
+  await clearDeviceRegistration();
+  await runDeviceRegistration(activePairing);
+}
+
+export function __resetForTests(): void {
+  listeners.clear();
+  currentStatus = { kind: 'idle' };
+  listenersInstalled = false;
+  activePairing = null;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -23,6 +23,12 @@ import {
   type Pairing,
 } from '../lib/pairing';
 import { pingHealth } from '../lib/health';
+import {
+  getRegistrationStatus,
+  reRegisterDevice,
+  subscribeRegistration,
+  type RegistrationStatus,
+} from '../lib/device-registration';
 import ConnectionIndicator from '../components/ConnectionIndicator';
 
 const MIN_TOKEN_LENGTH = 8;
@@ -40,6 +46,15 @@ function maskToken(token: string): string {
   return `****${token.slice(-4)}`;
 }
 
+function fcmTokenPreview(status: RegistrationStatus): string {
+  if (status.kind === 'registered') {
+    return `…${status.fcmToken.slice(-8)}`;
+  }
+  if (status.kind === 'pending') return 'Registering…';
+  if (status.kind === 'permission_denied') return 'Push permission denied';
+  return 'Not registered';
+}
+
 const SettingsPage: React.FC = () => {
   const history = useHistory();
   const [storedPairing, setStoredPairing] = useState<Pairing | null>(null);
@@ -52,6 +67,9 @@ const SettingsPage: React.FC = () => {
   const [formError, setFormError] = useState<string | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [registration, setRegistration] = useState<RegistrationStatus>(
+    getRegistrationStatus(),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -64,6 +82,14 @@ const SettingsPage: React.FC = () => {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    return subscribeRegistration((status) => setRegistration(status));
+  }, []);
+
+  const handleReRegister = () => {
+    void reRegisterDevice();
+  };
 
   const trimmedUrl = url.trim();
   const trimmedToken = token.trim();
@@ -172,6 +198,42 @@ const SettingsPage: React.FC = () => {
             >
               Re-pair
             </IonButton>
+
+            <section
+              aria-label="Device"
+              className="ion-margin-top"
+            >
+              <IonItem>
+                <IonLabel>
+                  <h2>Device</h2>
+                  <IonText color="medium">
+                    <p>{fcmTokenPreview(registration)}</p>
+                  </IonText>
+                  {registration.kind === 'error' ? (
+                    <IonText color="danger" role="alert">
+                      <p>Device registration failed — pull to retry</p>
+                    </IonText>
+                  ) : null}
+                  {registration.kind === 'permission_denied' ? (
+                    <IonText color="warning">
+                      <p>
+                        Push permission denied. Enable notifications in system
+                        settings, then tap Re-register.
+                      </p>
+                    </IonText>
+                  ) : null}
+                </IonLabel>
+              </IonItem>
+              <IonButton
+                expand="block"
+                fill="outline"
+                color="medium"
+                className="ion-margin-top"
+                onClick={handleReRegister}
+              >
+                Re-register
+              </IonButton>
+            </section>
           </section>
         ) : (
           <section aria-label="Pairing form">
@@ -239,9 +301,6 @@ const SettingsPage: React.FC = () => {
             </IonButton>
           </section>
         )}
-
-        {/* Device section — [2C-08] anchor: render FCM token preview + Re-register button here. */}
-        <IonItem className="ion-margin-top" aria-label="Device section placeholder" />
 
         <IonToast
           isOpen={toastMessage !== null}


### PR DESCRIPTION
## Summary

Adds the client side of the device-registration loop. On a paired launch the
app requests `POST_NOTIFICATIONS` permission, calls
`PushNotifications.register()`, and POSTs the resulting FCM token to the
brain3 `POST /api/app/devices` endpoint with bearer auth. A persisted
`brain.deviceRegisteredToken` short-circuits subsequent launches when the
FCM value hasn't changed; rotation surfaces as a fresh `registration` event
(BrainFirebaseMessagingService inherits the plugin's `MessagingService` so
`onNewToken` still flows to JS) and triggers a re-POST that the server's
fcm_token-uniqueness upsert handles. Re-pair clears the registered token so
a new server URL re-registers cleanly.

Settings gains a Device section (paired branch only) with the masked
fcm_token (last 8 chars + ellipsis), permission/error copy, and a
Re-register button.

Closes #3

## Changes

- `package.json` / `package-lock.json` — add `@capacitor/device@^6.0.0`,
  pinned to honor the Capacitor 6 line per repo CLAUDE.md.
- `src/lib/device-registration.ts` — new module. `postDeviceRegistration`
  ships the `[2C-05]` contract body; `syncFcmToken` is the registered-flag
  / token-rotation comparator; `runDeviceRegistration` wires the
  PushNotifications plugin (permission → register → listeners), idempotent
  across re-runs; subscribe/getStatus expose state to the UI;
  `clearDeviceRegistration` and `reRegisterDevice` cover re-pair and the
  debugging affordance.
- `src/App.tsx` — adds `DeviceRegistrar` (renders null) mounted under
  `IonApp`. Subscribes to pairing changes: paired → run, unpaired → clear.
- `src/pages/SettingsPage.tsx` — replaces the `[2C-08]` placeholder anchor
  with a Device section under the paired branch. Subscribes to registration
  status and renders the spec copy "Device registration failed — pull to
  retry" verbatim on error.
- `src/lib/device-registration.test.ts` — co-located vitest suite; 13 tests
  covering contract shape, registered-flag short-circuit, token rotation,
  error paths (no persistence on failure), listener-install idempotence,
  re-register, and subscriber semantics.

## How to Verify

Automated (run from repo root):

```
npm run lint
npm run test.unit -- --run
npm run build
```

All three exit clean. The full unit suite is 29 tests across four files.

Manual (acceptance criteria — server-side observation requires a running
brain3 with the [2C-05] endpoint):

1. **Fresh install + pair**: pair via Settings, grant push permission when
   prompted. `GET /api/app/devices` on the server shows the device within
   ~5s. Settings → Device section shows `…<last-8-of-fcm-token>`.
2. **Re-launch**: kill and re-open the app on the same install. No new row
   appears in `GET /api/app/devices` (the persisted token matches; POST is
   skipped). Device section shows the same masked token.
3. **Airplane-mode pair**: enable airplane mode, complete the pair flow.
   Device section shows "Device registration failed — pull to retry".
   Disable airplane mode and re-launch — registration succeeds and the
   device appears server-side. (Equivalent shortcut: tap Re-register from
   Settings once back online.)
4. **Token refresh**: invalidate registration tokens via Firebase Console.
   Re-launch the app. The new token surfaces via the `registration` event
   and the client POSTs again; the server upserts and the device list
   reflects the new fcm_token.

## Deviations

1. **Single-key persistence instead of a separate boolean.** The spec
   describes a `registered: true` flag in preferences. I store the
   FCM token itself under `brain.deviceRegisteredToken` — presence
   encodes "registered", and the value is what the rotation-detection
   short-circuit needs anyway. Two keys would have duplicated state.
2. **"Pull to retry" copy preserved verbatim, retry affordance is the
   Re-register button.** The spec error string says "pull to retry" but
   the only Settings affordance the spec explicitly calls out is the
   Re-register button (described as "for debugging"). I kept the copy as
   written and let Re-register also serve as the retry action; auto-retry
   on next launch is unchanged. Adding `IonRefresher` to Settings just for
   pull-to-refresh on the device row would have introduced unrelated UX
   concerns on the unpaired form. Flagging in case L wants the refresher
   added or the copy reworded as a follow-up.
3. **Re-pair (clearPairing) cascades to clearDeviceRegistration.** Spec is
   silent on this; the reasoning is that an old pairing's
   registered-token marker no longer reflects whether the *new* server
   knows about us. `DeviceRegistrar` performs the cascade in App.tsx; the
   pairing module itself is unchanged.
4. **No native code changes.** The activation prompt called out
   `BrainFirebaseMessagingService.onNewToken(token)` and
   `FirebaseMessaging.getInstance().token` as the two surfaces feeding
   registration. [2C-06] PR #37 left BrainFirebaseMessagingService
   extending the plugin's `MessagingService` precisely so the inherited
   `onNewToken` still surfaces as the plugin's JS `registration` event.
   Both initial fetch and rotation flow through the same JS listener I
   wired here, so no native plumbing was needed.

## Test Results

```
$ npm run test.unit -- --run

 ✓ src/lib/device-registration.test.ts  (13 tests) 6ms
 ✓ src/lib/health.test.ts  (7 tests) 5ms
 ✓ src/lib/pairing.test.ts  (8 tests) 4ms
 ✓ src/App.test.tsx  (1 test) 91ms

 Test Files  4 passed (4)
      Tests  29 passed (29)
```

```
$ npm run lint
> eslint
(clean — no output)
```

```
$ npm run build
> tsc && vite build
✓ built in 7.14s
```

## Acceptance Checklist

- [x] Fresh install → pair flow → permission grant → device appears in
  `GET /api/app/devices` list within ~5s _(automated: contract test asserts
  POST shape + URL + auth header; manual verification belongs to L)_
- [x] Re-launch on same install → no new device row created (`registered`
  flag honored) _(automated: registered-flag short-circuit test)_
- [x] Airplane-mode pair → registration fails gracefully, retry succeeds
  on next launch with network _(automated: network-failure test asserts
  no persistence; rerun on next launch is the natural mechanism)_
- [x] Simulated token refresh → next launch re-registers, server handles
  upsert _(automated: token-rotation test asserts re-POST with new token
  and persistence update)_