### PR TITLE
[2C-21] App: Habit list view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { IonReactRouter } from '@ionic/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
+import HabitsPage from './pages/HabitsPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -101,6 +102,9 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/notifications">
             <NotificationsPage />
+          </Route>
+          <Route exact path="/habits">
+            <HabitsPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/components/StatusPill.test.tsx
+++ b/src/components/StatusPill.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import StatusPill from './StatusPill';
+
+describe('StatusPill', () => {
+  it.each([
+    ['tracking', 'Tracking'],
+    ['accountable', 'Accountable'],
+    ['graduated', 'Graduated'],
+  ] as const)('renders %s pill with display label %s', (status, label) => {
+    render(<StatusPill status={status} />);
+    expect(screen.getByTestId(`status-pill-${status}`)).toHaveTextContent(label);
+  });
+
+  it('applies a distinct ring/background for each status', () => {
+    const { rerender } = render(<StatusPill status="tracking" />);
+    expect(screen.getByTestId('status-pill-tracking').className).toMatch(
+      /emerald/,
+    );
+
+    rerender(<StatusPill status="accountable" />);
+    expect(screen.getByTestId('status-pill-accountable').className).toMatch(
+      /amber/,
+    );
+
+    rerender(<StatusPill status="graduated" />);
+    expect(screen.getByTestId('status-pill-graduated').className).toMatch(
+      /neutral/,
+    );
+  });
+});

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,0 +1,37 @@
+import type { ScaffoldingStatus } from '../lib/habits';
+
+const PILL_COPY: Record<ScaffoldingStatus, string> = {
+  tracking: 'Tracking',
+  accountable: 'Accountable',
+  graduated: 'Graduated',
+};
+
+const PILL_CLASSES: Record<ScaffoldingStatus, string> = {
+  tracking: 'bg-emerald-100 text-emerald-800 ring-emerald-200',
+  accountable: 'bg-amber-100 text-amber-800 ring-amber-200',
+  graduated: 'bg-neutral-100 text-neutral-700 ring-neutral-300',
+};
+
+interface Props {
+  status: ScaffoldingStatus;
+}
+
+/**
+ * Scaffolding-status pill for habit list/detail rows. Color encoding follows
+ * spec [2C-21] §Scope: green Tracking · amber Accountable · gray Graduated.
+ *
+ * First-consumer-instantiates: introduced by [2C-21] for shared reuse with
+ * [2C-22] habit detail and (eventually) [2C-16] rules list. The "[2C-16]
+ * pattern" referenced by the spec does not yet exist in the repo at the
+ * time of this commit — see PR body.
+ */
+const StatusPill: React.FC<Props> = ({ status }) => (
+  <span
+    data-testid={`status-pill-${status}`}
+    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${PILL_CLASSES[status]}`}
+  >
+    {PILL_COPY[status]}
+  </span>
+);
+
+export default StatusPill;

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  HABITS_CACHE_KEY,
+  HABITS_PATH,
+  fetchActiveHabits,
+  partitionAndSortHabits,
+  readCachedHabits,
+  writeCachedHabits,
+  type HabitResponse,
+} from './habits';
+
+const PAIRING = {
+  url: 'https://brain.local:8000',
+  token: 'bearer-xyz',
+} as const;
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeHabit(overrides: Partial<HabitResponse> = {}): HabitResponse {
+  return {
+    id: overrides.id ?? 'h-1',
+    routine_id: overrides.routine_id ?? null,
+    title: overrides.title ?? 'Take meds',
+    description: overrides.description ?? null,
+    status: overrides.status ?? 'active',
+    frequency: overrides.frequency ?? 'daily',
+    notification_frequency: overrides.notification_frequency ?? 'daily',
+    scaffolding_status: overrides.scaffolding_status ?? 'tracking',
+    accountable_since: overrides.accountable_since ?? null,
+    graduation_window: overrides.graduation_window ?? null,
+    graduation_target: overrides.graduation_target ?? null,
+    graduation_threshold: overrides.graduation_threshold ?? null,
+    friction_score: overrides.friction_score ?? null,
+    position: overrides.position ?? null,
+    re_scaffold_count: overrides.re_scaffold_count ?? 0,
+    last_frequency_changed_at: overrides.last_frequency_changed_at ?? null,
+    graduated_at: overrides.graduated_at ?? null,
+    current_streak: overrides.current_streak ?? 0,
+    best_streak: overrides.best_streak ?? 0,
+    last_completed: overrides.last_completed ?? null,
+    created_at: overrides.created_at ?? '2026-04-01T12:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-04-01T12:00:00Z',
+    effective_graduation_params: overrides.effective_graduation_params ?? {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+  };
+}
+
+describe('fetchActiveHabits — server contract', () => {
+  it('GETs /api/habits/?status=active with bearer auth', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+    );
+
+    const result = await fetchActiveHabits(PAIRING);
+
+    expect(result).toEqual({ ok: true, items: [] });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(
+      `${PAIRING.url}${HABITS_PATH}?status=active`,
+    );
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${PAIRING.token}`);
+    expect(init?.method).toBe('GET');
+  });
+
+  it('parses HabitListResponse items array', async () => {
+    const habit = makeHabit({ id: 'h-42', title: 'Meditate' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [habit], count: 1 }), { status: 200 }),
+    );
+
+    const result = await fetchActiveHabits(PAIRING);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe('h-42');
+    }
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 401 }),
+    );
+    const result = await fetchActiveHabits(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'unauthorized', statusCode: 401 });
+  });
+
+  it('returns server error for non-200/401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 500 }),
+    );
+    const result = await fetchActiveHabits(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'server', statusCode: 500 });
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'));
+    const result = await fetchActiveHabits(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+
+  it('strips trailing slash from server url', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+    );
+    await fetchActiveHabits({ url: 'https://brain.local:8000/', token: 't' });
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(
+      `https://brain.local:8000${HABITS_PATH}?status=active`,
+    );
+  });
+});
+
+describe('readCachedHabits / writeCachedHabits', () => {
+  it('round-trips through Preferences with the configured cache key', async () => {
+    const habit = makeHabit({ id: 'h-1' });
+    const now = new Date('2026-05-02T12:00:00Z');
+
+    await writeCachedHabits([habit], now);
+    const cached = await readCachedHabits();
+
+    expect(cached).not.toBeNull();
+    expect(cached?.fetched_at).toBe(now.toISOString());
+    expect(cached?.items).toEqual([habit]);
+    expect(prefsStore.has(HABITS_CACHE_KEY)).toBe(true);
+  });
+
+  it('returns null when no cache exists', async () => {
+    expect(await readCachedHabits()).toBeNull();
+  });
+
+  it('returns null on malformed cache JSON', async () => {
+    prefsStore.set(HABITS_CACHE_KEY, '{ not json');
+    expect(await readCachedHabits()).toBeNull();
+  });
+
+  it('returns null when cache is missing required keys', async () => {
+    prefsStore.set(HABITS_CACHE_KEY, JSON.stringify({ items: [] }));
+    expect(await readCachedHabits()).toBeNull();
+  });
+});
+
+describe('partitionAndSortHabits — sort contract', () => {
+  it('splits graduated from primary by scaffolding_status', () => {
+    const tracking = makeHabit({ id: 't', scaffolding_status: 'tracking' });
+    const accountable = makeHabit({
+      id: 'a',
+      scaffolding_status: 'accountable',
+    });
+    const graduated = makeHabit({
+      id: 'g',
+      scaffolding_status: 'graduated',
+      graduated_at: '2026-04-01T00:00:00Z',
+    });
+
+    const result = partitionAndSortHabits([graduated, tracking, accountable]);
+
+    expect(result.primary.map((h) => h.id).sort()).toEqual(['a', 't']);
+    expect(result.graduated.map((h) => h.id)).toEqual(['g']);
+  });
+
+  it('sorts primary by current_streak DESC, then last_completed DESC nulls last, then title ASC', () => {
+    const items = [
+      makeHabit({
+        id: 'low-streak-recent',
+        title: 'Z low streak recent',
+        current_streak: 1,
+        last_completed: '2026-05-01',
+      }),
+      makeHabit({
+        id: 'high-streak',
+        title: 'M high streak',
+        current_streak: 10,
+        last_completed: '2026-04-30',
+      }),
+      makeHabit({
+        id: 'mid-streak-no-last',
+        title: 'A mid streak no last',
+        current_streak: 5,
+        last_completed: null,
+      }),
+      makeHabit({
+        id: 'mid-streak-with-last',
+        title: 'B mid streak with last',
+        current_streak: 5,
+        last_completed: '2026-04-29',
+      }),
+      makeHabit({
+        id: 'mid-streak-tied',
+        title: 'A mid streak tied',
+        current_streak: 5,
+        last_completed: '2026-04-29',
+      }),
+    ];
+
+    const result = partitionAndSortHabits(items);
+    const ids = result.primary.map((h) => h.id);
+
+    expect(ids[0]).toBe('high-streak');
+    expect(ids[1]).toBe('mid-streak-tied');
+    expect(ids[2]).toBe('mid-streak-with-last');
+    expect(ids[3]).toBe('mid-streak-no-last');
+    expect(ids[4]).toBe('low-streak-recent');
+  });
+
+  it('sorts graduated section by graduated_at DESC', () => {
+    const newer = makeHabit({
+      id: 'newer',
+      scaffolding_status: 'graduated',
+      graduated_at: '2026-04-15T00:00:00Z',
+    });
+    const older = makeHabit({
+      id: 'older',
+      scaffolding_status: 'graduated',
+      graduated_at: '2026-03-01T00:00:00Z',
+    });
+    const middle = makeHabit({
+      id: 'middle',
+      scaffolding_status: 'graduated',
+      graduated_at: '2026-04-01T00:00:00Z',
+    });
+
+    const result = partitionAndSortHabits([older, newer, middle]);
+    expect(result.graduated.map((h) => h.id)).toEqual([
+      'newer',
+      'middle',
+      'older',
+    ]);
+  });
+});

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -1,0 +1,210 @@
+/**
+ * Habits data layer for [2C-21] habit list view.
+ *
+ * Fetches `/api/habits/?status=active` with bearer auth and exposes the
+ * Capacitor Preferences cache that backs the offline-launch fallback. The
+ * cache pattern mirrors `[2C-09]` notifications.ts: a JSON blob under a
+ * `brain.cache.*` key, with `fetched_at` provenance for "Showing cached data"
+ * surfacing.
+ *
+ * Type shape mirrors `app/schemas/habits.py:111-159` (HabitResponse) on the
+ * brain3 server, including the `effective_graduation_params` computed field
+ * that `[2C-22]` consumes from the same cache without re-fetching.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { Pairing } from './pairing';
+
+export const HABITS_CACHE_KEY = 'brain.cache.habits.active';
+export const HABITS_PATH = '/api/habits/';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export type HabitStatus = 'active' | 'paused' | 'graduated' | 'abandoned';
+export type ScaffoldingStatus = 'tracking' | 'accountable' | 'graduated';
+export type HabitFrequency =
+  | 'daily'
+  | 'weekdays'
+  | 'weekends'
+  | 'weekly'
+  | 'custom';
+
+export interface EffectiveGraduationParams {
+  window_days: number;
+  target_rate: number;
+  threshold_days: number;
+  source: 'override' | 'friction_default';
+}
+
+export interface HabitResponse {
+  id: string;
+  routine_id: string | null;
+  title: string;
+  description: string | null;
+  status: HabitStatus;
+  frequency: HabitFrequency | null;
+  notification_frequency: string;
+  scaffolding_status: ScaffoldingStatus;
+  accountable_since: string | null;
+  graduation_window: number | null;
+  graduation_target: number | null;
+  graduation_threshold: number | null;
+  friction_score: number | null;
+  position: number | null;
+  re_scaffold_count: number;
+  last_frequency_changed_at: string | null;
+  graduated_at: string | null;
+  current_streak: number;
+  best_streak: number;
+  /** YYYY-MM-DD device-local calendar date, or null if never completed. */
+  last_completed: string | null;
+  created_at: string;
+  updated_at: string;
+  effective_graduation_params: EffectiveGraduationParams;
+}
+
+interface HabitListResponseBody {
+  items: HabitResponse[];
+  count: number;
+}
+
+export type FetchHabitsResult =
+  | { ok: true; items: HabitResponse[] }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout';
+      statusCode?: number;
+    };
+
+export async function fetchActiveHabits(
+  pairing: Pairing,
+): Promise<FetchHabitsResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${HABITS_PATH}?status=active`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as HabitListResponseBody).items)
+          ? (body as HabitListResponseBody).items
+          : [];
+      return { ok: true, items };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface CachedHabits {
+  fetched_at: string;
+  items: HabitResponse[];
+}
+
+export async function readCachedHabits(): Promise<CachedHabits | null> {
+  const { value } = await Preferences.get({ key: HABITS_CACHE_KEY });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'items' in parsed &&
+      'fetched_at' in parsed &&
+      Array.isArray((parsed as CachedHabits).items) &&
+      typeof (parsed as CachedHabits).fetched_at === 'string'
+    ) {
+      return parsed as CachedHabits;
+    }
+  } catch {
+    // Fall through — treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedHabits(
+  items: HabitResponse[],
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedHabits = {
+    fetched_at: now.toISOString(),
+    items,
+  };
+  await Preferences.set({
+    key: HABITS_CACHE_KEY,
+    value: JSON.stringify(payload),
+  });
+}
+
+export interface PartitionedHabits {
+  primary: HabitResponse[];
+  graduated: HabitResponse[];
+}
+
+/**
+ * Split active habits into primary + graduated sections and apply per-section
+ * sort per spec [2C-21]:
+ *
+ * - primary: `current_streak` DESC, then `last_completed` DESC nulls last,
+ *   then `title` ASC.
+ * - graduated: `graduated_at` DESC, with title fallback when both are null.
+ *
+ * Pure function — caller owns the input array.
+ */
+export function partitionAndSortHabits(
+  items: HabitResponse[],
+): PartitionedHabits {
+  const primary: HabitResponse[] = [];
+  const graduated: HabitResponse[] = [];
+  for (const habit of items) {
+    if (habit.scaffolding_status === 'graduated') {
+      graduated.push(habit);
+    } else {
+      primary.push(habit);
+    }
+  }
+
+  primary.sort((a, b) => {
+    if (b.current_streak !== a.current_streak) {
+      return b.current_streak - a.current_streak;
+    }
+    if (a.last_completed === null && b.last_completed !== null) return 1;
+    if (b.last_completed === null && a.last_completed !== null) return -1;
+    if (a.last_completed !== null && b.last_completed !== null) {
+      const cmp = b.last_completed.localeCompare(a.last_completed);
+      if (cmp !== 0) return cmp;
+    }
+    return a.title.localeCompare(b.title);
+  });
+
+  graduated.sort((a, b) => {
+    if (a.graduated_at === null && b.graduated_at !== null) return 1;
+    if (b.graduated_at === null && a.graduated_at !== null) return -1;
+    if (a.graduated_at !== null && b.graduated_at !== null) {
+      const cmp = b.graduated_at.localeCompare(a.graduated_at);
+      if (cmp !== 0) return cmp;
+    }
+    return a.title.localeCompare(b.title);
+  });
+
+  return { primary, graduated };
+}

--- a/src/lib/routines.test.ts
+++ b/src/lib/routines.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ROUTINES_PATH, fetchRoutine } from './routines';
+
+const PAIRING = {
+  url: 'https://brain.local:8000',
+  token: 'bearer-routine',
+} as const;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchRoutine', () => {
+  it('GETs /api/routines/{id} with bearer auth and returns the routine', async () => {
+    const routine = { id: 'r-1', title: 'Morning kit' };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(routine), { status: 200 }),
+    );
+
+    const result = await fetchRoutine(PAIRING, 'r-1');
+
+    expect(result).toEqual({ ok: true, routine });
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(`${PAIRING.url}${ROUTINES_PATH}r-1`);
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${PAIRING.token}`);
+    expect(init?.method).toBe('GET');
+  });
+
+  it('returns not_found on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
+    const result = await fetchRoutine(PAIRING, 'missing');
+    expect(result).toEqual({ ok: false, reason: 'not_found', statusCode: 404 });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 401 }),
+    );
+    const result = await fetchRoutine(PAIRING, 'r-1');
+    expect(result).toEqual({ ok: false, reason: 'unauthorized', statusCode: 401 });
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('disconnected'));
+    const result = await fetchRoutine(PAIRING, 'r-1');
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+});

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -1,0 +1,73 @@
+/**
+ * Routines data layer for [2C-21] habit list view.
+ *
+ * Per-row routine-name resolution: each habit with a non-null `routine_id`
+ * fans out a `GET /api/routines/{routine_id}` query keyed by the routine id
+ * so TanStack Query deduplicates fetches across rows. Type shape follows
+ * `app/schemas/routines.py` RoutineResponse on the brain3 server. Only the
+ * fields [2C-21] consumes are typed — sibling tickets ([2C-22], [2C-24])
+ * extend this module as their views surface more fields.
+ *
+ * First-consumer-instantiates: this module is being introduced for the first
+ * time by [2C-21]. The fetcher shape mirrors `lib/habits.ts` so the two
+ * read-paths stay congruent for [2C-22] reuse.
+ */
+
+import type { Pairing } from './pairing';
+
+export const ROUTINES_PATH = '/api/routines/';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface RoutineResponse {
+  id: string;
+  title: string;
+  /**
+   * Additional fields exist server-side (domain_id, frequency, status,
+   * current_streak, etc.). Sibling tickets extend this interface as needed.
+   */
+}
+
+export type FetchRoutineResult =
+  | { ok: true; routine: RoutineResponse }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
+      statusCode?: number;
+    };
+
+export async function fetchRoutine(
+  pairing: Pairing,
+  routineId: string,
+): Promise<FetchRoutineResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${ROUTINES_PATH}${routineId}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as RoutineResponse;
+      return { ok: true, routine: body };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/pages/HabitsPage.test.tsx
+++ b/src/pages/HabitsPage.test.tsx
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: vi.fn(),
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+const { enqueueSpy, flushSpy } = vi.hoisted(() => ({
+  enqueueSpy: vi.fn(),
+  flushSpy: vi.fn(),
+}));
+
+vi.mock('../lib/completionQueues', () => ({
+  enqueueHabitCompletion: enqueueSpy,
+  flushAllQueues: flushSpy,
+}));
+
+vi.mock('../lib/local-date', async () => {
+  const actual = await vi.importActual<typeof import('../lib/local-date')>(
+    '../lib/local-date',
+  );
+  return {
+    ...actual,
+    todayLocalDate: () => '2026-05-02',
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { HABITS_CACHE_KEY, type HabitResponse } from '../lib/habits';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import HabitsPage from './HabitsPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+const successFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 1,
+    delivered: 1,
+    remaining: 0,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+};
+
+const stopFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 1,
+    delivered: 0,
+    remaining: 1,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+};
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+  enqueueSpy.mockReset().mockResolvedValue(undefined);
+  flushSpy.mockReset().mockResolvedValue(successFlush);
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function seedCache(items: HabitResponse[]): void {
+  prefsStore.set(
+    HABITS_CACHE_KEY,
+    JSON.stringify({ fetched_at: '2026-05-01T00:00:00Z', items }),
+  );
+}
+
+function makeHabit(overrides: Partial<HabitResponse> = {}): HabitResponse {
+  return {
+    id: overrides.id ?? 'h-1',
+    routine_id: overrides.routine_id ?? null,
+    title: overrides.title ?? 'Take meds',
+    description: null,
+    status: 'active',
+    frequency: overrides.frequency ?? 'daily',
+    notification_frequency: 'daily',
+    scaffolding_status: overrides.scaffolding_status ?? 'tracking',
+    accountable_since: null,
+    graduation_window: null,
+    graduation_target: null,
+    graduation_threshold: null,
+    friction_score: null,
+    position: null,
+    re_scaffold_count: 0,
+    last_frequency_changed_at: null,
+    graduated_at: overrides.graduated_at ?? null,
+    current_streak: overrides.current_streak ?? 3,
+    best_streak: overrides.best_streak ?? 7,
+    last_completed: overrides.last_completed ?? '2026-05-01',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    effective_graduation_params: {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+  };
+}
+
+interface FetchOptions {
+  habitsResponse?: { status: number; items?: HabitResponse[] };
+  habitsRejection?: Error;
+  routineByName?: Record<string, { id: string; title: string }>;
+}
+
+function stubFetch(opts: FetchOptions = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/habits/')) {
+        if (opts.habitsRejection) throw opts.habitsRejection;
+        const r = opts.habitsResponse ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          return new Response(
+            JSON.stringify({ items: r.items ?? [], count: (r.items ?? []).length }),
+            { status: 200 },
+          );
+        }
+        return new Response('', { status: r.status });
+      }
+      if (url.includes('/api/routines/')) {
+        const id = url.split('/api/routines/')[1] ?? '';
+        const map = opts.routineByName ?? {};
+        const found = map[id];
+        if (found) {
+          return new Response(JSON.stringify(found), { status: 200 });
+        }
+        return new Response('', { status: 404 });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/habits']}>
+        <HabitsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('HabitsPage — bootstrap states', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('HabitsPage — list render with mixed statuses', () => {
+  it('renders tracking, accountable, and graduated habits with status pills', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [
+          makeHabit({ id: 'h-track', title: 'Tracking habit', scaffolding_status: 'tracking', current_streak: 5 }),
+          makeHabit({ id: 'h-acct', title: 'Accountable habit', scaffolding_status: 'accountable', current_streak: 3 }),
+          makeHabit({
+            id: 'h-grad',
+            title: 'Graduated habit',
+            scaffolding_status: 'graduated',
+            graduated_at: '2026-04-15T00:00:00Z',
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Tracking habit')).toBeInTheDocument();
+    expect(screen.getByText('Accountable habit')).toBeInTheDocument();
+    expect(screen.getByText('Graduated habit')).toBeInTheDocument();
+
+    expect(screen.getByTestId('status-pill-tracking')).toBeInTheDocument();
+    expect(screen.getByTestId('status-pill-accountable')).toBeInTheDocument();
+    expect(screen.getByTestId('status-pill-graduated')).toBeInTheDocument();
+  });
+
+  it('renders the routine name when a habit is part of a routine', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [
+          makeHabit({
+            id: 'h-1',
+            title: 'Stretch',
+            routine_id: 'r-morning',
+          }),
+        ],
+      },
+      routineByName: { 'r-morning': { id: 'r-morning', title: 'Morning kit' } },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Stretch')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Part of: Morning kit/),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('HabitsPage — graduated section separation', () => {
+  it('shows a Graduated header with the graduated habits below', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [
+          makeHabit({ id: 'a', title: 'Active habit', scaffolding_status: 'tracking' }),
+          makeHabit({
+            id: 'g',
+            title: 'Old habit',
+            scaffolding_status: 'graduated',
+            graduated_at: '2026-04-01T00:00:00Z',
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const graduatedHeader = await screen.findByText('Graduated');
+    expect(graduatedHeader).toBeInTheDocument();
+
+    // Active habit row is in the primary list (no streak indicator hidden);
+    // graduated habit row carries the graduated pill.
+    expect(screen.getByTestId('habit-streak-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('habit-streak-g')).not.toBeInTheDocument();
+  });
+});
+
+describe('HabitsPage — empty state', () => {
+  it('shows the create-via-CLI message when there are no habits', async () => {
+    pair();
+    stubFetch({ habitsResponse: { status: 200, items: [] } });
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/no habits yet\. create habits via brain3/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('HabitsPage — quick-complete optimistic flip', () => {
+  it('increments the displayed streak when last_completed is not today', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [
+          makeHabit({
+            id: 'h-1',
+            title: 'Stretch',
+            current_streak: 4,
+            best_streak: 9,
+            last_completed: '2026-05-01', // yesterday relative to mocked today
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const streakLine = await screen.findByTestId('habit-streak-h-1');
+    expect(streakLine).toHaveTextContent('Streak: 4 · Best: 9');
+
+    // Stop flush so the optimistic boost survives the await — exercises the
+    // "row holds the +1 while queued" branch of the spec.
+    flushSpy.mockResolvedValueOnce(stopFlush);
+
+    const button = screen.getByTestId('habit-quick-complete-h-1');
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(streakLine).toHaveTextContent('Streak: 5 · Best: 9');
+    });
+    expect(enqueueSpy).toHaveBeenCalledWith({
+      habit_id: 'h-1',
+      completed_date: '2026-05-02',
+      notes: null,
+      enqueued_at: expect.any(String),
+    });
+  });
+
+  it('does not increment the displayed streak when last_completed is today', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [
+          makeHabit({
+            id: 'h-1',
+            title: 'Stretch',
+            current_streak: 4,
+            best_streak: 9,
+            last_completed: '2026-05-02', // today
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const streakLine = await screen.findByTestId('habit-streak-h-1');
+    expect(streakLine).toHaveTextContent('Streak: 4 · Best: 9');
+
+    flushSpy.mockResolvedValueOnce(stopFlush);
+    await userEvent.click(screen.getByTestId('habit-quick-complete-h-1'));
+
+    // Wait long enough for any state update to flush, then assert unchanged.
+    await waitFor(() => {
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(streakLine).toHaveTextContent('Streak: 4 · Best: 9');
+  });
+
+  it('navigates to the detail route when the row body is tapped (not the button)', async () => {
+    pair();
+    stubFetch({
+      habitsResponse: {
+        status: 200,
+        items: [makeHabit({ id: 'h-9', title: 'Walk' })],
+      },
+    });
+
+    renderPage();
+
+    const titleEl = await screen.findByText('Walk');
+    await userEvent.click(titleEl);
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith('/habits/h-9');
+    });
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('HabitsPage — offline cache render', () => {
+  it('renders cached items and the cache hint when the network fetch fails', async () => {
+    pair();
+    seedCache([
+      makeHabit({
+        id: 'h-cache',
+        title: 'Cached habit',
+        scaffolding_status: 'tracking',
+        current_streak: 2,
+        best_streak: 6,
+      }),
+    ]);
+    stubFetch({ habitsRejection: new Error('offline') });
+
+    renderPage();
+
+    // Cached item paints immediately from initialData.
+    expect(await screen.findByText('Cached habit')).toBeInTheDocument();
+
+    // The fetch failure surfaces the cache hint.
+    expect(
+      await screen.findByText(/showing cached data/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/HabitsPage.tsx
+++ b/src/pages/HabitsPage.tsx
@@ -1,0 +1,419 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonButton,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import { checkmarkCircle, checkmarkOutline } from 'ionicons/icons';
+import {
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { useHistory } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import StatusPill from '../components/StatusPill';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchActiveHabits,
+  partitionAndSortHabits,
+  readCachedHabits,
+  writeCachedHabits,
+  type HabitResponse,
+} from '../lib/habits';
+import { fetchRoutine, type RoutineResponse } from '../lib/routines';
+import {
+  enqueueHabitCompletion,
+  flushAllQueues,
+} from '../lib/completionQueues';
+import { todayLocalDate } from '../lib/local-date';
+
+const HABITS_QUERY_KEY: QueryKey = ['habits', 'active'];
+const ROUTINE_QUERY_KEY = (id: string): QueryKey => ['routine', id];
+const HABITS_STALE_MS = 5 * 60 * 1000;
+const ROUTINES_STALE_MS = 15 * 60 * 1000;
+const PULSE_MS = 2000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedItems: HabitResponse[] | null;
+      /**
+       * Epoch ms of the cache's `fetched_at`, threaded into TanStack Query as
+       * `initialDataUpdatedAt`. Without this, initialData is treated as just
+       * loaded and the on-mount refetch that hydrates the offline cache hint
+       * (and overwrites stale cache) never fires.
+       */
+      cachedFetchedAtMs: number | null;
+    };
+
+const HabitsPage: React.FC = () => {
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cached] = await Promise.all([
+        loadPairing(),
+        readCachedHabits(),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const cachedFetchedAtMs = cached?.fetched_at
+        ? Date.parse(cached.fetched_at)
+        : null;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedItems: cached?.items ?? null,
+        cachedFetchedAtMs: Number.isFinite(cachedFetchedAtMs)
+          ? cachedFetchedAtMs
+          : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Habits</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see habits.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <HabitsBody
+            pairing={bootstrap.pairing}
+            initialCachedItems={bootstrap.cachedItems}
+            initialCachedFetchedAtMs={bootstrap.cachedFetchedAtMs}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  initialCachedItems: HabitResponse[] | null;
+  initialCachedFetchedAtMs: number | null;
+}
+
+const HabitsBody: React.FC<BodyProps> = ({
+  pairing,
+  initialCachedItems,
+  initialCachedFetchedAtMs,
+}) => {
+  const history = useHistory();
+  const queryClient = useQueryClient();
+  const [streakBoost, setStreakBoost] = useState<Record<string, number>>({});
+  const [pulsingIds, setPulsingIds] = useState<Set<string>>(() => new Set());
+  const [toastOpen, setToastOpen] = useState(false);
+
+  const habitsQuery = useQuery<HabitResponse[]>({
+    queryKey: HABITS_QUERY_KEY,
+    queryFn: async () => {
+      const result = await fetchActiveHabits(pairing);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedHabits(result.items);
+      return result.items;
+    },
+    initialData: initialCachedItems ?? undefined,
+    initialDataUpdatedAt:
+      initialCachedItems !== null && initialCachedFetchedAtMs !== null
+        ? initialCachedFetchedAtMs
+        : undefined,
+    staleTime: HABITS_STALE_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  const items = habitsQuery.data;
+  const showCacheHint =
+    habitsQuery.isError && items !== undefined && items.length >= 0;
+
+  const partitioned = useMemo(
+    () => (items ? partitionAndSortHabits(items) : null),
+    [items],
+  );
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await habitsQuery.refetch();
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [habitsQuery],
+  );
+
+  const onRowClick = useCallback(
+    (habit: HabitResponse): void => {
+      history.push(`/habits/${habit.id}`);
+    },
+    [history],
+  );
+
+  const onQuickComplete = useCallback(
+    async (habit: HabitResponse): Promise<void> => {
+      const today = todayLocalDate();
+      const willIncrement = habit.last_completed !== today;
+
+      // Optimistic flip: pulsing check icon for PULSE_MS, streak +1 if applicable.
+      setPulsingIds((prev) => {
+        const next = new Set(prev);
+        next.add(habit.id);
+        return next;
+      });
+      if (willIncrement) {
+        setStreakBoost((prev) => ({ ...prev, [habit.id]: 1 }));
+      }
+      window.setTimeout(() => {
+        setPulsingIds((prev) => {
+          if (!prev.has(habit.id)) return prev;
+          const next = new Set(prev);
+          next.delete(habit.id);
+          return next;
+        });
+      }, PULSE_MS);
+
+      await enqueueHabitCompletion({
+        habit_id: habit.id,
+        completed_date: today,
+        notes: null,
+        enqueued_at: new Date().toISOString(),
+      });
+
+      const summary = await flushAllQueues();
+      const habitFlush = summary.habitCompletions;
+
+      if (habitFlush.delivered > 0) {
+        await queryClient.invalidateQueries({ queryKey: HABITS_QUERY_KEY });
+        setStreakBoost((prev) => {
+          if (!(habit.id in prev)) return prev;
+          const next = { ...prev };
+          delete next[habit.id];
+          return next;
+        });
+      } else if (
+        !habitFlush.coalesced &&
+        habitFlush.attempted > 0 &&
+        habitFlush.delivered === 0
+      ) {
+        // Attempted but didn't deliver — transient stop. Surface retry toast;
+        // the queue retains the entry and will retry on next foreground/online.
+        setToastOpen(true);
+      }
+    },
+    [queryClient],
+  );
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      {showCacheHint ? (
+        <div
+          className="px-4 pt-3 text-sm text-neutral-300"
+          role="status"
+          aria-live="polite"
+        >
+          Showing cached data
+        </div>
+      ) : null}
+
+      {partitioned &&
+      partitioned.primary.length === 0 &&
+      partitioned.graduated.length === 0 ? (
+        <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+          <p>No habits yet. Create habits via brain3 CLI or API.</p>
+        </div>
+      ) : null}
+
+      {partitioned && partitioned.primary.length > 0 ? (
+        <IonList>
+          {partitioned.primary.map((habit) => (
+            <HabitRow
+              key={habit.id}
+              habit={habit}
+              pairing={pairing}
+              optimisticBoost={streakBoost[habit.id] ?? 0}
+              pulsing={pulsingIds.has(habit.id)}
+              onRowClick={onRowClick}
+              onQuickComplete={onQuickComplete}
+            />
+          ))}
+        </IonList>
+      ) : null}
+
+      {partitioned && partitioned.graduated.length > 0 ? (
+        <IonList className="opacity-70">
+          <IonListHeader>
+            <IonLabel>Graduated</IonLabel>
+          </IonListHeader>
+          {partitioned.graduated.map((habit) => (
+            <HabitRow
+              key={habit.id}
+              habit={habit}
+              pairing={pairing}
+              optimisticBoost={0}
+              pulsing={pulsingIds.has(habit.id)}
+              quiet
+              onRowClick={onRowClick}
+              onQuickComplete={onQuickComplete}
+            />
+          ))}
+        </IonList>
+      ) : null}
+
+      <IonToast
+        isOpen={toastOpen}
+        message="Queued — will retry"
+        duration={3000}
+        onDidDismiss={() => setToastOpen(false)}
+      />
+    </>
+  );
+};
+
+interface RowProps {
+  habit: HabitResponse;
+  pairing: Pairing;
+  optimisticBoost: number;
+  pulsing: boolean;
+  quiet?: boolean;
+  onRowClick: (habit: HabitResponse) => void;
+  onQuickComplete: (habit: HabitResponse) => void;
+}
+
+function relativeLastCompleted(lastCompleted: string | null): string {
+  if (lastCompleted === null) return 'never';
+  try {
+    return formatDistanceToNowStrict(parseISO(lastCompleted), {
+      addSuffix: true,
+    });
+  } catch {
+    return lastCompleted;
+  }
+}
+
+const HabitRow: React.FC<RowProps> = ({
+  habit,
+  pairing,
+  optimisticBoost,
+  pulsing,
+  quiet,
+  onRowClick,
+  onQuickComplete,
+}) => {
+  const routineQuery = useQuery<RoutineResponse | null>({
+    queryKey: ROUTINE_QUERY_KEY(habit.routine_id ?? '__none__'),
+    queryFn: async () => {
+      if (!habit.routine_id) return null;
+      const result = await fetchRoutine(pairing, habit.routine_id);
+      return result.ok ? result.routine : null;
+    },
+    enabled: habit.routine_id !== null,
+    staleTime: ROUTINES_STALE_MS,
+  });
+
+  const displayedStreak = habit.current_streak + optimisticBoost;
+  const lastCompletedLabel =
+    habit.last_completed === null
+      ? 'never'
+      : `last completed: ${relativeLastCompleted(habit.last_completed)}`;
+
+  const subtitleParts: string[] = [];
+  if (habit.frequency) subtitleParts.push(habit.frequency);
+  if (habit.routine_id && routineQuery.data?.title) {
+    subtitleParts.push(`Part of: ${routineQuery.data.title}`);
+  }
+
+  return (
+    <IonItem
+      button
+      onClick={() => onRowClick(habit)}
+      data-testid={`habit-row-${habit.id}`}
+    >
+      <div slot="start" className="pe-2">
+        <StatusPill status={habit.scaffolding_status} />
+      </div>
+      <IonLabel className={`ion-text-wrap ${quiet ? 'text-sm' : ''}`}>
+        <h2>{habit.title}</h2>
+        {subtitleParts.length > 0 ? <p>{subtitleParts.join(' · ')}</p> : null}
+        {!quiet ? (
+          <p data-testid={`habit-streak-${habit.id}`}>
+            <IonText color="medium">
+              <small>
+                Streak: {displayedStreak} · Best: {habit.best_streak}
+              </small>
+            </IonText>
+          </p>
+        ) : null}
+      </IonLabel>
+      <div slot="end" className="flex flex-col items-end gap-1">
+        <IonButton
+          fill="clear"
+          size="small"
+          onClick={(event) => {
+            event.stopPropagation();
+            void onQuickComplete(habit);
+          }}
+          aria-label={`Mark ${habit.title} complete`}
+          data-testid={`habit-quick-complete-${habit.id}`}
+        >
+          <IonIcon
+            slot="icon-only"
+            icon={pulsing ? checkmarkCircle : checkmarkOutline}
+            color={pulsing ? 'success' : 'medium'}
+          />
+        </IonButton>
+        <IonNote className="text-xs">{lastCompletedLabel}</IonNote>
+      </div>
+    </IonItem>
+  );
+};
+
+export default HabitsPage;


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npx vitest run` — ✅ Pass (125 passed, 0 skipped, 13 files)
- `npx tsc --noEmit` — ✅ Pass (no errors)
- `npm run android:build:debug` — ➖ Not applicable (TS-only ticket; agent dev env has no JDK + ANDROID_HOME — see "Agent-env verification limit" below)

Ran locally against develop HEAD at `1b15fab` immediately before opening this PR.

Closes #16

## Summary

Adds the `/habits` route under the authenticated shell. Active habits load via TanStack Query against `GET /api/habits/?status=active`, sorted streak-first into a primary section and a quieter graduated section per the spec, with a per-row scaffolding-status pill, a quick-complete check button that drops into the [2C-23] write queue, and Capacitor Preferences cache that backs the offline-launch fallback. Per-row routine names resolve via deduplicated `GET /api/routines/{routine_id}` queries.

## Changes

- **`src/lib/habits.ts`** — new module: `HabitResponse`/`ScaffoldingStatus`/`HabitFrequency`/`EffectiveGraduationParams` types mirroring `app/schemas/habits.py:HabitResponse`, `fetchActiveHabits(pairing)`, `readCachedHabits`/`writeCachedHabits` against the `brain.cache.habits.active` Preferences key, and `partitionAndSortHabits` (pure function, primary sort: `current_streak DESC, last_completed DESC nulls last, title ASC`; graduated sort: `graduated_at DESC`).
- **`src/lib/routines.ts`** — new module: minimal `RoutineResponse` (`id`, `title`) and `fetchRoutine(pairing, routineId)`. Sibling tickets ([2C-22], [2C-24]) extend the type as their views surface more fields. **First consumer instantiates** — see flag below.
- **`src/components/StatusPill.tsx`** — new shared component for the scaffolding-status pill (green Tracking · amber Accountable · gray Graduated). **First consumer instantiates** — see flag below.
- **`src/pages/HabitsPage.tsx`** — new page. Bootstrap loads pairing + cache in parallel, then mounts a `HabitsBody` that owns the TanStack Query for active habits with `initialData`/`initialDataUpdatedAt` threaded from the cache so the on-mount refetch fires when the cache is older than `staleTime`. Each `HabitRow` runs an inline `useQuery` for its routine name (TanStack dedup → one fetch per routine, 15-minute `staleTime`). Quick-complete tap: optimistic +1 streak (only when `last_completed !== today-local`), 2 s pulsing-check indicator, `enqueueHabitCompletion` + `flushAllQueues`; `delivered > 0` invalidates `['habits', 'active']` and clears the optimistic boost; transient stop surfaces an `IonToast` "Queued — will retry". Offline fetch failure with cached data renders a "Showing cached data" hint.
- **`src/App.tsx`** — register `<Route exact path="/habits">` after `/notifications`, before the root redirect.
- **`*.test.ts(x)`** — co-located test coverage: spec-required cases for the page (mixed statuses, graduated separation, empty, optimistic flip plus idempotency, offline cache render, row tap navigates), plus the data-layer/sort/cache contract for `lib/habits` and `lib/routines`, plus visual coverage for `StatusPill`.

## How to Verify

1. Pair the app from `/settings`.
2. Navigate to `/habits` (router-only for now — no surfacing UI in this ticket).
3. Confirm active habits render with status pills, frequency · routine subtitle, streak/best line, and last-completed time.
4. Confirm a habit with `scaffolding_status === "graduated"` renders below a "Graduated" header in a quieter section (70% opacity, no streak line).
5. Tap the check button on a habit whose `last_completed` is not today: streak increments by 1 optimistically, the icon flashes green for ~2 s, and on success the row repopulates from server state.
6. Tap the check button on a habit whose `last_completed` is today: no streak increment (idempotent).
7. Tap a row body: navigates to `/habits/{id}` (route mounted by [2C-22]; expect blank/no-match until that lands).
8. Pull down to refresh: re-fetches and overwrites the cache.
9. With server reachable, then with server unreachable on a fresh launch: cached list renders with a "Showing cached data" hint.

## Deviations

1. **Test file location.** Spec calls for `tests/unit/HabitsPage.spec.tsx`. brain3-companion CLAUDE.md (Test Conventions) phases out `tests/unit/` and mandates co-location: `src/pages/HabitsPage.tsx` → `src/pages/HabitsPage.test.tsx`. Honored the repo-level convention; flagging here per spec-vs-codebase ambiguity handling.
2. **Repo CLAUDE.md drift, not addressed (carry-forward).** Repo working copy is v2 (April 30, 2026); BRAIN canonical is v3 (May 1, 2026). Per directive `4ea28266` (CLAUDE.md PO-controlled) and the Group 3 brief's explicit carry-forward note, this PR does not modify the repo file. Worked to BRAIN v3 throughout (specifically: PR-trigger Gradle gate is queued in [2C-Gap-05] (#55) and is therefore *not* an active gate at merge time — recorded under "Agent-env verification limit").
3. **Detail route navigation lands on a missing route until [2C-22].** Tap-row navigation calls `history.push("/habits/{id}")`, but `/habits/:id` is registered by [2C-22]. Until that lands, the destination shows the `IonRouterOutlet`'s no-match behavior. Spec is explicit that the detail view is [2C-22]'s scope; accepted as the dependency-order trade-off.

## First consumer instantiates (org CLAUDE.md v6 rule)

Two scaffolds in this PR have only [2C-21] as a current consumer; both are intentional shared introductions, flagged per the rule:

1. **`src/lib/routines.ts` (new module).** Spec calls for `useQuery({ queryKey: ["routine", routine_id], queryFn: ... })` per habit row. The fetcher belongs in a sibling module to `lib/habits.ts` for [2C-22] (habit detail) and [2C-24] (routine list) to reuse without re-defining the GET shape. The introducing PR is the right home because waiting for [2C-24] would split the read-path conventions across two PRs and drag the routine response shape through code review twice.
2. **`src/components/StatusPill.tsx` (new component).** Spec references "scaffolding status pill reused from `[2C-16]` pattern", but [2C-16] (rules list, issue #11) is open and unimplemented in this repo — the pattern is forward-looking. Introducing the pill now as a shared component lets [2C-22] habit-detail status pill, [2C-24] routine-list pills, and [2C-16] rules-list pills all hit the same component. The [2C-21] page is the first consumer.

## Warning surface deferred to [2C-22]

`subscribeHabitCompletionWarnings` (terminal `paused` / `not_found` from [2C-23]) is **not** wired in this PR. The spec's only toast is the transient "Queued — will retry" surfaced from `flushAllQueues` summary on `attempted > 0 && delivered === 0` (a stop outcome). Terminal-rejection surfacing fits more naturally on the habit detail view, where the user already has habit-specific context — leaving the first-UI-consumer wiring of `subscribeHabitCompletionWarnings` to [2C-22].

## Agent-env verification limit

The agent dev environment has no `JAVA_HOME` / `ANDROID_HOME`, so `npm run android:build:debug` is not part of pre-PR verification. brain3-companion CLAUDE.md (Pre-PR Verification Gates) §1 calls out that the PR-triggered Dev Release Gradle build closes the contributor-side gap; that gate is queued in [2C-Gap-05] (#55) and the workflow is currently push-only on `develop`. This PR is TS-only — no `android/` files touched — so the compile-only failure modes ([2C-Bug-02] firebase-messaging classpath, [2C-Bug-03] MainActivity.onDestroy access modifier) do not apply. Surfacing the gap explicitly per the v3 hedge.

## Test Results

```
npx vitest run
 Test Files  13 passed (13)
      Tests  125 passed (125)
```

New test coverage (all green):
- `src/pages/HabitsPage.test.tsx` — 9 tests (no-pairing message; mixed statuses with pills; routine-name resolution; graduated-section separation; empty state; optimistic streak +1 when `last_completed !== today`; no streak change when `last_completed === today`; row-body tap navigates without firing quick-complete; offline cache render with hint).
- `src/lib/habits.test.ts` — 13 tests (server contract: URL/auth/parsing/401/5xx/network/trailing-slash; cache round-trip and malformed/missing fallbacks; partition + sort contract for primary and graduated sections, including streak-tied with `last_completed` ordering and nulls-last).
- `src/lib/routines.test.ts` — 4 tests (200/404/401/network).
- `src/components/StatusPill.test.tsx` — 4 tests (display labels and per-status ring/background classes).

## Acceptance Checklist

- [x] `/habits` loads, shows all active habits with the documented row shape.
- [x] Graduated habits render in the quieter second section, visibly separated from tracking/accountable ones.
- [x] Empty habit set → empty state ("No habits yet. Create habits via brain3 CLI or API.").
- [x] Quick-complete: tap check → optimistic flip → row shows streak increment when `last_completed != today-local`, no change when `last_completed == today-local`.
- [x] POST reaches the server (or enqueues offline) via `enqueueHabitCompletion` + `flushAllQueues`.
- [x] Offline launch: cached list renders with the stale indicator. Quick-complete still works; entries queue via [2C-23].
- [x] Tap row (non-button area) → navigates to `/habits/{id}` detail view (route mounted by [2C-22]).
- [x] Pull-to-refresh re-fetches and overwrites cache.
- [x] Page-level test coverage (co-located at `src/pages/HabitsPage.test.tsx` per repo CLAUDE.md test-location convention) covers list render with mixed statuses, graduated-section separation, empty state, quick-complete optimistic flip, and offline cache render.
