### PR TITLE
[2C-Bug-04]: Android cleartext HTTP blocks companion APK pairing to brain3-test on LAN

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    brain3-companion network security configuration.
+
+    Cleartext HTTP is permitted because the v2.0.0 deployment target is the
+    user's home LAN (e.g. http://192.168.0.14:8100) where TLS is impractical
+    without reverse-proxy + cert-management work that is explicitly out of
+    scope for this release. See brain3 Deployment Reference §8.1 + §9.
+
+    When TLS lands on the NAS deployment, flip cleartextTrafficPermitted to
+    "false" in <base-config> and add <domain-config cleartextTrafficPermitted="true">
+    blocks only for hosts that legitimately need an HTTP exception.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors, clean exit)
- `npx vitest run` — ✅ Pass (7 test files, 64 tests, 0 failures)
- `npm run android:build:debug` — ⚠️ Not run (agent-env Gradle/JDK absence; see Deviations)

Ran locally against develop HEAD at `e14a818` immediately before opening this PR.

## Summary

Adds an Android Network Security Configuration declaring cleartext HTTP permitted under `<base-config>`, and references it from `<application>` in the manifest. Unblocks the v2.0.0 demo path: physical Android devices on API 28+ can now reach brain3-test on the home LAN during pairing and subsequent fetches.

P-8b (CI-invisible runtime gap) corrective on the implementation side. Real verification is L's on-device manual gate, preserved verbatim on the linked issue.

## Changes

- **NEW:** `android/app/src/main/res/xml/network_security_config.xml` — single `<base-config cleartextTrafficPermitted="true">` with system trust anchors. Comment block explains the LAN-only deployment posture and the future flip to `false` when TLS lands on the NAS deployment (Deployment Reference §9 reserved expansion).
- **MODIFIED:** `android/app/src/main/AndroidManifest.xml` — single attribute added to `<application>`: `android:networkSecurityConfig="@xml/network_security_config"`. Inserted alphabetically between `android:label` and `android:roundIcon`. No other changes.

No `android:usesCleartextTraffic` attribute added — NSC supersedes it on API 24+; combining the two would obscure intent per the spec rationale.

## How to Verify

L runs the on-device manual verification gate per the issue body's `#### Manual verification` section, preserved verbatim on the issue. Pre-merge auto-checks (lint + vitest) confirm no regression in the JS layer; the XML is a passive resource that the manifest references.

## Deviations

1. **`npm run test.unit` runs vitest in watch mode.** `package.json` defines `"test.unit": "vitest"` with no `--run` flag, so the script hangs on stdin in a non-interactive shell. To verify, I invoked `npx vitest run` directly. The underlying test result is identical — only the script's interactive default differs from what the spec's acceptance criterion implies. Flagging per the deviation contract; not silently fixed. Worth a follow-up Gap to make the script CI-shaped (e.g., `vitest run` for `test.unit`, `vitest` for a separate `test.unit.watch`), but out of scope here per "log it, don't fix it."
2. **`npm run android:build:debug` not executed.** Same agent-env Gradle/JDK absence carry-forward as [2C-09]; flagging here for consistency. Compile risk for an XML-only change is low (manifest is syntactically validated against the schema by Android Studio/AAPT2 at build time, but no JS/TS surface is touched). The release-pipeline manual on-device gate (P-8b corrective) is the authoritative verification.

## Test Results

```
$ npm run lint

> brain3-companion@0.0.1 lint
> eslint

(clean exit, 0 errors)

$ npx vitest run

 RUN  v1.6.1 D:/_DEVELOPMENT/brain3-companion

 ✓ src/lib/device-registration.test.ts (13 tests) 7ms
 ✓ src/lib/pairing.test.ts (8 tests) 3ms
 ✓ src/lib/health.test.ts (7 tests) 4ms
 ✓ src/lib/writeQueue.test.ts (12 tests) 10ms
 ✓ src/lib/notifications.test.ts (16 tests) 21ms
 ✓ src/lib/local-date.test.ts (7 tests) 4ms
 ✓ src/App.test.tsx (1 test) 118ms

 Test Files  7 passed (7)
      Tests  64 passed (64)
   Duration  4.60s
```

## Acceptance Checklist

- [x] `android/app/src/main/res/xml/network_security_config.xml` exists with the XML contents from the spec, including the explanatory comment block verbatim.
- [x] `android/app/src/main/AndroidManifest.xml` `<application>` element includes `android:networkSecurityConfig="@xml/network_security_config"`.
- [x] No `android:usesCleartextTraffic` attribute added.
- [x] `npm run lint` passes clean.
- [x] `npm run test.unit` passes clean (executed as `npx vitest run` per Deviation 1).
- [ ] `npm run android:build:debug` — not run; agent-env limit per Deviation 2. L's on-device manual gate is the authoritative check.
- [x] PR title matches the issue title exactly.
- [x] PR description includes `Closes #45` on its own line.
- [x] Manual verification preserved verbatim on the issue (no edits to the issue body in this PR).

Closes #45