### PR TITLE
[2C-Bug-02] dev-release Android build fails: firebase-messaging not on :app classpath after [2C-06]

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation project(':capacitor-android')
+    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation 'org.json:json:20240303'
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -15,4 +15,5 @@ ext {
     androidxJunitVersion = '1.1.5'
     androidxEspressoCoreVersion = '3.5.1'
     cordovaAndroidVersion = '10.1.1'
+    firebaseMessagingVersion = '23.3.1'
 }


### PR DESCRIPTION
## Summary

Pin `firebase-messaging:23.3.1` directly on `:app`'s compile classpath. The `@capacitor/push-notifications` plugin declares its Firebase dependency as `implementation` (not `api`), so transitively `:app → :capacitor-push-notifications → firebase-messaging` works at runtime but is hidden from `:app` at compile time. `BrainFirebaseMessagingService` (added by [2C-06]) extends `MessagingService` which extends `FirebaseMessagingService` — Kotlin needs the whole supertype chain on `:app`'s compile classpath, hence the `:app:compileDebugKotlin` failure in the post-merge Dev Release workflow.

Fix: declare `firebase-messaging` as a direct `:app` `implementation` dependency, version-pinned via the plugin's existing `firebaseMessagingVersion` ext for single-source-of-truth.

## Changes

- `android/variables.gradle` — added `firebaseMessagingVersion = '23.3.1'` to the existing `ext { ... }` block. Default value matches the plugin's own default (`node_modules/@capacitor/push-notifications/android/build.gradle`), so consumers can override here if needed.
- `android/app/build.gradle` — added `implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"` to the dependencies block, alongside the other Capacitor/AndroidX pins.

Two-line change, no new files, no Gradle plugin changes, no `google-services.json` work (out of scope per issue body).

## How to Verify

1. `git checkout fix/2C-Bug-02-firebase-messaging-classpath`
2. `cd android` and run `.\gradlew.bat assembleDebug` — `:app:compileDebugKotlin` should succeed where it previously failed with "unresolved supertypes: com.google.firebase.messaging.FirebaseMessagingService" + 16 cascade errors.
3. Or merge and watch the next Dev Release workflow run on `develop` — it should produce a debug APK and a `develop-{short-sha}` pre-release on GitHub Releases instead of failing on `:app:compileDebugKotlin`.

The compile-classpath fix is independent of `google-services.json`. Push notifications still won't actually deliver on dev-release APKs (the `apply plugin: 'com.google.gms.google-services'` block in `android/app/build.gradle` lines 62-69 is conditional on `google-services.json` existing, which CI doesn't have) — that's a separate ticket and explicitly out of scope here. The build *succeeding* is what unblocks the dev-release channel.

## Deviations

**Local Gradle build not run.** Per repo CLAUDE.md, `npm run android:build:debug` requires `JAVA_HOME` (JDK 17+) and `ANDROID_HOME` set. This dev environment has only JDK 8 (`C:\Program Files\Android\jdk\jdk-8.0.302.8-hotspot`) and no Android SDK install — the `[2C-06]` Android-SDK gap is still present here. JS-side verification (`npm run lint`, `npm run test.unit`) is clean, but the Gradle compile cannot be exercised locally. The Dev Release workflow run on merge will be the verification of record. Activation prompt explicitly anticipated this case ("if you can't, flag in PR body and we'll watch the post-merge run").

**BOM alternative not taken.** Issue body offered the Firebase BOM as an alternative form. Activation prompt accepted the direct-pin approach as written — single-source-of-truth with the plugin's existing `firebaseMessagingVersion` ext, YAGNI on aligning Firebase artifact versions until we use a second one. No condition surfaced during implementation that would prefer the BOM (the conditional google-services Gradle plugin only applies when `google-services.json` exists, which it doesn't here, so it isn't pulling a BOM we'd be conflicting with).

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint
(clean — exit 0)

$ npx vitest run
 RUN  v1.6.1 D:/_DEVELOPMENT/brain3-companion
 ✓ src/lib/health.test.ts (7 tests) 5ms
 ✓ src/lib/pairing.test.ts (8 tests) 4ms
 ✓ src/lib/device-registration.test.ts (13 tests) 6ms
 ✓ src/App.test.tsx (1 test) 96ms
 Test Files  4 passed (4)
      Tests  29 passed (29)
   Duration  3.26s
```

Gradle build: not exercised locally (see Deviations). Verification of record is the post-merge Dev Release workflow run on `develop`.

## Acceptance Checklist

- [x] `firebaseMessagingVersion = '23.3.1'` added to `android/variables.gradle` `ext` block
- [x] `implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"` added to `android/app/build.gradle` dependencies
- [x] No bundled scope (no `google-services.json` work, no verification-process gap discussion, no [2C-07]/[2C-09] work)
- [x] JS-side verification clean (lint + unit tests)
- [ ] Post-merge Dev Release workflow on `develop` produces a signed debug APK as a `develop-{short-sha}` pre-release (verification of record — runs on merge)

Closes #39