### PR TITLE
[2C-Bug-05] FirebaseApp init fix — google-services.json wiring + native guard

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -50,6 +50,22 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Inject google-services.json for Firebase
+        # Decode the base64-encoded google-services.json from a repo secret so
+        # the gms plugin runs at gradle-time and bakes Firebase resources
+        # (google_app_id, etc.) into the APK. The grep guard fails the build
+        # loudly if the secret is missing or malformed — closing the silent
+        # try/catch skip at android/app/build.gradle:63-70 that hid this bug
+        # class on every CI build prior to [2C-Bug-05].
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > android/app/google-services.json
+          if ! grep -q '"project_id"' android/app/google-services.json; then
+            echo "::error::google-services.json injection failed — file is empty or malformed."
+            exit 1
+          fi
+
       - name: Regenerate debug keystore
         # The debug keystore is gitignored per [2C-11] (see android/keystore/README.md).
         # CI regenerates it deterministically with the documented command — no secrets needed.

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
@@ -7,6 +7,10 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        // Register before super.onCreate so SafePushNotificationsPlugin
+        // claims the "PushNotifications" name first; auto-discovery from
+        // capacitor.plugins.json then no-ops on duplicate. See [2C-Bug-05].
+        registerPlugin(SafePushNotificationsPlugin.class);
         super.onCreate(savedInstanceState);
         BridgeHolder.INSTANCE.attach(getBridge());
     }

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/SafePushNotificationsPlugin.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/SafePushNotificationsPlugin.kt
@@ -1,0 +1,26 @@
+package com.fluxmeridian.brain3companion
+
+import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.google.firebase.FirebaseApp
+
+// Defense-in-depth wrapper around the upstream Capacitor PushNotifications
+// plugin. The default register() calls FirebaseMessaging.getInstance() with
+// no FirebaseApp init guard, so a missing google-services.json kills the
+// process via FATAL EXCEPTION on the CapacitorPlugins thread (see [2C-Bug-05]).
+// This subclass converts that into a recoverable JS-layer rejection so the
+// existing try/catch at device-registration.ts:168 can surface it.
+@CapacitorPlugin(name = "PushNotifications")
+class SafePushNotificationsPlugin : PushNotificationsPlugin() {
+
+    @PluginMethod
+    override fun register(call: PluginCall) {
+        if (FirebaseApp.getApps(context).isEmpty()) {
+            call.reject("FIREBASE_NOT_CONFIGURED")
+            return
+        }
+        super.register(call)
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the post-pair process kill on `PushNotifications.register()` by getting `google-services.json` into the build (so `FirebaseApp` actually initializes) and adding a native guard so a future regression degrades to a recoverable JS error rather than a FATAL EXCEPTION.

This is the bundled response to Stellan Report `605869fa` §4.1 + §4.2. PO-ratified single-PR shape per Brief `7b0bc6ff` §2.

## Changes

- `.github/workflows/dev-release.yml` — new step **Inject google-services.json for Firebase**, sandwiched between **Install npm dependencies** and **Regenerate debug keystore** (i.e. before the web bundle and gradle build). Decodes `GOOGLE_SERVICES_JSON_BASE64` from repo secrets to `android/app/google-services.json`. Includes a `grep '"project_id"'` guard that fails the build loudly if the secret is missing or malformed — explicitly closing the silent gradle skip at `android/app/build.gradle:63-70` that produced runtime crashes on every prior CI APK.
- `android/app/src/main/java/com/fluxmeridian/brain3companion/SafePushNotificationsPlugin.kt` *(new)* — Kotlin subclass of `com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin` annotated `@CapacitorPlugin(name = "PushNotifications")`. Overrides `register(call:)` with a `FirebaseApp.getApps(context).isEmpty()` short-circuit that calls `call.reject("FIREBASE_NOT_CONFIGURED")` before delegating to `super.register(call)`. Defense-in-depth — converts the previously un-catchable native FATAL EXCEPTION into a JS Promise rejection that the existing `device-registration.ts:168-173` try/catch can surface.
- `android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java` — adds `registerPlugin(SafePushNotificationsPlugin.class)` **before** `super.onCreate(savedInstanceState)`. Capacitor's plugin registry de-dupes by `@CapacitorPlugin(name=...)` and ignores duplicates, so registering first means our safe wrapper claims the `PushNotifications` slot before auto-discovery from `capacitor.plugins.json` runs.

No TS/JS source touched; the `<DeviceRegistrar />` fire-and-forget pattern at `App.tsx:64-66` is intentionally left alone (out-of-scope per Brief §4 + Stellan Report §4.3).

## How to Verify

### CI verification (auto)
1. Confirm repo secret `GOOGLE_SERVICES_JSON_BASE64` is populated *(L confirmed uploaded this session)*.
2. After merge, the `Dev Release` workflow runs on the resulting `develop` push.
3. The **Inject google-services.json for Firebase** step should succeed; the **Build debug APK** step should now apply the `com.google.gms.google-services` plugin (no more silent skip).
4. APK Analyzer on the published `develop-{sha}` pre-release: `res/values/values.xml` contains a `google_app_id` string resource, and `assets/capacitor.plugins.json` still lists `PushNotifications`.
5. **Negative test for the grep guard:** if you want to prove the silent-skip surface is closed, temporarily corrupt the secret in a fork — the workflow should fail at the inject step with the `::error::` annotation rather than producing a runtime-crashing APK.

### Manual verification (preserved verbatim from issue #50)

L runs the procedure on the AVD or a physical device:

1. Uninstall any existing `com.fluxmeridian.brain3companion` install (`adb -s <serial> uninstall com.fluxmeridian.brain3companion`).
2. Sideload the new post-fix APK from the dev-release pre-release tag.
3. Launch app, navigate to Settings, enter valid pairing URL + bearer token, tap Connect.
4. Confirm: connection indicator transitions to green AND the app remains alive for ≥5 seconds with no crash.
5. Confirm in `adb logcat`: zero `FATAL EXCEPTION` lines; one `Capacitor D Handling CapacitorHttp request: …health…` line indicating fix-2 still working; (if Firebase setup fully landed) one `FirebaseInstanceId` or `FirebaseMessaging` info line showing the FCM token was obtained.
6. (If [2C-05] server is available and pair URL points at it) Confirm in `docker compose logs api` on the test stack: one `POST /api/app/devices` line with status 200 or 201.

The MV gate uses the six-criterion structure proposed in Stellan Report `c4fd5034` §6.3 + the original five-criterion gate from #47 §5: provenance (APK Analyzer check that `assets/capacitor.config.json` has `CapacitorHttp.enabled: true` AND `assets/google_services.json`-derived strings exist) + outcome (a/b/c) + mechanism (d/e: zero Mixed Content, zero cleartext blocks).

## Deviations

**Bundled scope (PO-ratified).** §4.1 (workflow change) and §4.2 (native guard) ship in one PR rather than two. Brief `7b0bc6ff` §2 ratifies this as an explicit exception to the strict one-issue-one-PR norm — §4.2 is the direct defense-in-depth consequence of §4.1's root-cause analysis. Both close the same FATAL-EXCEPTION surface from different layers; splitting them would create a window where one was merged without the other. Documented per Org CLAUDE.md deviation rule.

**Inject step placement.** Stellan §4.1 step 3 specifies "between Install npm dependencies and Build web bundle (i.e., after line 51 in the current workflow)." Placed directly after `Install npm dependencies` (current line 51 → 52), before the unrelated `Regenerate debug keystore` step. Either placement satisfies "between"; this one keeps secret-consumption setup steps grouped with other install/setup steps, away from the build steps proper. Consistent with the spec's intent.

**No App.tsx / device-registration.ts changes.** The brief and Stellan Report both flag the fire-and-forget pattern as orthogonal — that pattern is fine when the underlying plugin doesn't process-kill. Honoring scope discipline; not refactored.

## Test Results

Lint:
```
> brain3-companion@0.0.1 lint
> eslint
```
Clean.

Unit tests untouched — `device-registration.test.ts` mocks `PushNotifications` at the JS layer and does not exercise the native plugin (per Stellan Report §6.2.5).

Native compile / instrumentation tests will run during CI's `assembleDebug` after merge; this is the canonical signal that the gradle change wires through correctly.

## Acceptance Checklist

- [x] L has created Firebase project, downloaded `google-services.json`, placed locally *(per Brief §3 prerequisite — confirmed by L this session)*
- [x] `GOOGLE_SERVICES_JSON_BASE64` exists in repo secrets *(per Brief §3 prerequisite — confirmed by L this session)*
- [x] `dev-release.yml` includes the inject step with the `grep` guard
- [ ] `npm run android:build:debug` locally produces an APK that contains `google_app_id` in `app/build/intermediates/.../res/values/values.xml` (verifiable via APK Analyzer) — *L on-device check post-merge*
- [ ] CI build of the modified workflow produces an APK that contains `google_app_id` — *post-merge CI run*
- [ ] Sideload of the new APK to AVD or physical device: pair handshake completes; no FATAL EXCEPTION; app stays alive after pair — *L MV post-merge*

Closes #50
Refs #45