### PR TITLE
[2C-Bug-04-fix-2]: Enable CapacitorHttp plugin so pair fetch bypasses WebView mixed-content block

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -5,6 +5,9 @@ const config: CapacitorConfig = {
   appName: 'BRAIN Companion',
   webDir: 'dist',
   plugins: {
+    CapacitorHttp: {
+      enabled: true,
+    },
     SplashScreen: {
       backgroundColor: '#0B0714',
       showSpinner: false,


### PR DESCRIPTION
## Summary

Enables Capacitor 6's built-in `CapacitorHttp` plugin via `capacitor.config.ts`. The plugin patches `window.fetch` and `XMLHttpRequest` at WebView startup so they route through native Java HTTP rather than the WebView's network stack. This bypasses Android WebView's mixed-content gate (which fires *before* the NSC layer) and finally lets PR #46's `cleartextTrafficPermitted="true"` take effect on LAN pair fetches.

PR #46's NSC files stay exactly as merged — this fix is layered on top, not a replacement. They become functionally load-bearing once requests reach the native HTTP layer.

## Changes

- `capacitor.config.ts` — additive: a new `CapacitorHttp: { enabled: true }` block prepended inside `plugins`. `SplashScreen` and `PushNotifications` blocks unchanged.

No source files under `src/` are modified. No native Java/Kotlin files are modified. No new dependencies (`CapacitorHttp` ships in `@capacitor/core@^6.0.0`, already pinned).

## How to Verify

### Auto-verifiable

```
npm run lint            # passes clean
npx vitest run          # 7 files, 64 tests pass
npm run android:sync    # regenerates android/app/src/main/assets/capacitor.config.json with CapacitorHttp.enabled=true
```

### Manual verification

> **Preserved verbatim from issue #47.** L runs this on a physical phone post-merge. Implementing agent does **not** run this. This is the second-iteration P-8b corrective gate — the first-pass three-criterion gate proved necessary but not sufficient (criterion (a) "no app error" passed in unit tests and CI, but the merged APK still failed at runtime). The new gate adds two empirical-silence criteria that verify the architectural layers we depend on are not blocking. v2.0.0 release does not ship until this passes.

**Pre-conditions:**

- brain3-test deployed and reachable at `http://192.168.0.14:8100` from the LAN (per Deployment Reference §3.4: `curl http://192.168.0.14:8100/health` returns `{"status":"healthy","database":"connected"}`).
- Bearer token in `/mnt/Main/brain3-test/.env` known.
- Phone on same LAN as NAS, USB-debugging enabled, paired with `adb`.
- Post-fix debug APK built from this branch's HEAD and sideloaded to phone.

**Procedure:**

1. On NAS shell, start live API log tail:

   ```
   docker compose -f docker-compose.test.yml logs -f --tail 0 api
   ```

2. On the PC, clear and start a filtered logcat capture (Windows cmd.exe; for POSIX shells substitute redirection accordingly):

   ```
   adb logcat -c
   adb logcat -v time *:I > logcat-pair-postfix.txt
   ```

3. On the phone: open BRAIN Companion → Pair → enter `http://192.168.0.14:8100` + bearer token → tap Pair.

4. Wait until the app shows either successful pair or an error.

5. Stop logcat in the cmd window (`Ctrl+C`).

6. **Pass criteria (all five must hold):**

   - **(a)** App shows successful pair (no "couldn't reach server" error).
   - **(b)** Connection indicator transitions to connected within 5 seconds.
   - **(c)** API log on NAS shows `GET /api/app/health` with the bearer header in the same window — confirms request reached the server.
   - **(d)** `findstr /I /C:"Mixed Content" logcat-pair-postfix.txt` returns **zero** matches — confirms WebView mixed-content gate did not fire (i.e., CapacitorHttp's native routing is in effect).
   - **(e)** `findstr /I /C:"cleartext" logcat-pair-postfix.txt` returns **zero** matches — confirms NSC did not block the request (i.e., PR #46's posture is being honored).

7. **Fail criteria (any one):**

   - App reports a network error or stays on the pair screen past the 5-second validation-ping timeout.
   - API log tail shows no incoming request during the pair attempt.
   - Connection indicator stays disconnected after the timeout elapses.
   - logcat contains any "Mixed Content" line referring to `192.168.0.14:8100` (criterion (d) failure).
   - logcat contains any "cleartext" line referring to `192.168.0.14:8100` (criterion (e) failure).

If pass criteria are met, this gate is satisfied for v2.0.0. The five-criterion structure becomes the template for the manual on-device acceptance gate added to the v2.0.0 release pipeline (P-8b corrective, separate followup brief).

**Why criteria (d) and (e) are necessary, not just (a)-(c):**

(a)-(c) measure outcome — did the pair work? (d)-(e) measure mechanism — did it work for the right reasons? A future regression (Capacitor major-version bump, `androidScheme` change, NSC scope tightening, WebView upgrade altering mixed-content policy) could pass (a)-(c) by accident-of-architecture and then silently fail at the next environmental change. (d)-(e) make both load-bearing layers empirically observable.

## Deviations

1. **`capacitor.config.json` is gitignored — only `capacitor.config.ts` is committed.** The spec's Technical Approach section says "Both files must be committed — the Android build reads the JSON, not the TS." On inspection, `android/.gitignore:99` excludes `app/src/main/assets/capacitor.config.json`. The spec's intent is honored without committing the JSON: `npm run android:sync` regenerates it from the TS (and is wrapped by `npm run android:build:debug`), and I verified empirically that the regenerated JSON contains `CapacitorHttp.enabled = true`. Acceptance criterion #2 is satisfied at build time, not at commit time. The JSON gitignore is a pre-existing repo decision (not introduced by this PR); the spec was written under the assumption it was committed. Worth a doc back-port if the same assumption is made in future Stream C briefs.

2. **Pre-existing gradle drift surfaced by `npm run android:sync`, reverted from this PR.** Running sync also produced unrelated deltas in `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle` adding `:capacitor-device` plugin references. `@capacitor/device@6.0.3` was added to `package.json` in [2C-05] (`3d6ef44`) but its sync into the Android gradle config never landed. This is pre-existing repo drift unrelated to the CapacitorHttp fix — reverted here to keep this PR scoped, will file as a separate Gap per "Log It, Don't Fix It."

3. **Agent-env verification gap (carry-forward).** Same Gradle/JDK absence in this agent environment as previous Stream C dispatches: `npm run android:build:debug` cannot be run by the implementing agent. Acceptance criterion #7 (build succeeds, manifest still references NSC, regenerated JSON includes the flag) is verified by L on-device or via the dev-channel CI workflow on push to `develop`. Compile risk for this change is low — config-only, no dependency churn, no source/native edits.

## Test Results

```
$ npm run lint
(passes clean — no findings)

$ npx vitest run
 ✓ src/lib/device-registration.test.ts  (13 tests)
 ✓ src/lib/writeQueue.test.ts           (12 tests)
 ✓ src/lib/pairing.test.ts              (8 tests)
 ✓ src/lib/health.test.ts               (7 tests)
 ✓ src/lib/notifications.test.ts        (16 tests)
 ✓ src/lib/local-date.test.ts           (7 tests)
 ✓ src/App.test.tsx                     (1 test)

 Test Files   7 passed (7)
      Tests   64 passed (64)
   Duration   5.00s
```

## Acceptance Checklist

- [x] `capacitor.config.ts` has `plugins.CapacitorHttp.enabled = true` (additive change to the existing `plugins` block; `SplashScreen` and `PushNotifications` blocks remain unchanged).
- [x] `android/app/src/main/assets/capacitor.config.json` (regenerated by `npm run android:sync`) reflects the new `CapacitorHttp` config. *(Verified empirically; not committed because gitignored — see Deviation 1.)*
- [x] No source files under `src/` are modified.
- [x] No native Java/Kotlin files modified.
- [x] PR #46's `android/app/src/main/AndroidManifest.xml` `android:networkSecurityConfig` reference and `android/app/src/main/res/xml/network_security_config.xml` remain intact.
- [x] `npm run lint` passes clean.
- [x] `npm run test.unit` passes clean.
- [ ] `npm run android:build:debug` succeeds; manifest still references NSC; regenerated JSON includes `CapacitorHttp.enabled = true`. *(Agent-env limit — see Deviation 3. Verified locally by L or via dev-channel CI on push.)*
- [x] PR title matches the issue title exactly per org CLAUDE.md.
- [x] PR description includes `Closes #47` on its own line (below).
- [x] Manual verification preserved verbatim in this PR body.

Closes #47
