### PR TITLE
[2C-23] App: Completion write-queue extension for habit + routine

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   runDeviceRegistration,
 } from './lib/device-registration';
 import { initWriteQueue } from './lib/writeQueue';
+import { initCompletionQueues } from './lib/completionQueues';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -78,8 +79,12 @@ const DeviceRegistrar: React.FC = () => {
 
 const WriteQueueRunner: React.FC = () => {
   useEffect(() => {
-    const teardown = initWriteQueue();
-    return () => teardown();
+    const teardownNotifications = initWriteQueue();
+    const teardownCompletions = initCompletionQueues();
+    return () => {
+      teardownNotifications();
+      teardownCompletions();
+    };
   }, []);
   return null;
 };

--- a/src/lib/completionQueues.habit.test.ts
+++ b/src/lib/completionQueues.habit.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
+import {
+  __resetForTests,
+  enqueueHabitCompletion,
+  flushAllQueues,
+  HABIT_COMPLETIONS_KEY,
+  subscribeHabitCompletionWarnings,
+  type HabitCompletionEntry,
+  type HabitCompletionWarning,
+} from './completionQueues';
+import { __resetForTests as __resetWriteQueueForTests } from './writeQueue';
+
+const PAIRING_URL = 'https://brain.local:8000';
+const PAIRING_TOKEN = 'bearer-abc-123';
+
+const prefsStore = new Map<string, string>();
+
+function entry(
+  overrides: Partial<HabitCompletionEntry> = {},
+): HabitCompletionEntry {
+  return {
+    habit_id: '11111111-1111-1111-1111-111111111111',
+    completed_date: '2026-05-02',
+    notes: null,
+    enqueued_at: '2026-05-02T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function seedPairing(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRING_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRING_TOKEN);
+}
+
+async function readQueue(): Promise<HabitCompletionEntry[]> {
+  const raw = prefsStore.get(HABIT_COMPLETIONS_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as HabitCompletionEntry[];
+}
+
+beforeEach(() => {
+  __resetForTests();
+  __resetWriteQueueForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('enqueueHabitCompletion', () => {
+  it('persists entries to brain.writeQueue.habitCompletions in order', async () => {
+    await enqueueHabitCompletion(entry({ habit_id: 'a' }));
+    await enqueueHabitCompletion(entry({ habit_id: 'b' }));
+    const queue = await readQueue();
+    expect(queue.map((e) => e.habit_id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('habit completion flush — happy path', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('POSTs each entry to /api/habits/{id}/complete with bearer auth and the spec body', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'h-1', completed_date: '2026-05-02', notes: 'first' }),
+      ]),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const summary = await flushAllQueues();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe('https://brain.local:8000/api/habits/h-1/complete');
+    const headers = init!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${PAIRING_TOKEN}`);
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init!.body as string)).toEqual({
+      completed_date: '2026-05-02',
+      notes: 'first',
+    });
+    expect(summary.habitCompletions.delivered).toBe(1);
+    expect(summary.habitCompletions.remaining).toBe(0);
+    expect(await readQueue()).toEqual([]);
+  });
+
+  it('treats 200 (idempotent retry) and 201 identically as delivered', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'h-1' }),
+        entry({ habit_id: 'h-2' }),
+      ]),
+    );
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    const summary = await flushAllQueues();
+
+    expect(summary.habitCompletions.delivered).toBe(2);
+    expect(summary.habitCompletions.remaining).toBe(0);
+  });
+});
+
+describe('habit completion flush — terminal-drop paths', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('drops entry and emits paused warning on 400 with the paused-status detail', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'paused-id' }),
+        entry({ habit_id: 'after' }),
+      ]),
+    );
+    const warnings: HabitCompletionWarning[] = [];
+    subscribeHabitCompletionWarnings((w) => warnings.push(w));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            detail:
+              "Cannot complete a habit with status 'paused'. Only active habits can be completed.",
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const summary = await flushAllQueues();
+
+    // Paused entry is discarded (removed but not counted as delivered);
+    // the second entry is genuinely delivered.
+    expect(summary.habitCompletions.attempted).toBe(2);
+    expect(summary.habitCompletions.delivered).toBe(1);
+    expect(summary.habitCompletions.remaining).toBe(0);
+    expect(warnings).toEqual([{ kind: 'paused', habit_id: 'paused-id' }]);
+  });
+
+  it('drops entry and emits not_found warning on 404, continuing the flush', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'gone' }),
+        entry({ habit_id: 'after' }),
+      ]),
+    );
+    const warnings: HabitCompletionWarning[] = [];
+    subscribeHabitCompletionWarnings((w) => warnings.push(w));
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const summary = await flushAllQueues();
+
+    expect(summary.habitCompletions.attempted).toBe(2);
+    expect(summary.habitCompletions.delivered).toBe(1);
+    expect(summary.habitCompletions.remaining).toBe(0);
+    expect(warnings).toEqual([{ kind: 'not_found', habit_id: 'gone' }]);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('habit completion flush — halt paths', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('halts on network failure and preserves enqueue order', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'first' }),
+        entry({ habit_id: 'second' }),
+      ]),
+    );
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+
+    const summary = await flushAllQueues();
+
+    expect(summary.habitCompletions.attempted).toBe(1);
+    expect(summary.habitCompletions.delivered).toBe(0);
+    expect(summary.habitCompletions.remaining).toBe(2);
+    const queue = await readQueue();
+    expect(queue.map((e) => e.habit_id)).toEqual(['first', 'second']);
+  });
+
+  it('halts on 5xx without dropping the failed entry', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        entry({ habit_id: 'first' }),
+        entry({ habit_id: 'second' }),
+      ]),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+
+    const summary = await flushAllQueues();
+
+    expect(summary.habitCompletions.attempted).toBe(1);
+    expect(summary.habitCompletions.delivered).toBe(0);
+    expect(summary.habitCompletions.remaining).toBe(2);
+  });
+});
+
+describe('habit completion flush — gating', () => {
+  it('no-ops when no pairing is stored', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([entry({ habit_id: 'h-1' })]),
+    );
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const summary = await flushAllQueues();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(summary.habitCompletions).toEqual({
+      attempted: 0,
+      delivered: 0,
+      remaining: 1,
+      coalesced: false,
+    });
+  });
+});

--- a/src/lib/completionQueues.routine.test.ts
+++ b/src/lib/completionQueues.routine.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
+import {
+  __resetForTests,
+  enqueueRoutineCompletion,
+  flushAllQueues,
+  HABIT_COMPLETIONS_KEY,
+  ROUTINE_COMPLETIONS_KEY,
+  subscribeRoutineCompletionWarnings,
+  type HabitCompletionEntry,
+  type RoutineCompletionEntry,
+  type RoutineCompletionWarning,
+} from './completionQueues';
+import { __resetForTests as __resetWriteQueueForTests } from './writeQueue';
+
+const PAIRING_URL = 'https://brain.local:8000';
+const PAIRING_TOKEN = 'bearer-abc-123';
+
+const prefsStore = new Map<string, string>();
+
+function entry(
+  overrides: Partial<RoutineCompletionEntry> = {},
+): RoutineCompletionEntry {
+  return {
+    routine_id: '22222222-2222-2222-2222-222222222222',
+    completed_date: '2026-05-02',
+    status: 'all_done',
+    freeform_note: null,
+    child_habit_completions: null,
+    enqueued_at: '2026-05-02T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function seedPairing(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRING_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRING_TOKEN);
+}
+
+async function readRoutineQueue(): Promise<RoutineCompletionEntry[]> {
+  const raw = prefsStore.get(ROUTINE_COMPLETIONS_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as RoutineCompletionEntry[];
+}
+
+async function readHabitQueue(): Promise<HabitCompletionEntry[]> {
+  const raw = prefsStore.get(HABIT_COMPLETIONS_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as HabitCompletionEntry[];
+}
+
+beforeEach(() => {
+  __resetForTests();
+  __resetWriteQueueForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('enqueueRoutineCompletion — non-partial statuses', () => {
+  it('all_done: appends only to the routine queue, no habit pre-enqueue', async () => {
+    await enqueueRoutineCompletion(
+      entry({ routine_id: 'r-1', status: 'all_done' }),
+    );
+    expect((await readRoutineQueue()).map((e) => e.routine_id)).toEqual([
+      'r-1',
+    ]);
+    expect(await readHabitQueue()).toEqual([]);
+  });
+
+  it('skipped: appends only to the routine queue, no habit pre-enqueue', async () => {
+    await enqueueRoutineCompletion(
+      entry({ routine_id: 'r-2', status: 'skipped' }),
+    );
+    expect((await readRoutineQueue()).map((e) => e.routine_id)).toEqual([
+      'r-2',
+    ]);
+    expect(await readHabitQueue()).toEqual([]);
+  });
+});
+
+describe('enqueueRoutineCompletion — partial pre-enqueues child habits before the routine', () => {
+  it('appends each child_habit_completions entry to the habit queue first, then the routine entry', async () => {
+    await enqueueRoutineCompletion(
+      entry({
+        routine_id: 'r-partial',
+        status: 'partial',
+        freeform_note: 'only got two of three',
+        child_habit_completions: [
+          { habit_id: 'h-A', completed_date: '2026-05-02' },
+          { habit_id: 'h-B', completed_date: '2026-05-02' },
+        ],
+      }),
+    );
+
+    const habits = await readHabitQueue();
+    const routines = await readRoutineQueue();
+    expect(habits.map((e) => e.habit_id)).toEqual(['h-A', 'h-B']);
+    expect(routines.map((e) => e.routine_id)).toEqual(['r-partial']);
+    // Note semantics for child entries: notes is null per spec.
+    expect(habits.every((e) => e.notes === null)).toBe(true);
+  });
+
+  it('partial flush order: child habits POST before the routine POST', async () => {
+    seedPairing();
+    await enqueueRoutineCompletion(
+      entry({
+        routine_id: 'r-partial',
+        status: 'partial',
+        freeform_note: 'only got two',
+        child_habit_completions: [
+          { habit_id: 'h-A', completed_date: '2026-05-02' },
+          { habit_id: 'h-B', completed_date: '2026-05-02' },
+        ],
+      }),
+    );
+
+    const order: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/habits/h-A/')) order.push('habit:h-A');
+      else if (url.includes('/api/habits/h-B/')) order.push('habit:h-B');
+      else if (url.includes('/api/routines/r-partial/')) order.push('routine:r-partial');
+      return new Response(null, { status: 200 });
+    });
+
+    await flushAllQueues();
+
+    expect(order).toEqual(['habit:h-A', 'habit:h-B', 'routine:r-partial']);
+  });
+});
+
+describe('routine completion flush — happy path', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('POSTs to /api/routines/{id}/complete with the spec body for all_done', async () => {
+    await enqueueRoutineCompletion(
+      entry({ routine_id: 'r-1', status: 'all_done', freeform_note: null }),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const summary = await flushAllQueues();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe(
+      'https://brain.local:8000/api/routines/r-1/complete',
+    );
+    expect(JSON.parse(init!.body as string)).toEqual({
+      completed_date: '2026-05-02',
+      status: 'all_done',
+      freeform_note: null,
+    });
+    expect(summary.routineCompletions.delivered).toBe(1);
+  });
+
+  it('POSTs status=partial with the freeform_note when partial entry flushes', async () => {
+    await enqueueRoutineCompletion(
+      entry({
+        routine_id: 'r-1',
+        status: 'partial',
+        freeform_note: 'only got two of three',
+        child_habit_completions: [
+          { habit_id: 'h-A', completed_date: '2026-05-02' },
+        ],
+      }),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await flushAllQueues();
+
+    const routinePost = fetchSpy.mock.calls.find(([url]) =>
+      String(url).includes('/api/routines/'),
+    );
+    expect(routinePost).toBeDefined();
+    expect(JSON.parse(routinePost![1]!.body as string)).toEqual({
+      completed_date: '2026-05-02',
+      status: 'partial',
+      freeform_note: 'only got two of three',
+    });
+  });
+
+  it('POSTs status=skipped with null freeform_note', async () => {
+    await enqueueRoutineCompletion(
+      entry({ routine_id: 'r-1', status: 'skipped', freeform_note: null }),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await flushAllQueues();
+
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      completed_date: '2026-05-02',
+      status: 'skipped',
+      freeform_note: null,
+    });
+  });
+
+  it('treats 200 (idempotent retry) as delivered, mirroring the [2C-26] uq_routine_completions_routine_date_status guarantee', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-1' }));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ routine_id: 'r-1', completed_date: '2026-05-02' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const summary = await flushAllQueues();
+
+    expect(summary.routineCompletions.delivered).toBe(1);
+    expect(summary.routineCompletions.remaining).toBe(0);
+    expect(await readRoutineQueue()).toEqual([]);
+  });
+});
+
+describe('routine completion flush — terminal-drop paths', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('drops entry and emits not_active warning on 409 (routine non-active)', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-paused' }));
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-after' }));
+    const warnings: RoutineCompletionWarning[] = [];
+    subscribeRoutineCompletionWarnings((w) => warnings.push(w));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: 'Cannot complete a non-active routine' }), {
+          status: 409,
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const summary = await flushAllQueues();
+
+    expect(summary.routineCompletions.attempted).toBe(2);
+    // First entry discarded (409 not-active); second entry delivered.
+    expect(summary.routineCompletions.delivered).toBe(1);
+    expect(summary.routineCompletions.remaining).toBe(0);
+    expect(warnings).toEqual([
+      { kind: 'not_active', routine_id: 'r-paused', status: 'all_done' },
+    ]);
+  });
+
+  it('drops entry and emits not_found warning on 404', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'gone' }));
+    const warnings: RoutineCompletionWarning[] = [];
+    subscribeRoutineCompletionWarnings((w) => warnings.push(w));
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    const summary = await flushAllQueues();
+
+    expect(summary.routineCompletions.attempted).toBe(1);
+    // 404 is a discard, not a delivery.
+    expect(summary.routineCompletions.delivered).toBe(0);
+    expect(summary.routineCompletions.remaining).toBe(0);
+    expect(warnings).toEqual([
+      { kind: 'not_found', routine_id: 'gone', status: 'all_done' },
+    ]);
+  });
+});
+
+describe('routine completion flush — halt paths', () => {
+  beforeEach(() => {
+    seedPairing();
+  });
+
+  it('halts on network failure and preserves enqueue order', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'first' }));
+    await enqueueRoutineCompletion(entry({ routine_id: 'second' }));
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+
+    const summary = await flushAllQueues();
+
+    expect(summary.routineCompletions.attempted).toBe(1);
+    expect(summary.routineCompletions.delivered).toBe(0);
+    expect(summary.routineCompletions.remaining).toBe(2);
+    const queue = await readRoutineQueue();
+    expect(queue.map((e) => e.routine_id)).toEqual(['first', 'second']);
+  });
+
+  it('halts on 5xx without dropping the failed entry', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-1' }));
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-2' }));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    const summary = await flushAllQueues();
+
+    expect(summary.routineCompletions.attempted).toBe(1);
+    expect(summary.routineCompletions.delivered).toBe(0);
+    expect(summary.routineCompletions.remaining).toBe(2);
+  });
+});
+
+describe('routine completion flush — gating', () => {
+  it('no-ops when no pairing is stored', async () => {
+    await enqueueRoutineCompletion(entry({ routine_id: 'r-1' }));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const summary = await flushAllQueues();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(summary.routineCompletions).toEqual({
+      attempted: 0,
+      delivered: 0,
+      remaining: 1,
+      coalesced: false,
+    });
+  });
+});

--- a/src/lib/completionQueues.ts
+++ b/src/lib/completionQueues.ts
@@ -1,0 +1,401 @@
+/**
+ * Habit and routine completion write-queues for [2C-23].
+ *
+ * Two offline-first write queues built on the {@link createWriteQueue}
+ * factory from `./writeQueue`, each persisted to its own
+ * `@capacitor/preferences` key:
+ *
+ * - `brain.writeQueue.habitCompletions` — POSTs to
+ *   `/api/habits/{habit_id}/complete`. Server idempotency comes from the
+ *   `(habit_id, completed_at)` unique constraint on `HabitCompletion`, so
+ *   duplicate retries return 200 with the existing row.
+ * - `brain.writeQueue.routineCompletions` — POSTs to
+ *   `/api/routines/{routine_id}/complete`. Server idempotency comes from
+ *   `[2C-26]`'s `uq_routine_completions_routine_date_status` unique constraint
+ *   on `(routine_id, completed_at, status)`, so duplicate same-status retries
+ *   return the existing row while genuine cross-status entries on the same
+ *   day persist as separate rows.
+ *
+ * Queues are independent — a 4xx that drains one queue's head entry does not
+ * halt the other's flush. Each queue's flusher halts on network failures and
+ * 5xx, preserving enqueue order until connectivity restores.
+ *
+ * The `[2C-07]` notification-response queue is owned by `./writeQueue` and is
+ * not touched here; {@link flushAllQueues} composes all three so UI surfaces
+ * have a single trigger after enqueue.
+ */
+
+import { App } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+import {
+  createWriteQueue,
+  flushWriteQueue,
+  type FlushSummary,
+  type QueueFlushSummary,
+} from './writeQueue';
+import { loadPairing, type Pairing } from './pairing';
+
+export const HABIT_COMPLETIONS_KEY = 'brain.writeQueue.habitCompletions';
+export const ROUTINE_COMPLETIONS_KEY = 'brain.writeQueue.routineCompletions';
+
+// ---------------------------------------------------------------------------
+// Entry shapes
+// ---------------------------------------------------------------------------
+
+export interface HabitCompletionEntry {
+  habit_id: string;
+  /** YYYY-MM-DD device-local calendar date. */
+  completed_date: string;
+  notes: string | null;
+  /** ISO timestamp of when the entry was enqueued, used for ordering audits. */
+  enqueued_at: string;
+}
+
+export type RoutineCompletionStatus = 'all_done' | 'partial' | 'skipped';
+
+export interface RoutineChildHabitCompletion {
+  habit_id: string;
+  /** YYYY-MM-DD device-local calendar date. */
+  completed_date: string;
+}
+
+export interface RoutineCompletionEntry {
+  routine_id: string;
+  completed_date: string;
+  status: RoutineCompletionStatus;
+  freeform_note: string | null;
+  /**
+   * Populated only when `status === 'partial'`. The server does not accept a
+   * per-partial habit list on the routine-complete endpoint, so the client
+   * pre-enqueues each child habit completion separately into the habit queue
+   * before appending the routine entry. The list is retained on the routine
+   * entry as an audit trail of what was pre-enqueued.
+   */
+  child_habit_completions: RoutineChildHabitCompletion[] | null;
+  enqueued_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Warning bus
+// ---------------------------------------------------------------------------
+
+export type HabitCompletionWarning =
+  | { kind: 'paused'; habit_id: string }
+  | { kind: 'not_found'; habit_id: string };
+
+export type RoutineCompletionWarning =
+  | { kind: 'not_active'; routine_id: string; status: RoutineCompletionStatus }
+  | { kind: 'not_found'; routine_id: string; status: RoutineCompletionStatus };
+
+type HabitWarningListener = (warning: HabitCompletionWarning) => void;
+type RoutineWarningListener = (warning: RoutineCompletionWarning) => void;
+
+const habitWarningListeners = new Set<HabitWarningListener>();
+const routineWarningListeners = new Set<RoutineWarningListener>();
+
+export function subscribeHabitCompletionWarnings(
+  listener: HabitWarningListener,
+): () => void {
+  habitWarningListeners.add(listener);
+  return () => {
+    habitWarningListeners.delete(listener);
+  };
+}
+
+export function subscribeRoutineCompletionWarnings(
+  listener: RoutineWarningListener,
+): () => void {
+  routineWarningListeners.add(listener);
+  return () => {
+    routineWarningListeners.delete(listener);
+  };
+}
+
+function emitHabitWarning(warning: HabitCompletionWarning): void {
+  for (const l of habitWarningListeners) l(warning);
+}
+
+function emitRoutineWarning(warning: RoutineCompletionWarning): void {
+  for (const l of routineWarningListeners) l(warning);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP plumbing
+// ---------------------------------------------------------------------------
+
+async function postHabitCompletion(
+  pairing: Pairing,
+  entry: HabitCompletionEntry,
+): Promise<Response> {
+  const base = pairing.url.replace(/\/$/, '');
+  return await fetch(`${base}/api/habits/${entry.habit_id}/complete`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${pairing.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      completed_date: entry.completed_date,
+      notes: entry.notes,
+    }),
+  });
+}
+
+async function postRoutineCompletion(
+  pairing: Pairing,
+  entry: RoutineCompletionEntry,
+): Promise<Response> {
+  const base = pairing.url.replace(/\/$/, '');
+  return await fetch(`${base}/api/routines/${entry.routine_id}/complete`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${pairing.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      completed_date: entry.completed_date,
+      status: entry.status,
+      freeform_note: entry.freeform_note,
+    }),
+  });
+}
+
+async function bodyContainsPaused(response: Response): Promise<boolean> {
+  try {
+    const cloned = response.clone();
+    const data = (await cloned.json()) as unknown;
+    if (data && typeof data === 'object' && 'detail' in data) {
+      const detail = (data as { detail: unknown }).detail;
+      return typeof detail === 'string' && detail.includes("paused");
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Habit queue
+// ---------------------------------------------------------------------------
+
+const habitQueue = createWriteQueue<HabitCompletionEntry>(
+  HABIT_COMPLETIONS_KEY,
+  {
+    shouldFlush: async () => (await loadPairing()) !== null,
+    flushOne: async (entry) => {
+      const pairing = await loadPairing();
+      if (!pairing) return { kind: 'stop' };
+
+      let response: Response;
+      try {
+        response = await postHabitCompletion(pairing, entry);
+      } catch {
+        return { kind: 'stop' };
+      }
+
+      if (response.status === 200 || response.status === 201) {
+        return { kind: 'remove' };
+      }
+      if (response.status === 400) {
+        const paused = await bodyContainsPaused(response);
+        if (paused) {
+          emitHabitWarning({ kind: 'paused', habit_id: entry.habit_id });
+          return { kind: 'discard' };
+        }
+        // Other 400s: malformed payload, etc. Drop to avoid a poison-pill loop
+        // and log; the entry is otherwise unrecoverable on retry.
+        console.warn(
+          `[habitCompletions] dropping ${entry.habit_id}: 400 with non-paused detail`,
+        );
+        return { kind: 'discard' };
+      }
+      if (response.status === 404) {
+        console.warn(
+          `[habitCompletions] dropping ${entry.habit_id}: habit not found (404)`,
+        );
+        emitHabitWarning({ kind: 'not_found', habit_id: entry.habit_id });
+        return { kind: 'discard' };
+      }
+      return { kind: 'stop' };
+    },
+  },
+);
+
+export async function enqueueHabitCompletion(
+  entry: HabitCompletionEntry,
+): Promise<void> {
+  await habitQueue.enqueue(entry);
+}
+
+// ---------------------------------------------------------------------------
+// Routine queue
+// ---------------------------------------------------------------------------
+
+const routineQueue = createWriteQueue<RoutineCompletionEntry>(
+  ROUTINE_COMPLETIONS_KEY,
+  {
+    shouldFlush: async () => (await loadPairing()) !== null,
+    flushOne: async (entry) => {
+      const pairing = await loadPairing();
+      if (!pairing) return { kind: 'stop' };
+
+      let response: Response;
+      try {
+        response = await postRoutineCompletion(pairing, entry);
+      } catch {
+        return { kind: 'stop' };
+      }
+
+      if (response.status === 200 || response.status === 201) {
+        return { kind: 'remove' };
+      }
+      if (response.status === 404) {
+        console.warn(
+          `[routineCompletions] dropping ${entry.routine_id}: routine not found (404)`,
+        );
+        emitRoutineWarning({
+          kind: 'not_found',
+          routine_id: entry.routine_id,
+          status: entry.status,
+        });
+        return { kind: 'discard' };
+      }
+      if (response.status === 409) {
+        // Server returns 409 for non-active routines. Mirror habit's 400-paused
+        // pattern: log + warn + drop so the queue does not stall on a routine
+        // that was paused or archived after the entry was enqueued.
+        console.warn(
+          `[routineCompletions] dropping ${entry.routine_id}: routine not active (409)`,
+        );
+        emitRoutineWarning({
+          kind: 'not_active',
+          routine_id: entry.routine_id,
+          status: entry.status,
+        });
+        return { kind: 'discard' };
+      }
+      return { kind: 'stop' };
+    },
+  },
+);
+
+/**
+ * Append a routine completion entry. When `status === 'partial'`, each
+ * `child_habit_completions[i]` is pre-enqueued into the habit queue first so
+ * that flush order delivers child habits before the parent routine's
+ * streak-event POST. Cross-queue ordering matters for the user-visible state:
+ * a partial routine surfacing before its child habits would briefly show the
+ * routine as completed-with-no-children-completed.
+ */
+export async function enqueueRoutineCompletion(
+  entry: RoutineCompletionEntry,
+): Promise<void> {
+  if (entry.status === 'partial' && entry.child_habit_completions) {
+    for (const child of entry.child_habit_completions) {
+      await habitQueue.enqueue({
+        habit_id: child.habit_id,
+        completed_date: child.completed_date,
+        notes: null,
+        enqueued_at: entry.enqueued_at,
+      });
+    }
+  }
+  await routineQueue.enqueue(entry);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-queue flush
+// ---------------------------------------------------------------------------
+
+export interface AllQueuesFlushSummary {
+  notifications: FlushSummary;
+  habitCompletions: QueueFlushSummary;
+  routineCompletions: QueueFlushSummary;
+}
+
+/**
+ * Flush all three queues in fixed order: notifications → habits → routines.
+ * Order is observable when the network is partially up: a 5xx halts the
+ * notification queue but the habit and routine queues run independently and
+ * may still drain. Use this for UI-triggered flushes (after a manual
+ * enqueue); per-queue background triggers (`initCompletionQueues`,
+ * `initWriteQueue`) call their own queue's flush directly.
+ */
+export async function flushAllQueues(): Promise<AllQueuesFlushSummary> {
+  const notifications = await flushWriteQueue();
+  const habitCompletions = await habitQueue.flush();
+  const routineCompletions = await routineQueue.flush();
+  return { notifications, habitCompletions, routineCompletions };
+}
+
+// ---------------------------------------------------------------------------
+// Trigger wiring
+// ---------------------------------------------------------------------------
+
+let initialised = false;
+
+/**
+ * Wire flush triggers for the habit and routine completion queues. Mounts in
+ * parallel with `initWriteQueue` (which owns the [2C-07] notification queue's
+ * triggers). Both react to app foreground and the `online` event, but they
+ * stay in separate inits because the FCM-token gate and the native bridge
+ * event are notification-specific concerns. Manual flushes from UI surfaces
+ * call {@link flushAllQueues} directly.
+ *
+ * Returns a teardown for tests and lifecycle cleanup. Idempotent — repeat
+ * calls no-op until the returned cleanup runs.
+ */
+export function initCompletionQueues(): () => void {
+  if (initialised) return () => undefined;
+  initialised = true;
+
+  const cleanups: Array<() => void> = [];
+  const safeFlushHabit = (): void => {
+    void habitQueue.flush();
+  };
+  const safeFlushRoutine = (): void => {
+    void routineQueue.flush();
+  };
+  const safeFlushBoth = (): void => {
+    safeFlushHabit();
+    safeFlushRoutine();
+  };
+
+  // Initial drain on mount.
+  safeFlushBoth();
+
+  if (Capacitor.isNativePlatform()) {
+    const handlePromise = App.addListener(
+      'appStateChange',
+      ({ isActive }) => {
+        if (isActive) safeFlushBoth();
+      },
+    );
+    cleanups.push(() => {
+      void handlePromise.then((handle) => handle.remove());
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    const onlineHandler = (): void => safeFlushBoth();
+    window.addEventListener('online', onlineHandler);
+    cleanups.push(() => window.removeEventListener('online', onlineHandler));
+  }
+
+  return () => {
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    initialised = false;
+  };
+}
+
+export function __resetForTests(): void {
+  habitWarningListeners.clear();
+  routineWarningListeners.clear();
+  initialised = false;
+}

--- a/src/lib/writeQueue.test.ts
+++ b/src/lib/writeQueue.test.ts
@@ -40,6 +40,7 @@ import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
 import { REGISTERED_TOKEN_KEY } from './device-registration';
 import {
   __resetForTests,
+  createWriteQueue,
   enqueueResponse,
   flushWriteQueue,
   QUEUE_SOFT_CAP,
@@ -48,6 +49,14 @@ import {
   type ConflictWarning,
   type WriteQueueEntry,
 } from './writeQueue';
+import {
+  __resetForTests as __resetCompletionForTests,
+  flushAllQueues,
+  HABIT_COMPLETIONS_KEY,
+  ROUTINE_COMPLETIONS_KEY,
+  type HabitCompletionEntry,
+  type RoutineCompletionEntry,
+} from './completionQueues';
 
 const PAIRING_URL = 'https://brain.local:8000';
 const PAIRING_TOKEN = 'bearer-abc-123';
@@ -82,6 +91,7 @@ async function readQueue(): Promise<WriteQueueEntry[]> {
 
 beforeEach(() => {
   __resetForTests();
+  __resetCompletionForTests();
   prefsStore.clear();
   vi.mocked(Preferences.get).mockReset();
   vi.mocked(Preferences.set).mockReset();
@@ -364,5 +374,283 @@ describe('flushWriteQueue — 409 conflict', () => {
     expect(summary.conflicts).toBe(1);
     expect(summary.remaining).toBe(0);
     expect(warnings).toEqual([]);
+  });
+
+  it('coalesced concurrent flushes return zero conflicts even mid-flight', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'a' }),
+        entry({ notification_id: 'b' }),
+      ]),
+    );
+    let resolveFirst: (value: Response) => void = () => undefined;
+    const firstResponse = new Promise<Response>((r) => {
+      resolveFirst = r;
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(async () => firstResponse)
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const flushA = flushWriteQueue();
+    // While A is awaiting the first POST, kick off B; B should see flushing=true
+    // and short-circuit with all-zero counters (including conflicts).
+    const flushB = flushWriteQueue();
+
+    resolveFirst(new Response(null, { status: 200 }));
+    const [summaryA, summaryB] = await Promise.all([flushA, flushB]);
+
+    expect(summaryB).toEqual({
+      attempted: 0,
+      delivered: 0,
+      conflicts: 0,
+      remaining: expect.any(Number),
+    });
+    expect(summaryA.delivered).toBe(2);
+    expect(summaryA.conflicts).toBe(0);
+  });
+});
+
+describe('createWriteQueue — generic factory', () => {
+  const KEY = 'brain.test.factoryQueue';
+  type FactoryEntry = { id: string; payload: number };
+
+  function makeEntry(overrides: Partial<FactoryEntry> = {}): FactoryEntry {
+    return { id: 'e-1', payload: 1, ...overrides };
+  }
+
+  it('persists enqueued entries to the configured key in JSON-array form', async () => {
+    const adapter = {
+      flushOne: vi.fn(async () => ({ kind: 'remove' as const })),
+    };
+    const queue = createWriteQueue<FactoryEntry>(KEY, adapter);
+
+    await queue.enqueue(makeEntry({ id: 'a' }));
+    await queue.enqueue(makeEntry({ id: 'b' }));
+
+    expect(prefsStore.get(KEY)).toBe(
+      JSON.stringify([
+        { id: 'a', payload: 1 },
+        { id: 'b', payload: 1 },
+      ]),
+    );
+    const peeked = await queue.peek();
+    expect(peeked.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  it('drains entries in enqueue order on flush, removing each on remove outcome', async () => {
+    const seen: string[] = [];
+    const adapter = {
+      flushOne: vi.fn(async (entry: FactoryEntry) => {
+        seen.push(entry.id);
+        return { kind: 'remove' as const };
+      }),
+    };
+    const queue = createWriteQueue<FactoryEntry>(KEY, adapter);
+    await queue.enqueue(makeEntry({ id: 'a' }));
+    await queue.enqueue(makeEntry({ id: 'b' }));
+    await queue.enqueue(makeEntry({ id: 'c' }));
+
+    const summary = await queue.flush();
+
+    expect(seen).toEqual(['a', 'b', 'c']);
+    expect(summary).toEqual({
+      attempted: 3,
+      delivered: 3,
+      remaining: 0,
+      coalesced: false,
+    });
+    expect(await queue.peek()).toEqual([]);
+  });
+
+  it('halts on stop outcome and preserves enqueue order at the head', async () => {
+    let calls = 0;
+    const adapter = {
+      flushOne: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) return { kind: 'remove' as const };
+        return { kind: 'stop' as const };
+      }),
+    };
+    const queue = createWriteQueue<FactoryEntry>(KEY, adapter);
+    await queue.enqueue(makeEntry({ id: 'a' }));
+    await queue.enqueue(makeEntry({ id: 'b' }));
+    await queue.enqueue(makeEntry({ id: 'c' }));
+
+    const summary = await queue.flush();
+
+    expect(summary.attempted).toBe(2);
+    expect(summary.delivered).toBe(1);
+    expect(summary.remaining).toBe(2);
+    const remaining = await queue.peek();
+    expect(remaining.map((e) => e.id)).toEqual(['b', 'c']);
+  });
+
+  it('no-ops when shouldFlush returns false', async () => {
+    const adapter = {
+      shouldFlush: vi.fn(async () => false),
+      flushOne: vi.fn(async () => ({ kind: 'remove' as const })),
+    };
+    const queue = createWriteQueue<FactoryEntry>(KEY, adapter);
+    await queue.enqueue(makeEntry({ id: 'a' }));
+
+    const summary = await queue.flush();
+
+    expect(adapter.flushOne).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      attempted: 0,
+      delivered: 0,
+      remaining: 1,
+      coalesced: false,
+    });
+  });
+
+  it('clear empties the persisted queue', async () => {
+    const queue = createWriteQueue<FactoryEntry>(KEY, {
+      flushOne: vi.fn(async () => ({ kind: 'remove' as const })),
+    });
+    await queue.enqueue(makeEntry({ id: 'a' }));
+    await queue.enqueue(makeEntry({ id: 'b' }));
+
+    await queue.clear();
+
+    expect(await queue.peek()).toEqual([]);
+  });
+
+  it('logs a soft-cap warning above QUEUE_SOFT_CAP without dropping entries', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const queue = createWriteQueue<FactoryEntry>(KEY, {
+      flushOne: vi.fn(async () => ({ kind: 'remove' as const })),
+    });
+    const seeded = Array.from({ length: QUEUE_SOFT_CAP }, (_, i) =>
+      makeEntry({ id: `seed-${i}` }),
+    );
+    prefsStore.set(KEY, JSON.stringify(seeded));
+
+    await queue.enqueue(makeEntry({ id: 'overflow' }));
+
+    expect((await queue.peek()).length).toBe(QUEUE_SOFT_CAP + 1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain('exceeds soft cap');
+  });
+
+  it('beforeFlush fires once per non-coalesced flush, after shouldFlush passes', async () => {
+    const order: string[] = [];
+    const adapter = {
+      shouldFlush: vi.fn(async () => {
+        order.push('shouldFlush');
+        return true;
+      }),
+      beforeFlush: vi.fn(() => {
+        order.push('beforeFlush');
+      }),
+      flushOne: vi.fn(async () => {
+        order.push('flushOne');
+        return { kind: 'remove' as const };
+      }),
+    };
+    const queue = createWriteQueue<FactoryEntry>(KEY, adapter);
+    await queue.enqueue(makeEntry({ id: 'a' }));
+    await queue.enqueue(makeEntry({ id: 'b' }));
+
+    await queue.flush();
+
+    expect(order).toEqual([
+      'shouldFlush',
+      'beforeFlush',
+      'flushOne',
+      'flushOne',
+    ]);
+  });
+});
+
+describe('flushAllQueues — cross-queue order', () => {
+  beforeEach(() => {
+    seedPairing();
+    seedRegistered();
+  });
+
+  function habitEntry(
+    overrides: Partial<HabitCompletionEntry> = {},
+  ): HabitCompletionEntry {
+    return {
+      habit_id: '11111111-1111-1111-1111-111111111111',
+      completed_date: '2026-05-02',
+      notes: null,
+      enqueued_at: '2026-05-02T10:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function routineEntry(
+    overrides: Partial<RoutineCompletionEntry> = {},
+  ): RoutineCompletionEntry {
+    return {
+      routine_id: '22222222-2222-2222-2222-222222222222',
+      completed_date: '2026-05-02',
+      status: 'all_done',
+      freeform_note: null,
+      child_habit_completions: null,
+      enqueued_at: '2026-05-02T10:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('flushes notifications first, then habit completions, then routine completions', async () => {
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify([entry({ notification_id: 'n-1' })]));
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([habitEntry({ habit_id: 'h-1' })]),
+    );
+    prefsStore.set(
+      ROUTINE_COMPLETIONS_KEY,
+      JSON.stringify([routineEntry({ routine_id: 'r-1' })]),
+    );
+
+    const order: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/notifications/')) order.push('notification');
+      else if (url.includes('/api/habits/')) order.push('habit');
+      else if (url.includes('/api/routines/')) order.push('routine');
+      return new Response(null, { status: 200 });
+    });
+
+    const summary = await flushAllQueues();
+
+    expect(order).toEqual(['notification', 'habit', 'routine']);
+    expect(summary.notifications.delivered).toBe(1);
+    expect(summary.habitCompletions.delivered).toBe(1);
+    expect(summary.routineCompletions.delivered).toBe(1);
+  });
+
+  it('a halt in the habit queue does not prevent the routine queue from flushing', async () => {
+    prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify([]));
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([habitEntry({ habit_id: 'h-1' })]),
+    );
+    prefsStore.set(
+      ROUTINE_COMPLETIONS_KEY,
+      JSON.stringify([routineEntry({ routine_id: 'r-1' })]),
+    );
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/habits/')) {
+        throw new Error('habit network down');
+      }
+      if (url.includes('/api/routines/')) {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(null, { status: 200 });
+    });
+
+    const summary = await flushAllQueues();
+
+    expect(summary.habitCompletions.delivered).toBe(0);
+    expect(summary.habitCompletions.remaining).toBe(1);
+    expect(summary.routineCompletions.delivered).toBe(1);
+    expect(summary.routineCompletions.remaining).toBe(0);
   });
 });

--- a/src/lib/writeQueue.ts
+++ b/src/lib/writeQueue.ts
@@ -1,24 +1,23 @@
 /**
- * Canned-response offline queue for [2C-07].
+ * Generic offline write-queue factory and the [2C-07] canned-response queue
+ * built on top of it.
  *
- * The native [CannedResponseReceiver] persists each tapped response to
- * `brain.writeQueue` in `@capacitor/preferences` storage and (when the
- * WebView is alive) fires a `brainCannedResponse` window event. This module
- * owns the HTTP POST to BRAIN, the in-order flush, and the failure-handling
- * contract:
+ * The factory ({@link createWriteQueue}) extracts the queue primitive that
+ * [2C-07] introduced — `@capacitor/preferences`-backed JSON array, in-order
+ * flush, halt-on-failure, soft cap warning — into a generic helper reusable
+ * for habit and routine completion writes ([2C-23]) and any future write
+ * pipeline that needs the same offline-first shape.
  *
- * - 200 / 201 → entry removed.
- * - 409 → drop entry. If the server returned a different existing response
- *   ([2C-03]'s "legitimate conflict" branch), surface a {@link ConflictWarning}
- *   to subscribers. Same-response idempotency is a server-side 200 per
- *   [2C-03], so a 409 here always indicates a different existing response.
- * - Any other failure (5xx, network, timeout) → entry stays at the head of
- *   the queue, flush stops to preserve enqueue order.
+ * The `[2C-07]` notification-response queue is preserved as a concrete
+ * instance of the factory: the `brain.writeQueue` Preferences key, the
+ * `WriteQueueEntry` shape, the 200/201/409/error flush semantics, conflict
+ * warning emission, and the `initWriteQueue` trigger wiring all behave
+ * identically to the pre-refactor module. Callers of `enqueueResponse`,
+ * `flushWriteQueue`, `subscribeConflicts`, and `initWriteQueue` see no
+ * observable change.
  *
- * Flush is gated on both an active pairing (URL + bearer token from
- * `pairing.ts`) and a registered FCM token (`brain.deviceRegisteredToken`
- * from [2C-08]). When either is missing, queued entries wait until both are
- * present — registration completion triggers a flush automatically.
+ * See {@link createWriteQueue} for the factory shape and
+ * {@link ./completionQueues} for habit/routine consumers.
  */
 
 import { App } from '@capacitor/app';
@@ -34,6 +33,152 @@ export const WRITE_QUEUE_KEY = 'brain.writeQueue';
 export const BRIDGE_EVENT_NAME = 'brainCannedResponse';
 export const QUEUE_SOFT_CAP = 500;
 
+// ---------------------------------------------------------------------------
+// Generic factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-entry flush outcome returned by an adapter's {@link WriteQueueAdapter.flushOne}.
+ *
+ * - `remove` — server delivered the entry (200/201, idempotent re-confirm).
+ *   The entry is dropped from the queue and counted as delivered.
+ * - `discard` — entry is unrecoverable (404 not-found, 4xx terminal-rejection)
+ *   and must be dropped to keep the queue moving. Flush continues, but the
+ *   entry is *not* counted as delivered. Adapters typically surface a warning
+ *   alongside a discard so the UI can flag what happened.
+ * - `stop` — transient failure (network, 5xx, timeout). The entry stays at
+ *   the head of the queue and the flush halts to preserve enqueue order.
+ */
+export type FlushOutcome =
+  | { kind: 'remove' }
+  | { kind: 'discard' }
+  | { kind: 'stop' };
+
+export interface WriteQueueAdapter<T> {
+  /**
+   * Process a single entry. Should be throw-free — wrap the network call so
+   * exceptions become `{ kind: 'stop' }`.
+   */
+  flushOne(entry: T): Promise<FlushOutcome>;
+  /**
+   * Optional pre-flush gate. Return `false` to no-op the flush (pairing
+   * missing, device not registered, etc.). Defaults to always-flush.
+   */
+  shouldFlush?(): Promise<boolean>;
+  /**
+   * Optional sync hook fired once per non-coalesced flush, after `shouldFlush`
+   * passes and before the first `flushOne`. Adapters use this to reset
+   * per-flush state (e.g., conflict counters). Coalesced flushes skip it.
+   */
+  beforeFlush?(): void;
+}
+
+export interface QueueFlushSummary {
+  attempted: number;
+  delivered: number;
+  remaining: number;
+  /**
+   * `true` when this call returned without doing work because another flush
+   * for the same queue was already in flight. Wrappers that aggregate
+   * adapter-side state (e.g., conflict counters) should ignore that state on
+   * coalesced calls — the in-flight flush owns the counter.
+   */
+  coalesced: boolean;
+}
+
+export interface WriteQueueInstance<T> {
+  enqueue(entry: T): Promise<void>;
+  peek(): Promise<T[]>;
+  flush(): Promise<QueueFlushSummary>;
+  clear(): Promise<void>;
+}
+
+/**
+ * Build a write queue persisted to `@capacitor/preferences` under `key` and
+ * flushed via `adapter`. Each instance owns its own concurrency guard — a
+ * second call to `flush()` while one is in flight returns immediately with a
+ * zero-attempt summary rather than racing the queue.
+ */
+export function createWriteQueue<T>(
+  key: string,
+  adapter: WriteQueueAdapter<T>,
+): WriteQueueInstance<T> {
+  let flushing = false;
+
+  async function load(): Promise<T[]> {
+    const { value } = await Preferences.get({ key });
+    if (!value) return [];
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? (parsed as T[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async function save(queue: T[]): Promise<void> {
+    await Preferences.set({ key, value: JSON.stringify(queue) });
+  }
+
+  async function enqueue(entry: T): Promise<void> {
+    const queue = await load();
+    queue.push(entry);
+    if (queue.length > QUEUE_SOFT_CAP) {
+      console.warn(
+        `[writeQueue:${key}] size ${queue.length} exceeds soft cap ${QUEUE_SOFT_CAP}`,
+      );
+    }
+    await save(queue);
+  }
+
+  async function flush(): Promise<QueueFlushSummary> {
+    if (flushing) {
+      const remaining = (await load()).length;
+      return { attempted: 0, delivered: 0, remaining, coalesced: true };
+    }
+    flushing = true;
+    try {
+      if (adapter.shouldFlush) {
+        const ok = await adapter.shouldFlush();
+        if (!ok) {
+          const remaining = (await load()).length;
+          return { attempted: 0, delivered: 0, remaining, coalesced: false };
+        }
+      }
+      adapter.beforeFlush?.();
+      let queue = await load();
+      let attempted = 0;
+      let delivered = 0;
+      while (queue.length > 0) {
+        const entry = queue[0]!;
+        attempted += 1;
+        const outcome = await adapter.flushOne(entry);
+        if (outcome.kind === 'stop') break;
+        queue = queue.slice(1);
+        await save(queue);
+        if (outcome.kind === 'remove') delivered += 1;
+      }
+      return { attempted, delivered, remaining: queue.length, coalesced: false };
+    } finally {
+      flushing = false;
+    }
+  }
+
+  async function clear(): Promise<void> {
+    await save([]);
+  }
+
+  async function peek(): Promise<T[]> {
+    return load();
+  }
+
+  return { enqueue, peek, flush, clear };
+}
+
+// ---------------------------------------------------------------------------
+// [2C-07] canned-response queue — concrete instance of the factory
+// ---------------------------------------------------------------------------
+
 export interface WriteQueueEntry {
   notification_id: string;
   response: string;
@@ -47,11 +192,17 @@ export interface ConflictWarning {
   server_response: string;
 }
 
+/**
+ * Public summary returned by {@link flushWriteQueue}. Preserves [2C-07]'s
+ * pre-refactor shape — `coalesced` is stripped by the wrapper since callers
+ * historically didn't see it. The `conflicts` count is tracked by the
+ * notification adapter via a closure-scoped counter.
+ */
 export interface FlushSummary {
   attempted: number;
   delivered: number;
-  conflicts: number;
   remaining: number;
+  conflicts: number;
 }
 
 type ConflictListener = (warning: ConflictWarning) => void;
@@ -69,35 +220,7 @@ function emitConflict(warning: ConflictWarning): void {
   for (const listener of conflictListeners) listener(warning);
 }
 
-async function loadQueue(): Promise<WriteQueueEntry[]> {
-  const { value } = await Preferences.get({ key: WRITE_QUEUE_KEY });
-  if (!value) return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? (parsed as WriteQueueEntry[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-async function saveQueue(queue: WriteQueueEntry[]): Promise<void> {
-  await Preferences.set({
-    key: WRITE_QUEUE_KEY,
-    value: JSON.stringify(queue),
-  });
-}
-
-export async function enqueueResponse(entry: WriteQueueEntry): Promise<void> {
-  const queue = await loadQueue();
-  queue.push(entry);
-  if (queue.length > QUEUE_SOFT_CAP) {
-    // Soft cap — log only. Spec says "do not drop" beyond cap.
-    console.warn(
-      `[writeQueue] size ${queue.length} exceeds soft cap ${QUEUE_SOFT_CAP}`,
-    );
-  }
-  await saveQueue(queue);
-}
+let pendingConflicts = 0;
 
 async function postResponse(
   pairing: Pairing,
@@ -120,70 +243,9 @@ async function postResponse(
   );
 }
 
-let flushing = false;
-
-/**
- * Drain the queue in enqueue order. Concurrent calls coalesce: a second call
- * while a flush is in flight returns immediately rather than racing the queue.
- */
-export async function flushWriteQueue(): Promise<FlushSummary> {
-  if (flushing) {
-    const remaining = (await loadQueue()).length;
-    return { attempted: 0, delivered: 0, conflicts: 0, remaining };
-  }
-  flushing = true;
-  try {
-    const pairing = await loadPairing();
-    const registered = await loadRegisteredToken();
-    if (!pairing || !registered) {
-      const remaining = (await loadQueue()).length;
-      return { attempted: 0, delivered: 0, conflicts: 0, remaining };
-    }
-
-    let queue = await loadQueue();
-    let attempted = 0;
-    let delivered = 0;
-    let conflicts = 0;
-    while (queue.length > 0) {
-      const entry = queue[0]!;
-      attempted += 1;
-      let response: Response;
-      try {
-        response = await postResponse(pairing, entry);
-      } catch {
-        // Network failure — leave entry at the head, stop flushing.
-        break;
-      }
-      if (response.status === 200 || response.status === 201) {
-        queue = queue.slice(1);
-        await saveQueue(queue);
-        delivered += 1;
-        continue;
-      }
-      if (response.status === 409) {
-        const serverResponse = await readConflictResponse(response);
-        if (serverResponse !== null && serverResponse !== entry.response) {
-          emitConflict({
-            notification_id: entry.notification_id,
-            attempted_response: entry.response,
-            server_response: serverResponse,
-          });
-        }
-        queue = queue.slice(1);
-        await saveQueue(queue);
-        conflicts += 1;
-        continue;
-      }
-      // Any other failure (5xx, etc.) — leave entry, stop.
-      break;
-    }
-    return { attempted, delivered, conflicts, remaining: queue.length };
-  } finally {
-    flushing = false;
-  }
-}
-
-async function readConflictResponse(response: Response): Promise<string | null> {
+async function readConflictResponse(
+  response: Response,
+): Promise<string | null> {
   try {
     const body = (await response.clone().json()) as unknown;
     if (
@@ -200,13 +262,79 @@ async function readConflictResponse(response: Response): Promise<string | null> 
   }
 }
 
+const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
+  shouldFlush: async () => {
+    const [pairing, registered] = await Promise.all([
+      loadPairing(),
+      loadRegisteredToken(),
+    ]);
+    return pairing !== null && registered !== null;
+  },
+  beforeFlush: () => {
+    pendingConflicts = 0;
+  },
+  flushOne: async (entry) => {
+    // shouldFlush already gated on pairing presence; reload here to re-resolve
+    // on the off-chance it cleared mid-flush.
+    const pairing = await loadPairing();
+    if (!pairing) return { kind: 'stop' };
+    let response: Response;
+    try {
+      response = await postResponse(pairing, entry);
+    } catch {
+      return { kind: 'stop' };
+    }
+    if (response.status === 200 || response.status === 201) {
+      return { kind: 'remove' };
+    }
+    if (response.status === 409) {
+      const serverResponse = await readConflictResponse(response);
+      if (serverResponse !== null && serverResponse !== entry.response) {
+        emitConflict({
+          notification_id: entry.notification_id,
+          attempted_response: entry.response,
+          server_response: serverResponse,
+        });
+      }
+      pendingConflicts += 1;
+      return { kind: 'discard' };
+    }
+    return { kind: 'stop' };
+  },
+});
+
+export async function enqueueResponse(entry: WriteQueueEntry): Promise<void> {
+  await notificationQueue.enqueue(entry);
+}
+
+/**
+ * Drain the [2C-07] notification-response queue. Concurrent calls coalesce.
+ */
+export async function flushWriteQueue(): Promise<FlushSummary> {
+  const { coalesced, ...rest } = await notificationQueue.flush();
+  // Coalesced calls did no work — pendingConflicts belongs to the in-flight
+  // flush, not this caller. Report 0 to keep the summary self-consistent
+  // (`attempted === 0`, `delivered === 0`, `conflicts === 0`).
+  const conflicts = coalesced ? 0 : pendingConflicts;
+  return { ...rest, conflicts };
+}
+
+// ---------------------------------------------------------------------------
+// Trigger wiring
+// ---------------------------------------------------------------------------
+
 let initialised = false;
 
 /**
- * Wire flush triggers: app foreground, browser `online`, native bridge event,
- * and device-registration completion. Idempotent — repeat calls no-op until
- * the returned cleanup runs. Returns a tear-down used by tests; production
- * code mounts this once for the lifetime of the app.
+ * Wire flush triggers for the [2C-07] notification-response queue: app
+ * foreground, browser `online`, native bridge event, and device-registration
+ * completion. Idempotent — repeat calls no-op until the returned cleanup
+ * runs. Production code mounts this once for the lifetime of the app.
+ *
+ * Habit and routine completion queues mount their own listeners via
+ * `initCompletionQueues` in `./completionQueues` — the two are independent
+ * because the FCM-token gate and the bridge event are notification-specific
+ * concerns that should not extend their reach into completion writes.
  */
 export function initWriteQueue(): () => void {
   if (initialised) return () => undefined;
@@ -264,6 +392,6 @@ export function initWriteQueue(): () => void {
 
 export function __resetForTests(): void {
   conflictListeners.clear();
-  flushing = false;
+  pendingConflicts = 0;
   initialised = false;
 }


### PR DESCRIPTION
Closes #17

## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npx vitest run` — ✅ Pass (95 passed across 9 files; 43 in writeQueue.test.ts + completionQueues.{habit,routine}.test.ts)
- `npx tsc --noEmit` — ✅ Pass (no type errors)
- `npm run android:build:debug` — ⚠️ Not run (agent dev env has no JDK + ANDROID_HOME). This is a TypeScript-only change with no `android/` modifications, so the gap is low-risk; the dev-release workflow on push will surface any compile-only failures.

Ran locally against develop HEAD at `c51cb02` immediately before opening this PR.

## Summary

Extracts the [2C-07] notification-response queue's primitive into a reusable `createWriteQueue<T>(key, adapter)` factory in `src/lib/writeQueue.ts`, then stands up two new queue instances in a new `src/lib/completionQueues.ts` module:

- `brain.writeQueue.habitCompletions` — POSTs `/api/habits/{id}/complete`. Server idempotency comes from the `(habit_id, completed_at)` unique constraint. Handles 200/201 (delivered), 400-paused (discard + paused warning), 400-other (discard + log), 404 (discard + not_found warning), 5xx + network (halt-and-retry).
- `brain.writeQueue.routineCompletions` — POSTs `/api/routines/{id}/complete`. Server idempotency comes from [2C-26]'s `uq_routine_completions_routine_date_status` constraint. Handles 200/201 (delivered), 404 (discard + warning), 409 not-active (discard + warning), 5xx + network (halt-and-retry).

[2C-07]'s observable behavior is preserved unchanged: same `brain.writeQueue` Preferences key, same `WriteQueueEntry` shape, same `FlushSummary` fields, same conflict warnings, same triggers (foreground, online, native bridge event, FCM registration completion).

`flushAllQueues()` drains in fixed order — notifications → habits → routines — for UI-triggered flushes. Per-queue background triggers stay split: `initWriteQueue` owns the notification queue's notification-specific triggers (FCM gate, bridge event); `initCompletionQueues` owns app-foreground + `online` for the two completion queues. `App.tsx` mounts both.

Partial routine completions pre-enqueue each `child_habit_completions[i]` into the habit queue *before* appending the routine entry, so flush order delivers child habits before the parent routine streak event.

## Changes

- `src/lib/writeQueue.ts` — refactored. Extracts `createWriteQueue<T>(key, adapter)` factory with `enqueue`, `peek`, `flush`, `clear`. Adapter contract: `flushOne(entry)` returns `{ kind: 'remove' | 'discard' | 'stop' }`; optional `shouldFlush()` gate; optional `beforeFlush()` per-flush state hook. The notification queue is now an instance of the factory; all public exports (`enqueueResponse`, `flushWriteQueue`, `subscribeConflicts`, `initWriteQueue`, `WRITE_QUEUE_KEY`, `BRIDGE_EVENT_NAME`, `QUEUE_SOFT_CAP`, `WriteQueueEntry`, `ConflictWarning`, `FlushSummary`) keep their pre-refactor shape.
- `src/lib/completionQueues.ts` — new. Habit + routine queue instances built on the factory. Exports `enqueueHabitCompletion`, `enqueueRoutineCompletion`, `flushAllQueues`, `subscribeHabitCompletionWarnings`, `subscribeRoutineCompletionWarnings`, `initCompletionQueues`, plus the entry types and warning union types.
- `src/App.tsx` — `WriteQueueRunner` now mounts `initCompletionQueues` alongside `initWriteQueue`.
- `src/lib/writeQueue.test.ts` — extended. All pre-existing [2C-07] tests preserved verbatim. Adds: `createWriteQueue — generic factory` (factory shape, in-order drain, halt-on-stop, shouldFlush gating, clear, soft-cap, beforeFlush ordering); `flushAllQueues — cross-queue order` (fixed ordering and per-queue independence); a coalesce-safety test on `flushWriteQueue` to confirm concurrent flushes don't leak conflict counts across callers.
- `src/lib/completionQueues.habit.test.ts` — new. Covers happy path (200/201 idempotent retry), terminal-drop paths (400 paused with warning, 404 not-found with warning), halt paths (network, 5xx), and gating (no-op when no pairing).
- `src/lib/completionQueues.routine.test.ts` — new. Covers all three statuses (`all_done`, `partial`, `skipped`), the `partial` child-habit pre-enqueue ordering (child habits POST before the parent routine), 200 idempotent retry, terminal-drops (404, 409 non-active), halt paths, and gating.

## How to Verify

1. `git checkout feat/2C-23-completion-write-queue && npm install` (no new deps were added).
2. `npm run lint` — clean.
3. `npx vitest run src/lib/writeQueue.test.ts src/lib/completionQueues.habit.test.ts src/lib/completionQueues.routine.test.ts` — 43 passing in the three relevant files.
4. `npx vitest run` — 95 passing across the full suite (no regressions in `device-registration.test.ts`, `pairing.test.ts`, `health.test.ts`, `local-date.test.ts`, `notifications.test.ts`, `App.test.tsx`).
5. `npx tsc --noEmit` — clean.

### Manual verification (preserved from issue body — requires L's device)

The issue body's Acceptance criteria includes an airplane-mode manual verification: *"complete 3 habits and 1 routine, re-enable network, foreground the app — all POSTs land, no duplicates on routine (per guard)."* I cannot self-test this — it requires a paired physical device with airplane-mode toggling. Flagging for L's review run.

The unit suite covers the deterministic equivalent: offline retention (network failure halts but preserves order), connectivity restore (second flush drains successfully), and idempotency (duplicate POSTs return 200 and the entry drops without inflating streaks).

## Deviations

1. **Test file naming + location.** Spec named `tests/unit/writeQueue.spec.ts`, `tests/unit/writeQueue.habit.spec.ts`, `tests/unit/writeQueue.routine.spec.ts`. Per brain3-companion CLAUDE.md test-co-location convention and the [2C-07] PR #41 D-1 precedent, new tests live at `src/lib/writeQueue.test.ts` (extended), `src/lib/completionQueues.habit.test.ts`, `src/lib/completionQueues.routine.test.ts`. The cross-queue order test sits in `writeQueue.test.ts` since it exercises the factory's per-queue independence as well as `flushAllQueues` coordination.
2. **Factory `discard` outcome added.** Spec described a single "remove from queue" semantics. To preserve [2C-07]'s `FlushSummary` shape — where 409 conflicts are counted in `conflicts`, not `delivered` — the factory needed a third outcome that drops the entry without incrementing the delivered counter. Added `{ kind: 'discard' }` distinct from `{ kind: 'remove' }`. Used by notification 409, habit 400-paused / 400-other / 404, and routine 404 / 409.
3. **Routine 409 non-active path.** Spec only enumerated 200/201 for the routine flusher and pointed at "Mirrors `[2C-07]` notification-response flush pattern." Server (per `app/routers/routines.py:165-166` on brain3 `develop`) returns 409 with `Cannot complete a non-active routine` when the routine was paused after enqueue. Mirroring habit's 400-paused pattern (discard + warning) prevents the queue from stalling on a permanently-rejected entry. If a strict spec read is preferred, this can be reverted to halt-and-retry, but the queue would loop indefinitely on a single bad entry.
4. **Routine 404 path.** Same shape — spec didn't enumerate; added by analogy with habit 404. Discard + `not_found` warning so the queue keeps moving.
5. **Habit 400 with non-paused detail.** Spec enumerated 400-paused only. Added a poison-pill safeguard: any other 400 (e.g., a malformed payload) discards with a console warning. Without this, a malformed entry would loop forever on retries.
6. **Init split (not unified).** Kept `initWriteQueue` (notifications) and added `initCompletionQueues` (habit + routine) as two separate inits mounted side-by-side in `App.tsx`. Notification-specific triggers — FCM-token gate, native `brainCannedResponse` bridge event, registration-completion handler — stay scoped to the notification queue. Per-queue background flush is independent per spec; `flushAllQueues` is the unified path for UI-triggered flushes after enqueue.
7. **First Consumer Instantiates** (org CLAUDE.md v6 §"First Consumer Instantiates"). New scaffolds introduced here whose only current consumer is this ticket: (a) the `subscribeHabitCompletionWarnings` / `subscribeRoutineCompletionWarnings` listener APIs — needed for the spec's "surface a toast" requirement on habit 400-paused, but no UI consumer exists until [2C-21] / [2C-22] / [2C-24] / [2C-25] land; (b) the generic `createWriteQueue<T>` factory — second consumer (habit + routine queues) materializes in this same PR. Flagging both per the convention.
8. **Pass 5 O-3 watch-item — queue shape preserved.** Per Group 3 brief §5 and the activation prompt's cardinal rule, the notification + completion queues stay as separate factory instances rather than consolidating into a single discriminated queue. No amendment to [2C-07]'s contract from inside Group 3.
9. **CLAUDE.md drift.** Repo `CLAUDE.md` is v2 (HEAD `c51cb02`); BRAIN canonical is v3 (`908baa66` v3, last updated 2026-05-01). v3 hedges Pre-PR Verification Gates item 1 to acknowledge the workflow `on:` block is still push-only until [2C-Gap-05] (#55) lands. Per directive `4ea28266`, agents flag, PO updates — not modified inline. For this PR's verification: the workflow is push-only, so no PR-trigger Android compile gate fires, but the change is TS-only with no `android/` modifications, so the gap doesn't surface a new risk.
10. **Pre-PR Android build gate skipped.** Agent dev env has no JDK + ANDROID_HOME. `npm run android:build:debug` not run (carry-forward from Group 2). Low-risk for this ticket — no `android/`, no Capacitor plugin add, no `npm run android:sync` needed.

## Test Results

```
$ npx vitest run
✓ src/lib/writeQueue.test.ts (22 tests)
✓ src/lib/completionQueues.routine.test.ts (13 tests)
✓ src/lib/completionQueues.habit.test.ts (8 tests)
✓ src/lib/device-registration.test.ts (13 tests)
✓ src/lib/pairing.test.ts (8 tests)
✓ src/lib/health.test.ts (7 tests)
✓ src/lib/local-date.test.ts (7 tests)
✓ src/lib/notifications.test.ts (16 tests)
✓ src/App.test.tsx (1 test)
Test Files  9 passed (9)
     Tests  95 passed (95)

$ npm run lint
(clean)

$ npx tsc --noEmit
(clean)
```

## Acceptance Checklist

- [x] `tests/unit/writeQueue.spec.ts` covers factory instantiation, enqueue order, flush remove on success, flush halt on failure, cross-queue flush order — coverage in `src/lib/writeQueue.test.ts` (co-located per CLAUDE.md, see Deviations §1).
- [x] `tests/unit/writeQueue.habit.spec.ts` covers habit flush 200, idempotent retry, 400 paused (entry removed + warning), 404 (entry removed + warn), offline (entry retained) — coverage in `src/lib/completionQueues.habit.test.ts`.
- [x] `tests/unit/writeQueue.routine.spec.ts` covers routine flush all three statuses, partial path with child-habit prerequisite ordering — coverage in `src/lib/completionQueues.routine.test.ts`.
- [ ] **Airplane-mode manual verification — requires L's device.** See Manual verification section above.
- [x] Existing [2C-07] notification-response flush continues to work unchanged. All 22 pre-existing tests in `writeQueue.test.ts` still pass; observable API preserved (`brain.writeQueue` key, `WriteQueueEntry` shape, `FlushSummary` fields, `ConflictWarning`, `initWriteQueue`).
