### PR TITLE
[2C-Bug-03]: MainActivity.onDestroy declared protected; BridgeActivity override requires public

### DIFF
--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
@@ -12,7 +12,7 @@ public class MainActivity extends BridgeActivity {
     }
 
     @Override
-    protected void onDestroy() {
+    public void onDestroy() {
         BridgeHolder.INSTANCE.detach(getBridge());
         super.onDestroy();
     }


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npm run test.unit -- --run` — ✅ Pass (41 passed; no JS-side change)
- Local Gradle build: ➖ N/A — JDK + Android SDK absent on this dev machine, same gap that let the original slip through. Verification of record is the post-merge Dev Release workflow run on develop.

Ran locally against develop HEAD `0c4b8fb` immediately before opening this PR.

## Summary

One-line hotfix for the `:app:compileDebugJavaWithJavac` failure introduced by [2C-07] PR #41. `BridgeActivity.onDestroy()` is `public`; the override added in `MainActivity.java` was declared `protected`, so javac rejected the narrower access modifier. Widening to `public` matches the supertype and clears the build.

## Changes

- `android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java` — `onDestroy()` modifier `protected` → `public`. No behavior change.

## How to Verify

1. `git checkout fix/2C-Bug-03-mainactivity-ondestroy-access`
2. `cd android && .\gradlew.bat compileDebugJavaWithJavac` (with JDK + ANDROID_HOME set per repo CLAUDE.md). Should succeed.
3. The Dev Release workflow on push-to-develop should run clean post-merge.

## Deviations

None.

## Test Results

```
$ npm run test.unit -- --run

 Test Files  5 passed (5)
      Tests  41 passed (41)
```

JS suite unchanged — this is a Java access-modifier fix that only Gradle/javac catches. Local Gradle was not run pre-PR because JDK + ANDROID_HOME are not configured on this machine; same scenario as [2C-Bug-02] PR #40.

## Acceptance Checklist

- [x] `MainActivity.onDestroy()` declared `public` to match `BridgeActivity.onDestroy()`
- [x] No behavior change beyond the access modifier
- [x] Will unblock the Dev Release workflow on develop

Closes #42