### PR TITLE
[2C-07] Canned response dispatch with offline write queue

### DIFF
--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/BridgeHolder.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/BridgeHolder.kt
@@ -1,0 +1,34 @@
+package com.fluxmeridian.brain3companion
+
+import com.getcapacitor.Bridge
+
+/**
+ * Process-singleton holder for the Capacitor [Bridge]. MainActivity attaches in
+ * onCreate and detaches in onDestroy so non-plugin contexts — specifically
+ * [CannedResponseReceiver] — can dispatch JS events when the WebView is alive.
+ *
+ * When null (app process not running, or activity torn down), callers fall
+ * back to durable storage in [WriteQueueStore]; the JS layer drains the queue
+ * on its next launch, foreground, or `online` event. See [2C-07] spec.
+ */
+object BridgeHolder {
+    @Volatile
+    private var bridge: Bridge? = null
+
+    fun attach(bridge: Bridge?) {
+        this.bridge = bridge
+    }
+
+    fun detach(expected: Bridge?) {
+        if (this.bridge === expected) {
+            this.bridge = null
+        }
+    }
+
+    /** Best-effort JS event dispatch; no-ops when the bridge is not attached. */
+    fun triggerJSEvent(eventName: String): Boolean {
+        val active = bridge ?: return false
+        active.triggerWindowJSEvent(eventName)
+        return true
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
@@ -5,11 +5,17 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 /**
- * Receives canned-response action taps from the notification surface (phone or
- * watch). [2C-06] dismisses the notification and logs the chosen response —
- * the HTTP POST to BRAIN and offline-queue handling land in [2C-07].
+ * Receives canned-response action taps from the notification surface (phone
+ * or watch). Persists the response to the durable write queue, dismisses the
+ * notification from the tray, and best-effort signals the JS layer to flush
+ * immediately. The JS layer owns the HTTP POST and offline-retry behavior —
+ * see [WriteQueueStore] and `src/lib/writeQueue.ts`. Per [2C-07] spec.
  */
 class CannedResponseReceiver : BroadcastReceiver() {
 
@@ -25,11 +31,28 @@ class CannedResponseReceiver : BroadcastReceiver() {
                 "type=$notificationType response=$response",
         )
 
+        WriteQueueStore.enqueue(
+            context = context,
+            notificationId = notificationId,
+            response = response,
+            responseNote = null,
+            enqueuedAt = isoTimestamp(),
+        )
+
         NotificationManagerCompat.from(context).cancel(notificationId.hashCode())
+
+        BridgeHolder.triggerJSEvent(JS_EVENT)
+    }
+
+    private fun isoTimestamp(): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        format.timeZone = TimeZone.getTimeZone("UTC")
+        return format.format(Date())
     }
 
     companion object {
         private const val TAG = "CannedResponseReceiver"
+        private const val JS_EVENT = "brainCannedResponse"
         const val ACTION_RESPOND = "com.fluxmeridian.brain3companion.action.CANNED_RESPONSE"
         const val EXTRA_NOTIFICATION_ID = "notification_id"
         const val EXTRA_NOTIFICATION_TYPE = "notification_type"

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
@@ -1,5 +1,19 @@
 package com.fluxmeridian.brain3companion;
 
+import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        BridgeHolder.INSTANCE.attach(getBridge());
+    }
+
+    @Override
+    protected void onDestroy() {
+        BridgeHolder.INSTANCE.detach(getBridge());
+        super.onDestroy();
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/WriteQueueStore.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/WriteQueueStore.kt
@@ -1,0 +1,58 @@
+package com.fluxmeridian.brain3companion
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Durable enqueue for canned-response actions that survive app death.
+ *
+ * Writes to the same SharedPreferences file (`CapacitorStorage`, key
+ * `brain.writeQueue`) used by the JS `@capacitor/preferences` plugin so the
+ * JS layer drains the queue on its next launch, foreground, or `online`
+ * event. Storage shape mirrors the JS [WriteQueueEntry] contract — a JSON
+ * array of `{ notification_id, response, response_note, enqueued_at }`.
+ *
+ * The 500-entry cap is advisory: when reached we log a warning but never
+ * drop entries, per [2C-07] spec.
+ */
+object WriteQueueStore {
+    private const val TAG = "WriteQueueStore"
+    private const val PREFS_NAME = "CapacitorStorage"
+    private const val QUEUE_KEY = "brain.writeQueue"
+    private const val SOFT_CAP = 500
+
+    fun enqueue(
+        context: Context,
+        notificationId: String,
+        response: String,
+        responseNote: String?,
+        enqueuedAt: String,
+    ) {
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getString(QUEUE_KEY, null)
+        val array = if (raw.isNullOrEmpty()) {
+            JSONArray()
+        } else {
+            try {
+                JSONArray(raw)
+            } catch (err: Throwable) {
+                Log.w(TAG, "Corrupt $QUEUE_KEY contents — resetting", err)
+                JSONArray()
+            }
+        }
+        val entry = JSONObject().apply {
+            put("notification_id", notificationId)
+            put("response", response)
+            put("response_note", responseNote ?: JSONObject.NULL)
+            put("enqueued_at", enqueuedAt)
+        }
+        array.put(entry)
+        if (array.length() > SOFT_CAP) {
+            Log.w(TAG, "writeQueue size ${array.length()} exceeds soft cap $SOFT_CAP")
+        }
+        prefs.edit().putString(QUEUE_KEY, array.toString()).apply()
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   clearDeviceRegistration,
   runDeviceRegistration,
 } from './lib/device-registration';
+import { initWriteQueue } from './lib/writeQueue';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -75,10 +76,19 @@ const DeviceRegistrar: React.FC = () => {
   return null;
 };
 
+const WriteQueueRunner: React.FC = () => {
+  useEffect(() => {
+    const teardown = initWriteQueue();
+    return () => teardown();
+  }, []);
+  return null;
+};
+
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
     <IonApp>
       <DeviceRegistrar />
+      <WriteQueueRunner />
       <IonReactRouter>
         <IonRouterOutlet>
           <Route exact path="/settings">

--- a/src/lib/writeQueue.test.ts
+++ b/src/lib/writeQueue.test.ts
@@ -1,0 +1,368 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn(),
+    register: vi.fn(),
+    addListener: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/device', () => ({
+  Device: {
+    getInfo: vi.fn(async () => ({ model: 'Pixel 8' })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
+import { REGISTERED_TOKEN_KEY } from './device-registration';
+import {
+  __resetForTests,
+  enqueueResponse,
+  flushWriteQueue,
+  QUEUE_SOFT_CAP,
+  subscribeConflicts,
+  WRITE_QUEUE_KEY,
+  type ConflictWarning,
+  type WriteQueueEntry,
+} from './writeQueue';
+
+const PAIRING_URL = 'https://brain.local:8000';
+const PAIRING_TOKEN = 'bearer-abc-123';
+const FCM_TOKEN = 'fcm-token-aaaaaaaa-1111';
+
+const prefsStore = new Map<string, string>();
+
+function entry(overrides: Partial<WriteQueueEntry> = {}): WriteQueueEntry {
+  return {
+    notification_id: '11111111-1111-1111-1111-111111111111',
+    response: 'Already done',
+    response_note: null,
+    enqueued_at: '2026-04-28T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function seedPairing(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRING_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRING_TOKEN);
+}
+
+function seedRegistered(): void {
+  prefsStore.set(REGISTERED_TOKEN_KEY, FCM_TOKEN);
+}
+
+async function readQueue(): Promise<WriteQueueEntry[]> {
+  const raw = prefsStore.get(WRITE_QUEUE_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as WriteQueueEntry[];
+}
+
+beforeEach(() => {
+  __resetForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('enqueueResponse', () => {
+  it('persists entries to brain.writeQueue as a JSON array', async () => {
+    await enqueueResponse(entry());
+    await enqueueResponse(entry({ response: 'Skip today' }));
+    const queue = await readQueue();
+    expect(queue).toHaveLength(2);
+    expect(queue[0]?.response).toBe('Already done');
+    expect(queue[1]?.response).toBe('Skip today');
+  });
+
+  it('logs a warning above the soft cap but does not drop entries', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const seeded = Array.from({ length: QUEUE_SOFT_CAP }, (_, i) =>
+      entry({ notification_id: `seed-${i}` }),
+    );
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify(seeded));
+
+    await enqueueResponse(entry({ notification_id: 'overflow' }));
+
+    const queue = await readQueue();
+    expect(queue).toHaveLength(QUEUE_SOFT_CAP + 1);
+    expect(queue[queue.length - 1]?.notification_id).toBe('overflow');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain('exceeds soft cap');
+  });
+});
+
+describe('flushWriteQueue — gating', () => {
+  it('no-ops when no pairing is stored', async () => {
+    seedRegistered();
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify([entry()]));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      attempted: 0,
+      delivered: 0,
+      conflicts: 0,
+      remaining: 1,
+    });
+  });
+
+  it('no-ops when the device is not registered', async () => {
+    seedPairing();
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify([entry()]));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(summary.attempted).toBe(0);
+    expect(summary.remaining).toBe(1);
+  });
+});
+
+describe('flushWriteQueue — happy path', () => {
+  beforeEach(() => {
+    seedPairing();
+    seedRegistered();
+  });
+
+  it('POSTs each entry with bearer auth, in enqueue order, and clears the queue', async () => {
+    const entries = [
+      entry({ notification_id: 'aaaa', response: 'Already done' }),
+      entry({ notification_id: 'bbbb', response: 'Skip today' }),
+      entry({ notification_id: 'cccc', response: 'Snooze' }),
+    ];
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify(entries));
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const seenIds = fetchSpy.mock.calls.map(([url]) => String(url));
+    expect(seenIds[0]).toContain('/api/notifications/aaaa/respond');
+    expect(seenIds[1]).toContain('/api/notifications/bbbb/respond');
+    expect(seenIds[2]).toContain('/api/notifications/cccc/respond');
+
+    const firstInit = fetchSpy.mock.calls[0]![1]!;
+    const firstHeaders = firstInit.headers as Record<string, string>;
+    expect(firstHeaders.Authorization).toBe(`Bearer ${PAIRING_TOKEN}`);
+    expect(firstHeaders['Content-Type']).toBe('application/json');
+    expect(JSON.parse(firstInit.body as string)).toEqual({
+      response: 'Already done',
+      response_note: null,
+    });
+
+    expect(summary).toEqual({
+      attempted: 3,
+      delivered: 3,
+      conflicts: 0,
+      remaining: 0,
+    });
+    expect(await readQueue()).toEqual([]);
+  });
+
+  it('treats 200 and 201 identically as delivered', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'first' }),
+        entry({ notification_id: 'second' }),
+      ]),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(summary.delivered).toBe(2);
+    expect(summary.remaining).toBe(0);
+  });
+
+  it('strips trailing slashes from pairing.url before joining the path', async () => {
+    prefsStore.set(PAIRING_URL_KEY, 'https://brain.local:8000/');
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify([entry({ notification_id: 'xx' })]));
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await flushWriteQueue();
+
+    expect(fetchSpy.mock.calls[0]![0]).toBe(
+      'https://brain.local:8000/api/notifications/xx/respond',
+    );
+  });
+});
+
+describe('flushWriteQueue — failure handling', () => {
+  beforeEach(() => {
+    seedPairing();
+    seedRegistered();
+  });
+
+  it('stops on a network error and preserves enqueue order', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'first' }),
+        entry({ notification_id: 'second' }),
+      ]),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('offline'));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(summary.attempted).toBe(1);
+    expect(summary.delivered).toBe(0);
+    expect(summary.remaining).toBe(2);
+    const queue = await readQueue();
+    expect(queue.map((e) => e.notification_id)).toEqual(['first', 'second']);
+  });
+
+  it('stops on a 5xx response without dropping the failed entry', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'first' }),
+        entry({ notification_id: 'second' }),
+      ]),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 500 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(summary.delivered).toBe(0);
+    expect(summary.remaining).toBe(2);
+  });
+
+  it('flushes again successfully once connectivity restores (retry safety)', async () => {
+    // First flush fails on network; second flush after restore delivers all.
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'first' }),
+        entry({ notification_id: 'second' }),
+      ]),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const offline = await flushWriteQueue();
+    expect(offline.delivered).toBe(0);
+    expect(offline.remaining).toBe(2);
+
+    const restored = await flushWriteQueue();
+    expect(restored.delivered).toBe(2);
+    expect(restored.remaining).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(3); // 1 failed + 2 succeeded
+  });
+});
+
+describe('flushWriteQueue — 409 conflict', () => {
+  beforeEach(() => {
+    seedPairing();
+    seedRegistered();
+  });
+
+  it('drops the entry and emits a ConflictWarning when the server response differs', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'conflict-id', response: 'Already done' }),
+        entry({ notification_id: 'after', response: 'Skip today' }),
+      ]),
+    );
+    const warnings: ConflictWarning[] = [];
+    subscribeConflicts((w) => warnings.push(w));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ response: 'Skip today' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(summary.conflicts).toBe(1);
+    expect(summary.delivered).toBe(1);
+    expect(summary.remaining).toBe(0);
+    expect(warnings).toEqual([
+      {
+        notification_id: 'conflict-id',
+        attempted_response: 'Already done',
+        server_response: 'Skip today',
+      },
+    ]);
+  });
+
+  it('drops 409 entries even if the body is not parseable, without emitting a warning', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([entry({ notification_id: 'opaque' })]),
+    );
+    const warnings: ConflictWarning[] = [];
+    subscribeConflicts((w) => warnings.push(w));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not json', { status: 409 }),
+    );
+
+    const summary = await flushWriteQueue();
+
+    expect(summary.conflicts).toBe(1);
+    expect(summary.remaining).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/src/lib/writeQueue.ts
+++ b/src/lib/writeQueue.ts
@@ -1,0 +1,269 @@
+/**
+ * Canned-response offline queue for [2C-07].
+ *
+ * The native [CannedResponseReceiver] persists each tapped response to
+ * `brain.writeQueue` in `@capacitor/preferences` storage and (when the
+ * WebView is alive) fires a `brainCannedResponse` window event. This module
+ * owns the HTTP POST to BRAIN, the in-order flush, and the failure-handling
+ * contract:
+ *
+ * - 200 / 201 → entry removed.
+ * - 409 → drop entry. If the server returned a different existing response
+ *   ([2C-03]'s "legitimate conflict" branch), surface a {@link ConflictWarning}
+ *   to subscribers. Same-response idempotency is a server-side 200 per
+ *   [2C-03], so a 409 here always indicates a different existing response.
+ * - Any other failure (5xx, network, timeout) → entry stays at the head of
+ *   the queue, flush stops to preserve enqueue order.
+ *
+ * Flush is gated on both an active pairing (URL + bearer token from
+ * `pairing.ts`) and a registered FCM token (`brain.deviceRegisteredToken`
+ * from [2C-08]). When either is missing, queued entries wait until both are
+ * present — registration completion triggers a flush automatically.
+ */
+
+import { App } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+import { Preferences } from '@capacitor/preferences';
+import {
+  loadRegisteredToken,
+  subscribeRegistration,
+} from './device-registration';
+import { loadPairing, type Pairing } from './pairing';
+
+export const WRITE_QUEUE_KEY = 'brain.writeQueue';
+export const BRIDGE_EVENT_NAME = 'brainCannedResponse';
+export const QUEUE_SOFT_CAP = 500;
+
+export interface WriteQueueEntry {
+  notification_id: string;
+  response: string;
+  response_note: string | null;
+  enqueued_at: string;
+}
+
+export interface ConflictWarning {
+  notification_id: string;
+  attempted_response: string;
+  server_response: string;
+}
+
+export interface FlushSummary {
+  attempted: number;
+  delivered: number;
+  conflicts: number;
+  remaining: number;
+}
+
+type ConflictListener = (warning: ConflictWarning) => void;
+
+const conflictListeners = new Set<ConflictListener>();
+
+export function subscribeConflicts(listener: ConflictListener): () => void {
+  conflictListeners.add(listener);
+  return () => {
+    conflictListeners.delete(listener);
+  };
+}
+
+function emitConflict(warning: ConflictWarning): void {
+  for (const listener of conflictListeners) listener(warning);
+}
+
+async function loadQueue(): Promise<WriteQueueEntry[]> {
+  const { value } = await Preferences.get({ key: WRITE_QUEUE_KEY });
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as WriteQueueEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function saveQueue(queue: WriteQueueEntry[]): Promise<void> {
+  await Preferences.set({
+    key: WRITE_QUEUE_KEY,
+    value: JSON.stringify(queue),
+  });
+}
+
+export async function enqueueResponse(entry: WriteQueueEntry): Promise<void> {
+  const queue = await loadQueue();
+  queue.push(entry);
+  if (queue.length > QUEUE_SOFT_CAP) {
+    // Soft cap — log only. Spec says "do not drop" beyond cap.
+    console.warn(
+      `[writeQueue] size ${queue.length} exceeds soft cap ${QUEUE_SOFT_CAP}`,
+    );
+  }
+  await saveQueue(queue);
+}
+
+async function postResponse(
+  pairing: Pairing,
+  entry: WriteQueueEntry,
+): Promise<Response> {
+  const base = pairing.url.replace(/\/$/, '');
+  return await fetch(
+    `${base}/api/notifications/${entry.notification_id}/respond`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${pairing.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        response: entry.response,
+        response_note: entry.response_note,
+      }),
+    },
+  );
+}
+
+let flushing = false;
+
+/**
+ * Drain the queue in enqueue order. Concurrent calls coalesce: a second call
+ * while a flush is in flight returns immediately rather than racing the queue.
+ */
+export async function flushWriteQueue(): Promise<FlushSummary> {
+  if (flushing) {
+    const remaining = (await loadQueue()).length;
+    return { attempted: 0, delivered: 0, conflicts: 0, remaining };
+  }
+  flushing = true;
+  try {
+    const pairing = await loadPairing();
+    const registered = await loadRegisteredToken();
+    if (!pairing || !registered) {
+      const remaining = (await loadQueue()).length;
+      return { attempted: 0, delivered: 0, conflicts: 0, remaining };
+    }
+
+    let queue = await loadQueue();
+    let attempted = 0;
+    let delivered = 0;
+    let conflicts = 0;
+    while (queue.length > 0) {
+      const entry = queue[0]!;
+      attempted += 1;
+      let response: Response;
+      try {
+        response = await postResponse(pairing, entry);
+      } catch {
+        // Network failure — leave entry at the head, stop flushing.
+        break;
+      }
+      if (response.status === 200 || response.status === 201) {
+        queue = queue.slice(1);
+        await saveQueue(queue);
+        delivered += 1;
+        continue;
+      }
+      if (response.status === 409) {
+        const serverResponse = await readConflictResponse(response);
+        if (serverResponse !== null && serverResponse !== entry.response) {
+          emitConflict({
+            notification_id: entry.notification_id,
+            attempted_response: entry.response,
+            server_response: serverResponse,
+          });
+        }
+        queue = queue.slice(1);
+        await saveQueue(queue);
+        conflicts += 1;
+        continue;
+      }
+      // Any other failure (5xx, etc.) — leave entry, stop.
+      break;
+    }
+    return { attempted, delivered, conflicts, remaining: queue.length };
+  } finally {
+    flushing = false;
+  }
+}
+
+async function readConflictResponse(response: Response): Promise<string | null> {
+  try {
+    const body = (await response.clone().json()) as unknown;
+    if (
+      body &&
+      typeof body === 'object' &&
+      'response' in body &&
+      typeof (body as { response: unknown }).response === 'string'
+    ) {
+      return (body as { response: string }).response;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+let initialised = false;
+
+/**
+ * Wire flush triggers: app foreground, browser `online`, native bridge event,
+ * and device-registration completion. Idempotent — repeat calls no-op until
+ * the returned cleanup runs. Returns a tear-down used by tests; production
+ * code mounts this once for the lifetime of the app.
+ */
+export function initWriteQueue(): () => void {
+  if (initialised) return () => undefined;
+  initialised = true;
+
+  const cleanups: Array<() => void> = [];
+  const safeFlush = (): void => {
+    void flushWriteQueue();
+  };
+
+  // Initial drain — picks up entries persisted by the native receiver while
+  // the app process was dead.
+  safeFlush();
+
+  if (Capacitor.isNativePlatform()) {
+    const handlePromise = App.addListener(
+      'appStateChange',
+      ({ isActive }) => {
+        if (isActive) safeFlush();
+      },
+    );
+    cleanups.push(() => {
+      void handlePromise.then((handle) => handle.remove());
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    const onlineHandler = (): void => safeFlush();
+    window.addEventListener('online', onlineHandler);
+    cleanups.push(() => window.removeEventListener('online', onlineHandler));
+
+    const bridgeHandler = (): void => safeFlush();
+    window.addEventListener(BRIDGE_EVENT_NAME, bridgeHandler);
+    cleanups.push(() =>
+      window.removeEventListener(BRIDGE_EVENT_NAME, bridgeHandler),
+    );
+  }
+
+  const unsubscribeRegistration = subscribeRegistration((status) => {
+    if (status.kind === 'registered') safeFlush();
+  });
+  cleanups.push(unsubscribeRegistration);
+
+  return () => {
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    initialised = false;
+  };
+}
+
+export function __resetForTests(): void {
+  conflictListeners.clear();
+  flushing = false;
+  initialised = false;
+}


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npm run test.unit -- --run` — ✅ Pass (41 passed, 0 failed; 12 new in `src/lib/writeQueue.test.ts`)
- `npm run build` — ✅ Pass (tsc + vite build clean; pre-existing chunk-size warning unchanged)
- Native (Gradle) build: ➖ N/A — repo CLAUDE.md notes `npm run android:build:debug` requires `JAVA_HOME` + `ANDROID_HOME` set in shell; not run pre-PR.
- Manual on-device scenarios: ➖ Deferred to L — issue body has no `#### Manual verification` heading per repo CLAUDE.md, and the Acceptance Criteria scenarios (foreground tap / airplane-mode / retry-safety) require physical watch + phone + running BRAIN server.

Ran locally against develop HEAD `c82f4ff` immediately before opening this PR.

## Summary

[2C-07] closes the watch-tap → BRAIN-recorded loop introduced by [2C-06]. The native `CannedResponseReceiver` now durably enqueues each tapped response to `CapacitorStorage` (key `brain.writeQueue`), dismisses the notification, and best-effort signals the JS layer to flush. A new TypeScript module (`src/lib/writeQueue.ts`) owns the actual POST to `/api/notifications/{id}/respond`, the in-order flush, the 409 conflict branch from [2C-03], and the failure-handling contract that preserves enqueue order. Flush is gated on both an active pairing (bearer auth from [2C-08]) and a registered FCM token (`brain.deviceRegisteredToken`); when either is missing, queued entries wait — registration completion auto-triggers a flush.

## Changes

**Native (Android, Kotlin/Java):**
- `BridgeHolder.kt` — process-singleton holder for the Capacitor `Bridge`. Attached by `MainActivity.onCreate`, detached in `onDestroy`. Lets the receiver dispatch a window `brainCannedResponse` event when the WebView is alive without leaking a bridge reference past activity teardown.
- `WriteQueueStore.kt` — appends an entry `{ notification_id, response, response_note, enqueued_at }` to the same SharedPreferences file (`CapacitorStorage`) the JS `@capacitor/preferences` plugin uses, so JS can drain on next launch even if the receiver fired with the app process dead. Soft cap of 500 logs a warning but does not drop entries (per spec).
- `CannedResponseReceiver.kt` — extracts intent extras, calls `WriteQueueStore.enqueue`, dismisses the notification, then `BridgeHolder.triggerJSEvent("brainCannedResponse")` for the app-alive case.
- `MainActivity.java` — gains `onCreate` / `onDestroy` lifecycle for bridge attach/detach.

**Client (TypeScript):**
- `src/lib/writeQueue.ts` — `enqueueResponse`, `flushWriteQueue`, `subscribeConflicts`, `initWriteQueue`. Flush is single-flight (concurrent calls coalesce). 200/201 → remove. 409 → drop, emit `ConflictWarning` if the server's recorded response differs (recent-view UI consumes this in [2C-09]). Network/5xx → leave entry at head, stop flushing.
- `src/App.tsx` — adds a `WriteQueueRunner` companion to `DeviceRegistrar` so `initWriteQueue` mounts once at app start.

**Tests:** `src/lib/writeQueue.test.ts` — 12 specs covering enqueue persistence + soft cap, gating on pairing/registration, in-order flush with bearer auth, URL trailing-slash strip, network and 5xx halt-and-preserve, retry-safety once connectivity restores, 409 conflict drop with `ConflictWarning` emission, and 409-with-unparseable-body silent drop.

## How to Verify

Automated checks already captured in the Verification section above. On-device:

1. **Foreground:** Open the app with a paired + registered device. Trigger a habit nudge from BRAIN. Tap a canned response on the watch. The `respond` POST should land within ~1s; the notification status flips to `responded` server-side. The app's `brain.writeQueue` (Preferences) should remain empty.
2. **Airplane-mode:** Toggle airplane mode on, trigger a nudge, tap a canned response. The notification dismisses, `brain.writeQueue` contains one entry. Toggle airplane mode off and bring the app to foreground (or wait for the `online` event). Queue flushes to empty; server records the response.
3. **Retry safety:** Tap the same response twice in quick succession (force a duplicate enqueue if necessary). Server returns 200 both times per [2C-03]'s same-tuple idempotency; no double-write in `notification_responses`.

## Deviations

1. **Test path** — spec says `tests/unit/writeQueue.spec.ts`; I co-located at `src/lib/writeQueue.test.ts` per repo CLAUDE.md ("Do NOT introduce new files in `tests/unit/` — that directory is being phased out. Pattern: `src/lib/foo.ts` → `src/lib/foo.test.ts`."). Spec intent (the four behaviors enqueue/flush-in-order/409-conflict/queue-cap) is preserved; test count is broader (12 specs) to also lock down gating, retry-safety, and bearer-auth wiring.
2. **Native receiver always writes to SharedPreferences first**, then best-effort triggers the JS event. The spec leaves this to "Desmond chooses based on plugin version behavior". Capacitor 6 custom JS events do not buffer when no listener is attached, so the SharedPreferences-first path is required to survive the receiver-when-app-dead case; the JS event remains for the app-alive immediate-flush case. Matches the spec's fallback ("native receiver writes to SharedPreferences under the same key and JS reads it on launch").
3. **CLAUDE.md drift surfaced — flagging only, not fixing per directive `4ea28266`:**
   - The on-disk `D:\_DEVELOPMENT\CLAUDE.md` (org-level) is the older verbose format using the retired `TICKET-XX` prefix; BRAIN org CLAUDE.md v5 (`a2fbaab5`) supersedes it with the inheritance section, stream-ID prefix, and Verification + Closes-line conventions. Worked to BRAIN v5 for this session.
   - The on-disk `brain3-companion/CLAUDE.md` is mangled markdown — every `#`, backtick, and `*` is backslash-escaped, blank lines doubled. Content matches BRAIN v1 (`908baa66`) but rendering is broken; recommend re-syncing the working copy from BRAIN.

## Test Results

```
$ npm run test.unit -- --run

 ✓ src/lib/device-registration.test.ts (13 tests)
 ✓ src/lib/health.test.ts (7 tests)
 ✓ src/lib/writeQueue.test.ts (12 tests)
 ✓ src/lib/pairing.test.ts (8 tests)
 ✓ src/App.test.tsx (1 test)

 Test Files  5 passed (5)
      Tests  41 passed (41)
```

## Acceptance Checklist

- [x] `CannedResponseReceiver` extracts `notification_id` + `response`, dismisses, dispatches `brainCannedResponse` (when bridge alive) — receiver-side
- [x] JS listens for `brainCannedResponse` and flushes
- [x] POST to `/api/notifications/{id}/respond` with `{ response, response_note: null }` and bearer auth
- [x] On 200/201 → remove from queue; on 409 → drop (per [2C-03] same-tuple is server-side 200, so 409 here is the legitimate-conflict branch)
- [x] Failure path enqueues to `@capacitor/preferences` under `brain.writeQueue` with shape `{ notification_id, response, response_note, enqueued_at }[]`
- [x] Flush triggers on app foreground AND `online` event AND device-registration completion AND native bridge event AND app launch
- [x] Flush walks queue in enqueue order; stops on first non-2xx/non-409 to preserve order
- [x] Queue cap 500 logs a warning, does not drop entries
- [x] 409 with different existing response surfaces a `ConflictWarning` to subscribers (UI consumed by [2C-09])
- [x] Tests cover enqueue, flush-in-order, 409-conflict, queue-cap (path deviation noted above)

Closes #2