### PR TITLE
[2C-22] App: Habit detail view + graduation dashboard + lifecycle actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
 import HabitsPage from './pages/HabitsPage';
+import HabitDetailPage from './pages/HabitDetailPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -105,6 +106,9 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/habits">
             <HabitsPage />
+          </Route>
+          <Route exact path="/habits/:habitId">
+            <HabitDetailPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/lib/habit-detail.test.ts
+++ b/src/lib/habit-detail.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  fetchHabitDetail,
+  fetchHabitGraduationStatus,
+  fetchHabitCompletions,
+  patchHabitStatus,
+  postReScaffold,
+  postStepDownFrequency,
+  readCachedHabitDetail,
+  readCachedGraduationStatus,
+  writeCachedHabitDetail,
+  writeCachedGraduationStatus,
+  habitDetailCacheKey,
+  habitGraduationCacheKey,
+  type GraduationStatusResponse,
+  type HabitDetailResponse,
+} from './habit-detail';
+
+const PAIRING = { url: 'https://brain.local:8000', token: 'tk-1' };
+const HABIT_ID = 'h-1';
+
+const prefs = new Map<string, string>();
+
+beforeEach(() => {
+  prefs.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefs.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefs.set(key, value);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface StubResponse {
+  status?: number;
+  body?: unknown;
+}
+
+function stubFetch(response: StubResponse): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      response.body !== undefined ? JSON.stringify(response.body) : '',
+      { status: response.status ?? 200 },
+    ),
+  );
+}
+
+describe('fetchHabitDetail', () => {
+  it('returns ok+habit on 200', async () => {
+    const habit: HabitDetailResponse = {
+      id: HABIT_ID,
+      routine_id: null,
+      title: 'Read',
+      description: null,
+      status: 'active',
+      frequency: 'daily',
+      notification_frequency: 'daily',
+      scaffolding_status: 'tracking',
+      accountable_since: null,
+      graduation_window: null,
+      graduation_target: null,
+      graduation_threshold: null,
+      friction_score: null,
+      position: null,
+      re_scaffold_count: 0,
+      last_frequency_changed_at: null,
+      graduated_at: null,
+      current_streak: 0,
+      best_streak: 0,
+      last_completed: null,
+      created_at: '2026-04-01T00:00:00Z',
+      updated_at: '2026-04-01T00:00:00Z',
+      effective_graduation_params: {
+        window_days: 30,
+        target_rate: 0.8,
+        threshold_days: 5,
+        source: 'friction_default',
+      },
+      routine: null,
+    };
+    stubFetch({ status: 200, body: habit });
+
+    const result = await fetchHabitDetail(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.habit.id).toBe(HABIT_ID);
+    }
+  });
+
+  it('returns not_found on 404', async () => {
+    stubFetch({ status: 404 });
+    const result = await fetchHabitDetail(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_found');
+    }
+  });
+
+  it('returns unauthorized on 401', async () => {
+    stubFetch({ status: 401 });
+    const result = await fetchHabitDetail(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unauthorized');
+    }
+  });
+});
+
+describe('fetchHabitGraduationStatus', () => {
+  it('returns ok+status on 200', async () => {
+    const status: GraduationStatusResponse = {
+      habit_id: HABIT_ID,
+      habit_name: 'Read',
+      scaffolding_status: 'tracking',
+      notification_frequency: 'daily',
+      friction_score: null,
+      re_scaffold_count: 0,
+      accountable_since: null,
+      days_accountable: 0,
+      graduation_params: {
+        window_days: 30,
+        target_rate: 0.8,
+        threshold_days: 5,
+        source: 'friction_default',
+      },
+      current_metrics: {
+        already_done_rate: 0,
+        total_notifications: 0,
+        already_done_count: 0,
+      },
+      progress_summary: 'Habit is in tracking mode.',
+      frequency_step_down: {
+        eligible: false,
+        recommended_frequency: null,
+        current_rate_over_recent: 0,
+      },
+    };
+    stubFetch({ status: 200, body: status });
+
+    const result = await fetchHabitGraduationStatus(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status.habit_id).toBe(HABIT_ID);
+    }
+  });
+});
+
+describe('fetchHabitCompletions', () => {
+  it('returns the completions list on 200', async () => {
+    stubFetch({
+      status: 200,
+      body: [
+        {
+          id: 'c-1',
+          habit_id: HABIT_ID,
+          completed_at: '2026-05-01',
+          source: 'individual',
+          notes: null,
+          created_at: '2026-05-01T12:00:00Z',
+        },
+      ],
+    });
+    const result = await fetchHabitCompletions(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.completions).toHaveLength(1);
+      expect(result.completions[0]?.source).toBe('individual');
+    }
+  });
+});
+
+describe('patchHabitStatus', () => {
+  it('PATCHes with the given status and returns ok on 200', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: HABIT_ID, status: 'paused' }), {
+        status: 200,
+      }),
+    );
+    const result = await patchHabitStatus(PAIRING, HABIT_ID, 'paused');
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PAIRING.url}/api/habits/${HABIT_ID}`,
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'paused' }),
+      }),
+    );
+  });
+});
+
+describe('postReScaffold', () => {
+  it('returns invalid_state with the server detail on 422', async () => {
+    stubFetch({
+      status: 422,
+      body: { detail: "Habit scaffolding_status is 'tracking', must be 'graduated'" },
+    });
+    const result = await postReScaffold(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_state');
+      expect(result.detail).toContain("must be 'graduated'");
+    }
+  });
+});
+
+describe('postStepDownFrequency', () => {
+  it('returns not_recommended with the nested message on 422', async () => {
+    stubFetch({
+      status: 422,
+      body: {
+        detail: {
+          message: 'Step-down not recommended',
+          evaluation: { recommend_step_down: false },
+        },
+      },
+    });
+    const result = await postStepDownFrequency(PAIRING, HABIT_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('not_recommended');
+      expect(result.detail).toBe('Step-down not recommended');
+    }
+  });
+});
+
+describe('Capacitor Preferences caches', () => {
+  it('writeCachedHabitDetail stores under the per-habit key with fetched_at', async () => {
+    await writeCachedHabitDetail(
+      HABIT_ID,
+      { id: HABIT_ID, routine: null } as unknown as HabitDetailResponse,
+      new Date('2026-05-02T12:00:00Z'),
+    );
+    const stored = prefs.get(habitDetailCacheKey(HABIT_ID));
+    expect(stored).toBeDefined();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.fetched_at).toBe('2026-05-02T12:00:00.000Z');
+    expect(parsed.habit.id).toBe(HABIT_ID);
+  });
+
+  it('readCachedHabitDetail returns null for malformed payloads', async () => {
+    prefs.set(habitDetailCacheKey(HABIT_ID), '{not valid json');
+    const result = await readCachedHabitDetail(HABIT_ID);
+    expect(result).toBeNull();
+  });
+
+  it('writeCachedGraduationStatus + readCachedGraduationStatus round-trip', async () => {
+    const status: GraduationStatusResponse = {
+      habit_id: HABIT_ID,
+      habit_name: 'X',
+      scaffolding_status: 'tracking',
+      notification_frequency: 'daily',
+      friction_score: null,
+      re_scaffold_count: 0,
+      accountable_since: null,
+      days_accountable: 0,
+      graduation_params: {
+        window_days: 30,
+        target_rate: 0.8,
+        threshold_days: 5,
+        source: 'friction_default',
+      },
+      current_metrics: {
+        already_done_rate: 0,
+        total_notifications: 0,
+        already_done_count: 0,
+      },
+      progress_summary: 'Habit is in tracking mode.',
+      frequency_step_down: {
+        eligible: false,
+        recommended_frequency: null,
+        current_rate_over_recent: 0,
+      },
+    };
+    await writeCachedGraduationStatus(HABIT_ID, status);
+    const cached = await readCachedGraduationStatus(HABIT_ID);
+    expect(cached).not.toBeNull();
+    expect(cached!.status.habit_id).toBe(HABIT_ID);
+    expect(prefs.has(habitGraduationCacheKey(HABIT_ID))).toBe(true);
+  });
+});

--- a/src/lib/habit-detail.ts
+++ b/src/lib/habit-detail.ts
@@ -1,0 +1,585 @@
+/**
+ * Habit detail data layer for [2C-22] habit detail + graduation dashboard +
+ * lifecycle actions.
+ *
+ * Owns three GET fetchers (detail, graduation-status, recent completions),
+ * three direct mutations (PATCH status for pause/resume, POST re-scaffold,
+ * POST step-down-frequency), and per-habit Capacitor Preferences caches for
+ * the two GETs that drive the on-mount paint. Mirrors the cache-and-thread
+ * pattern from `lib/habits.ts`: payload + `fetched_at` provenance, so the
+ * caller can thread the cache age into TanStack Query's `initialDataUpdatedAt`
+ * and let the on-mount refetch fire (initialData alone reads as fresh).
+ *
+ * Mutations are intentionally NOT routed through the [2C-23] write queue —
+ * the queue is for idempotent completion writes (server returns the existing
+ * row on retry); lifecycle transitions return meaningful 422/409 detail that
+ * the UI surfaces as a toast and does not retry.
+ *
+ * Type shapes mirror the brain3 server: `app/routers/habits.py:91-157` for
+ * GET/PATCH detail, `app/routers/graduation.py:74-87` for
+ * GraduationStatusResponse, `app/routers/graduation.py:202-262` for the two
+ * POST mutations, and `app/routers/habits.py:294-319` for the completions
+ * history endpoint.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { Pairing } from './pairing';
+import type { HabitResponse, HabitStatus } from './habits';
+import type { RoutineResponse } from './routines';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HabitDetailResponse extends HabitResponse {
+  routine: RoutineResponse | null;
+}
+
+export interface GraduationParams {
+  window_days: number;
+  target_rate: number;
+  threshold_days: number;
+  source: 'per_habit' | 'friction_default';
+}
+
+export interface CurrentMetrics {
+  already_done_rate: number;
+  total_notifications: number;
+  already_done_count: number;
+}
+
+export interface FrequencyStepDownInfo {
+  eligible: boolean;
+  recommended_frequency: string | null;
+  current_rate_over_recent: number;
+}
+
+export interface GraduationStatusResponse {
+  habit_id: string;
+  habit_name: string;
+  scaffolding_status: 'tracking' | 'accountable' | 'graduated';
+  notification_frequency: string;
+  friction_score: number | null;
+  re_scaffold_count: number;
+  accountable_since: string | null;
+  days_accountable: number;
+  graduation_params: GraduationParams;
+  current_metrics: CurrentMetrics;
+  progress_summary: string;
+  frequency_step_down: FrequencyStepDownInfo;
+}
+
+export interface HabitCompletionItem {
+  id: string;
+  habit_id: string;
+  /** YYYY-MM-DD device-local calendar date. */
+  completed_at: string;
+  source: string;
+  notes: string | null;
+  /** ISO timestamp of when the completion row was created server-side. */
+  created_at: string;
+}
+
+export interface ReScaffoldResult {
+  success: boolean;
+  habit_id: string;
+  previous_scaffolding_status: string;
+  previous_notification_frequency: string;
+  new_notification_frequency: string;
+  re_scaffold_count: number;
+  tightened_params: Record<string, unknown>;
+  message: string;
+}
+
+export interface FrequencyChangeResult {
+  success: boolean;
+  habit_id: string;
+  previous_frequency: string;
+  new_frequency: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// GET fetchers
+// ---------------------------------------------------------------------------
+
+export type FetchHabitDetailResult =
+  | { ok: true; habit: HabitDetailResponse }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+    };
+
+export async function fetchHabitDetail(
+  pairing: Pairing,
+  habitId: string,
+): Promise<FetchHabitDetailResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const habit = (await response.json()) as HabitDetailResponse;
+      return { ok: true, habit };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type FetchGraduationStatusResult =
+  | { ok: true; status: GraduationStatusResponse }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+    };
+
+export async function fetchHabitGraduationStatus(
+  pairing: Pairing,
+  habitId: string,
+): Promise<FetchGraduationStatusResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}/graduation-status`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const status = (await response.json()) as GraduationStatusResponse;
+      return { ok: true, status };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type FetchHabitCompletionsResult =
+  | { ok: true; completions: HabitCompletionItem[] }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+    };
+
+export async function fetchHabitCompletions(
+  pairing: Pairing,
+  habitId: string,
+  limit: number = 20,
+): Promise<FetchHabitCompletionsResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}/completions?limit=${limit}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const completions = (await response.json()) as HabitCompletionItem[];
+      return { ok: true, completions };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — direct, not queued
+// ---------------------------------------------------------------------------
+
+export type PatchHabitStatusResult =
+  | { ok: true; habit: HabitResponse }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'invalid'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+    };
+
+export async function patchHabitStatus(
+  pairing: Pairing,
+  habitId: string,
+  status: HabitStatus,
+): Promise<PatchHabitStatusResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${pairing.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status }),
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const habit = (await response.json()) as HabitResponse;
+      return { ok: true, habit };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    if (response.status === 400 || response.status === 422) {
+      return { ok: false, reason: 'invalid', statusCode: response.status };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type PostReScaffoldResult =
+  | { ok: true; result: ReScaffoldResult }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'invalid_state'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+      detail?: string;
+    };
+
+export async function postReScaffold(
+  pairing: Pairing,
+  habitId: string,
+): Promise<PostReScaffoldResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}/re-scaffold`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${pairing.token}`,
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const result = (await response.json()) as ReScaffoldResult;
+      return { ok: true, result };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    if (response.status === 422) {
+      const detail = await readDetail(response);
+      return {
+        ok: false,
+        reason: 'invalid_state',
+        statusCode: 422,
+        detail,
+      };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type PostStepDownResult =
+  | { ok: true; result: FrequencyChangeResult }
+  | {
+      ok: false;
+      reason:
+        | 'unauthorized'
+        | 'not_found'
+        | 'not_recommended'
+        | 'network'
+        | 'server'
+        | 'timeout';
+      statusCode?: number;
+      detail?: string;
+    };
+
+export async function postStepDownFrequency(
+  pairing: Pairing,
+  habitId: string,
+): Promise<PostStepDownResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}/api/habits/${habitId}/step-down-frequency`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${pairing.token}`,
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const result = (await response.json()) as FrequencyChangeResult;
+      return { ok: true, result };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    if (response.status === 422) {
+      // Server payload: { detail: { message, evaluation } } per
+      // routers/graduation.py:215-221. Surface the message verbatim.
+      const detail = await readNestedMessage(response);
+      return {
+        ok: false,
+        reason: 'not_recommended',
+        statusCode: 422,
+        detail,
+      };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readDetail(response: Response): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as unknown;
+    if (
+      body &&
+      typeof body === 'object' &&
+      'detail' in body &&
+      typeof (body as { detail: unknown }).detail === 'string'
+    ) {
+      return (body as { detail: string }).detail;
+    }
+  } catch {
+    // Fall through.
+  }
+  return undefined;
+}
+
+async function readNestedMessage(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as unknown;
+    if (
+      body &&
+      typeof body === 'object' &&
+      'detail' in body &&
+      (body as { detail: unknown }).detail &&
+      typeof (body as { detail: unknown }).detail === 'object' &&
+      'message' in
+        ((body as { detail: object }).detail as Record<string, unknown>) &&
+      typeof (
+        (body as { detail: Record<string, unknown> }).detail as Record<
+          string,
+          unknown
+        >
+      ).message === 'string'
+    ) {
+      return (
+        (body as { detail: Record<string, unknown> }).detail as Record<
+          string,
+          string
+        >
+      ).message;
+    }
+  } catch {
+    // Fall through.
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Per-habit Capacitor Preferences caches
+// ---------------------------------------------------------------------------
+
+export const habitDetailCacheKey = (habitId: string): string =>
+  `brain.cache.habit.${habitId}`;
+export const habitGraduationCacheKey = (habitId: string): string =>
+  `brain.cache.habit-graduation.${habitId}`;
+
+export interface CachedHabitDetail {
+  fetched_at: string;
+  habit: HabitDetailResponse;
+}
+
+export interface CachedGraduationStatus {
+  fetched_at: string;
+  status: GraduationStatusResponse;
+}
+
+export async function readCachedHabitDetail(
+  habitId: string,
+): Promise<CachedHabitDetail | null> {
+  const { value } = await Preferences.get({
+    key: habitDetailCacheKey(habitId),
+  });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'habit' in parsed &&
+      'fetched_at' in parsed &&
+      typeof (parsed as CachedHabitDetail).fetched_at === 'string'
+    ) {
+      return parsed as CachedHabitDetail;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedHabitDetail(
+  habitId: string,
+  habit: HabitDetailResponse,
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedHabitDetail = {
+    fetched_at: now.toISOString(),
+    habit,
+  };
+  await Preferences.set({
+    key: habitDetailCacheKey(habitId),
+    value: JSON.stringify(payload),
+  });
+}
+
+export async function readCachedGraduationStatus(
+  habitId: string,
+): Promise<CachedGraduationStatus | null> {
+  const { value } = await Preferences.get({
+    key: habitGraduationCacheKey(habitId),
+  });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'status' in parsed &&
+      'fetched_at' in parsed &&
+      typeof (parsed as CachedGraduationStatus).fetched_at === 'string'
+    ) {
+      return parsed as CachedGraduationStatus;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedGraduationStatus(
+  habitId: string,
+  status: GraduationStatusResponse,
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedGraduationStatus = {
+    fetched_at: now.toISOString(),
+    status,
+  };
+  await Preferences.set({
+    key: habitGraduationCacheKey(habitId),
+    value: JSON.stringify(payload),
+  });
+}

--- a/src/pages/HabitDetailPage.test.tsx
+++ b/src/pages/HabitDetailPage.test.tsx
@@ -1,0 +1,794 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+// IonAlert and IonToast use shadow-DOM rendering that jsdom does not exercise
+// — accessible names for their internal buttons / message text aren't
+// queryable through Testing Library. Replace them with thin wrappers that
+// expose the same prop contract via plain DOM. Production keeps the real
+// Ionic implementations; the mocks only run inside this suite.
+vi.mock('@ionic/react', async () => {
+  const actual = await vi.importActual<typeof import('@ionic/react')>(
+    '@ionic/react',
+  );
+  type AlertButton = {
+    text: string;
+    role?: string;
+    handler?: () => void;
+  };
+  interface IonAlertProps {
+    isOpen: boolean;
+    header?: string;
+    message?: string;
+    buttons?: AlertButton[];
+    onDidDismiss?: () => void;
+  }
+  interface IonToastProps {
+    isOpen: boolean;
+    message?: string;
+    color?: string;
+    onDidDismiss?: () => void;
+  }
+  const IonAlert: React.FC<IonAlertProps> = ({
+    isOpen,
+    header,
+    message,
+    buttons,
+    onDidDismiss,
+  }) =>
+    isOpen ? (
+      <div role="alertdialog" aria-label={header} data-testid="alert">
+        {header ? <h2>{header}</h2> : null}
+        {message ? <p>{message}</p> : null}
+        {(buttons ?? []).map((b, i) => (
+          <button
+            key={i}
+            type="button"
+            data-testid={`alert-button-${i}`}
+            data-role={b.role ?? 'action'}
+            onClick={() => {
+              b.handler?.();
+              onDidDismiss?.();
+            }}
+          >
+            {b.text}
+          </button>
+        ))}
+      </div>
+    ) : null;
+  const IonToast: React.FC<IonToastProps> = ({
+    isOpen,
+    message,
+    color,
+  }) =>
+    isOpen ? (
+      <div role="status" data-testid="toast" data-color={color ?? ''}>
+        {message ?? ''}
+      </div>
+    ) : null;
+  return { ...actual, IonAlert, IonToast };
+});
+
+const { replaceSpy, pushSpy } = vi.hoisted(() => ({
+  replaceSpy: vi.fn(),
+  pushSpy: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: replaceSpy,
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+const { enqueueSpy, flushSpy } = vi.hoisted(() => ({
+  enqueueSpy: vi.fn(),
+  flushSpy: vi.fn(),
+}));
+
+vi.mock('../lib/completionQueues', () => ({
+  enqueueHabitCompletion: enqueueSpy,
+  flushAllQueues: flushSpy,
+}));
+
+vi.mock('../lib/local-date', async () => {
+  const actual = await vi.importActual<typeof import('../lib/local-date')>(
+    '../lib/local-date',
+  );
+  return {
+    ...actual,
+    todayLocalDate: () => '2026-05-02',
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import type { HabitResponse } from '../lib/habits';
+import type {
+  GraduationStatusResponse,
+  HabitCompletionItem,
+  HabitDetailResponse,
+} from '../lib/habit-detail';
+import HabitDetailPage from './HabitDetailPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+const HABIT_ID = 'h-1';
+
+const prefsStore = new Map<string, string>();
+
+const successFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 1,
+    delivered: 1,
+    remaining: 0,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+};
+
+const stopFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 1,
+    delivered: 0,
+    remaining: 1,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+};
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+  enqueueSpy.mockReset().mockResolvedValue(undefined);
+  flushSpy.mockReset().mockResolvedValue(successFlush);
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+
+  Object.defineProperty(window.navigator, 'onLine', {
+    value: true,
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeHabit(
+  overrides: Partial<HabitDetailResponse> = {},
+): HabitDetailResponse {
+  const base: HabitResponse = {
+    id: HABIT_ID,
+    routine_id: null,
+    title: 'Take meds',
+    description: null,
+    status: 'active',
+    frequency: 'daily',
+    notification_frequency: 'daily',
+    scaffolding_status: 'tracking',
+    accountable_since: null,
+    graduation_window: null,
+    graduation_target: null,
+    graduation_threshold: null,
+    friction_score: null,
+    position: null,
+    re_scaffold_count: 0,
+    last_frequency_changed_at: null,
+    graduated_at: null,
+    current_streak: 3,
+    best_streak: 7,
+    last_completed: '2026-05-01',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    effective_graduation_params: {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+  };
+  return { ...base, ...overrides, routine: overrides.routine ?? null };
+}
+
+function makeGraduation(
+  overrides: Partial<GraduationStatusResponse> = {},
+): GraduationStatusResponse {
+  return {
+    habit_id: HABIT_ID,
+    habit_name: 'Take meds',
+    scaffolding_status: 'tracking',
+    notification_frequency: 'daily',
+    friction_score: 3,
+    re_scaffold_count: 0,
+    accountable_since: null,
+    days_accountable: 0,
+    graduation_params: {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+    current_metrics: {
+      already_done_rate: 0,
+      total_notifications: 0,
+      already_done_count: 0,
+    },
+    progress_summary:
+      'Habit is in tracking mode. Not yet in accountability loop.',
+    frequency_step_down: {
+      eligible: false,
+      recommended_frequency: null,
+      current_rate_over_recent: 0,
+    },
+    ...overrides,
+  };
+}
+
+interface FetchOpts {
+  habit?: { status: number; body?: HabitDetailResponse };
+  graduation?: { status: number; body?: GraduationStatusResponse };
+  completions?: { status: number; body?: HabitCompletionItem[] };
+  patch?: { status: number; body?: HabitResponse };
+  reScaffold?: { status: number; body?: unknown };
+  stepDown?: { status: number; body?: unknown };
+}
+
+function stubFetch(opts: FetchOpts = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (
+        url.includes(`/api/habits/${HABIT_ID}/graduation-status`) &&
+        method === 'GET'
+      ) {
+        const r = opts.graduation ?? { status: 200, body: makeGraduation() };
+        return new Response(
+          r.body !== undefined ? JSON.stringify(r.body) : '',
+          { status: r.status },
+        );
+      }
+      if (
+        url.includes(`/api/habits/${HABIT_ID}/completions`) &&
+        method === 'GET'
+      ) {
+        const r = opts.completions ?? { status: 200, body: [] };
+        return new Response(
+          r.body !== undefined ? JSON.stringify(r.body) : '',
+          { status: r.status },
+        );
+      }
+      if (
+        url.includes(`/api/habits/${HABIT_ID}/re-scaffold`) &&
+        method === 'POST'
+      ) {
+        const r = opts.reScaffold ?? {
+          status: 200,
+          body: {
+            success: true,
+            habit_id: HABIT_ID,
+            previous_scaffolding_status: 'graduated',
+            previous_notification_frequency: 'never',
+            new_notification_frequency: 'daily',
+            re_scaffold_count: 1,
+            tightened_params: {},
+            message: 'ok',
+          },
+        };
+        return new Response(JSON.stringify(r.body), { status: r.status });
+      }
+      if (
+        url.includes(`/api/habits/${HABIT_ID}/step-down-frequency`) &&
+        method === 'POST'
+      ) {
+        const r = opts.stepDown ?? {
+          status: 200,
+          body: {
+            success: true,
+            habit_id: HABIT_ID,
+            previous_frequency: 'daily',
+            new_frequency: '3x_per_week',
+            message: 'ok',
+          },
+        };
+        return new Response(JSON.stringify(r.body), { status: r.status });
+      }
+      if (url.endsWith(`/api/habits/${HABIT_ID}`) && method === 'PATCH') {
+        const r = opts.patch ?? {
+          status: 200,
+          body: makeHabit({ status: 'paused' }),
+        };
+        return new Response(JSON.stringify(r.body), { status: r.status });
+      }
+      if (url.endsWith(`/api/habits/${HABIT_ID}`) && method === 'GET') {
+        const r = opts.habit ?? { status: 200, body: makeHabit() };
+        return new Response(
+          r.body !== undefined ? JSON.stringify(r.body) : '',
+          { status: r.status },
+        );
+      }
+      if (url.includes('/api/health')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/habits/${HABIT_ID}`]}>
+        <Route path="/habits/:habitId">
+          <HabitDetailPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+async function clickAlertButton(name: string): Promise<void> {
+  const alert = await screen.findByRole('alertdialog');
+  await userEvent.click(within(alert).getByRole('button', { name }));
+}
+
+function findPatchCall(
+  spy: ReturnType<typeof stubFetch>,
+): RequestInit | undefined {
+  const call = spy.mock.calls.find(
+    ([input, init]) =>
+      (init as RequestInit | undefined)?.method === 'PATCH' &&
+      (typeof input === 'string'
+        ? input
+        : (input as URL).toString()
+      ).includes(`/api/habits/${HABIT_ID}`),
+  );
+  return call ? (call[1] as RequestInit) : undefined;
+}
+
+function findPostCallByPath(
+  spy: ReturnType<typeof stubFetch>,
+  pathSubstring: string,
+): boolean {
+  return spy.mock.calls.some(
+    ([input, init]) =>
+      (init as RequestInit | undefined)?.method === 'POST' &&
+      (typeof input === 'string'
+        ? input
+        : (input as URL).toString()
+      ).includes(pathSubstring),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Render per scaffolding state
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — render per scaffolding state', () => {
+  it('renders the tracking state without a progress bar', async () => {
+    pair();
+    stubFetch({
+      graduation: {
+        status: 200,
+        body: makeGraduation({ scaffolding_status: 'tracking' }),
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Take meds')).toBeInTheDocument();
+    expect(
+      screen.getByText(/habit is in tracking mode/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('habit-graduation-accountable'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the accountable state with progress bar + caption + days line', async () => {
+    pair();
+    stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({
+          scaffolding_status: 'accountable',
+          accountable_since: '2026-04-30',
+        }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({
+          scaffolding_status: 'accountable',
+          days_accountable: 2,
+          current_metrics: {
+            already_done_rate: 0.5,
+            total_notifications: 10,
+            already_done_count: 5,
+          },
+          progress_summary:
+            '50% of the way to graduation target (80%). 3 more days until minimum threshold met.',
+        }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('habit-graduation-accountable'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('habit-graduation-target-marker'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('habit-graduation-caption')).toHaveTextContent(
+      '50% of 80% target · 5/10 completions this window',
+    );
+    expect(screen.getByTestId('habit-graduation-days-line')).toHaveTextContent(
+      '3 days until minimum threshold met.',
+    );
+  });
+
+  it('renders the step-down suggestion when frequency_step_down.eligible is true', async () => {
+    pair();
+    stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({ scaffolding_status: 'accountable' }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({
+          scaffolding_status: 'accountable',
+          days_accountable: 7,
+          frequency_step_down: {
+            eligible: true,
+            recommended_frequency: '3x_per_week',
+            current_rate_over_recent: 0.95,
+          },
+        }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('habit-step-down-button'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/stepping down to/i)).toBeInTheDocument();
+  });
+
+  it('renders the graduated state with re-scaffold button and hides mark-complete', async () => {
+    pair();
+    stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({
+          status: 'graduated',
+          scaffolding_status: 'graduated',
+          graduated_at: '2026-04-15T00:00:00Z',
+        }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({
+          scaffolding_status: 'graduated',
+          progress_summary: 'Habit has graduated.',
+        }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('habit-re-scaffold-button'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('habit-mark-complete-button'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mark-complete flow
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — mark complete', () => {
+  it('enqueues + flushes when the user taps Mark complete', async () => {
+    pair();
+    stubFetch();
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-mark-complete-button'),
+    );
+
+    await waitFor(() => {
+      expect(enqueueSpy).toHaveBeenCalledWith({
+        habit_id: HABIT_ID,
+        completed_date: '2026-05-02',
+        notes: null,
+        enqueued_at: expect.any(String),
+      });
+    });
+    expect(flushSpy).toHaveBeenCalled();
+  });
+
+  it('surfaces the queued retry toast when the flush attempts but does not deliver', async () => {
+    pair();
+    flushSpy.mockResolvedValueOnce(stopFlush);
+    stubFetch();
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-mark-complete-button'),
+    );
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/queued — will retry/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pause / Resume
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — pause / resume', () => {
+  it('PATCHes status=paused after the user confirms the pause alert', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      patch: { status: 200, body: makeHabit({ status: 'paused' }) },
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByTestId('habit-pause-button'));
+    await clickAlertButton('Pause');
+
+    await waitFor(() => {
+      const init = findPatchCall(fetchSpy);
+      expect(init).toBeDefined();
+      expect(init!.body).toBe(JSON.stringify({ status: 'paused' }));
+    });
+  });
+
+  it('PATCHes status=active after the user confirms the resume alert', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({ status: 'paused' }),
+      },
+      patch: { status: 200, body: makeHabit({ status: 'active' }) },
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByTestId('habit-resume-button'));
+    await clickAlertButton('Resume');
+
+    await waitFor(() => {
+      const init = findPatchCall(fetchSpy);
+      expect(init).toBeDefined();
+      expect(init!.body).toBe(JSON.stringify({ status: 'active' }));
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step-down flow
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — step down frequency', () => {
+  it('POSTs to step-down-frequency and shows a success toast', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({ scaffolding_status: 'accountable' }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({
+          scaffolding_status: 'accountable',
+          frequency_step_down: {
+            eligible: true,
+            recommended_frequency: '3x_per_week',
+            current_rate_over_recent: 0.95,
+          },
+        }),
+      },
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-step-down-button'),
+    );
+
+    await waitFor(() => {
+      expect(findPostCallByPath(fetchSpy, '/step-down-frequency')).toBe(true);
+    });
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/stepped down to 3x_per_week/i);
+  });
+
+  it('surfaces the 422 evaluation message when step-down is no longer recommended', async () => {
+    pair();
+    stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({ scaffolding_status: 'accountable' }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({
+          scaffolding_status: 'accountable',
+          frequency_step_down: {
+            eligible: true,
+            recommended_frequency: '3x_per_week',
+            current_rate_over_recent: 0.95,
+          },
+        }),
+      },
+      stepDown: {
+        status: 422,
+        body: {
+          detail: {
+            message: 'Step-down no longer recommended',
+            evaluation: { recommend_step_down: false },
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-step-down-button'),
+    );
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/step-down no longer recommended/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-scaffold flow
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — re-scaffold', () => {
+  it('POSTs to re-scaffold after the user confirms and navigates back to /habits', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({
+          status: 'graduated',
+          scaffolding_status: 'graduated',
+          graduated_at: '2026-04-15T00:00:00Z',
+        }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({ scaffolding_status: 'graduated' }),
+      },
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-re-scaffold-button'),
+    );
+    await clickAlertButton('Re-scaffold');
+
+    await waitFor(() => {
+      expect(findPostCallByPath(fetchSpy, '/re-scaffold')).toBe(true);
+    });
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith('/habits');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offline graceful degradation
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — offline graceful degradation', () => {
+  it('renders the not-found inline card with a back action when the habit GET returns 404', async () => {
+    pair();
+    stubFetch({ habit: { status: 404 } });
+
+    renderPage();
+
+    expect(await screen.findByTestId('habit-not-found')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('habit-not-found-back'));
+    expect(replaceSpy).toHaveBeenCalledWith('/habits');
+  });
+
+  it('does not POST re-scaffold when offline; surfaces the connection toast', async () => {
+    pair();
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+    const fetchSpy = stubFetch({
+      habit: {
+        status: 200,
+        body: makeHabit({
+          status: 'graduated',
+          scaffolding_status: 'graduated',
+          graduated_at: '2026-04-15T00:00:00Z',
+        }),
+      },
+      graduation: {
+        status: 200,
+        body: makeGraduation({ scaffolding_status: 'graduated' }),
+      },
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('habit-re-scaffold-button'),
+    );
+    await clickAlertButton('Re-scaffold');
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/action requires connection/i);
+    expect(findPostCallByPath(fetchSpy, '/re-scaffold')).toBe(false);
+  });
+});

--- a/src/pages/HabitDetailPage.tsx
+++ b/src/pages/HabitDetailPage.tsx
@@ -1,0 +1,1012 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonAlert,
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonProgressBar,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import {
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { format, formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { useHistory, useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import StatusPill from '../components/StatusPill';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchHabitCompletions,
+  fetchHabitDetail,
+  fetchHabitGraduationStatus,
+  patchHabitStatus,
+  postReScaffold,
+  postStepDownFrequency,
+  readCachedGraduationStatus,
+  readCachedHabitDetail,
+  writeCachedGraduationStatus,
+  writeCachedHabitDetail,
+  type GraduationStatusResponse,
+  type HabitCompletionItem,
+  type HabitDetailResponse,
+} from '../lib/habit-detail';
+import {
+  enqueueHabitCompletion,
+  flushAllQueues,
+} from '../lib/completionQueues';
+import { todayLocalDate } from '../lib/local-date';
+
+const HABIT_QUERY_KEY = (id: string): QueryKey => ['habit', id];
+const HABIT_GRADUATION_QUERY_KEY = (id: string): QueryKey => [
+  'habit-graduation',
+  id,
+];
+const HABIT_COMPLETIONS_QUERY_KEY = (id: string): QueryKey => [
+  'habit-completions',
+  id,
+];
+const HABITS_LIST_QUERY_KEY: QueryKey = ['habits', 'active'];
+const STALE_MS = 5 * 60 * 1000;
+const COMPLETIONS_LIMIT = 20;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedHabit: HabitDetailResponse | null;
+      cachedHabitFetchedAtMs: number | null;
+      cachedGraduation: GraduationStatusResponse | null;
+      cachedGraduationFetchedAtMs: number | null;
+    };
+
+const HabitDetailPage: React.FC = () => {
+  const { habitId } = useParams<{ habitId: string }>();
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cachedDetail, cachedGraduation] = await Promise.all([
+        loadPairing(),
+        readCachedHabitDetail(habitId),
+        readCachedGraduationStatus(habitId),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const detailMs = cachedDetail?.fetched_at
+        ? Date.parse(cachedDetail.fetched_at)
+        : NaN;
+      const gradMs = cachedGraduation?.fetched_at
+        ? Date.parse(cachedGraduation.fetched_at)
+        : NaN;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedHabit: cachedDetail?.habit ?? null,
+        cachedHabitFetchedAtMs: Number.isFinite(detailMs) ? detailMs : null,
+        cachedGraduation: cachedGraduation?.status ?? null,
+        cachedGraduationFetchedAtMs: Number.isFinite(gradMs) ? gradMs : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [habitId]);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/habits" />
+          </IonButtons>
+          <IonTitle>Habit</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see this habit.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <DetailBody
+            habitId={habitId}
+            pairing={bootstrap.pairing}
+            initialHabit={bootstrap.cachedHabit}
+            initialHabitFetchedAtMs={bootstrap.cachedHabitFetchedAtMs}
+            initialGraduation={bootstrap.cachedGraduation}
+            initialGraduationFetchedAtMs={
+              bootstrap.cachedGraduationFetchedAtMs
+            }
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  habitId: string;
+  pairing: Pairing;
+  initialHabit: HabitDetailResponse | null;
+  initialHabitFetchedAtMs: number | null;
+  initialGraduation: GraduationStatusResponse | null;
+  initialGraduationFetchedAtMs: number | null;
+}
+
+interface ToastState {
+  open: boolean;
+  message: string;
+  color?: 'success' | 'danger' | 'medium';
+}
+
+const DetailBody: React.FC<BodyProps> = ({
+  habitId,
+  pairing,
+  initialHabit,
+  initialHabitFetchedAtMs,
+  initialGraduation,
+  initialGraduationFetchedAtMs,
+}) => {
+  const history = useHistory();
+  const queryClient = useQueryClient();
+  const [toast, setToast] = useState<ToastState>({ open: false, message: '' });
+  const [reScaffoldAlertOpen, setReScaffoldAlertOpen] = useState(false);
+  const [pauseAlertOpen, setPauseAlertOpen] = useState(false);
+  const [resumeAlertOpen, setResumeAlertOpen] = useState(false);
+  const [actionPending, setActionPending] = useState(false);
+
+  const habitQuery = useQuery<HabitDetailResponse>({
+    queryKey: HABIT_QUERY_KEY(habitId),
+    queryFn: async () => {
+      const result = await fetchHabitDetail(pairing, habitId);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      await writeCachedHabitDetail(habitId, result.habit);
+      return result.habit;
+    },
+    initialData: initialHabit ?? undefined,
+    initialDataUpdatedAt:
+      initialHabit !== null && initialHabitFetchedAtMs !== null
+        ? initialHabitFetchedAtMs
+        : undefined,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  const graduationQuery = useQuery<GraduationStatusResponse>({
+    queryKey: HABIT_GRADUATION_QUERY_KEY(habitId),
+    queryFn: async () => {
+      const result = await fetchHabitGraduationStatus(pairing, habitId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedGraduationStatus(habitId, result.status);
+      return result.status;
+    },
+    initialData: initialGraduation ?? undefined,
+    initialDataUpdatedAt:
+      initialGraduation !== null && initialGraduationFetchedAtMs !== null
+        ? initialGraduationFetchedAtMs
+        : undefined,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    enabled: !isNotFoundError(habitQuery.error),
+    retry: false,
+  });
+
+  const completionsQuery = useQuery<HabitCompletionItem[]>({
+    queryKey: HABIT_COMPLETIONS_QUERY_KEY(habitId),
+    queryFn: async () => {
+      const result = await fetchHabitCompletions(
+        pairing,
+        habitId,
+        COMPLETIONS_LIMIT,
+      );
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      return result.completions;
+    },
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    enabled: !isNotFoundError(habitQuery.error),
+    retry: false,
+  });
+
+  const habit = habitQuery.data;
+  const graduation = graduationQuery.data;
+  const completions = completionsQuery.data;
+  const showCacheHint =
+    habitQuery.isError &&
+    !isNotFoundError(habitQuery.error) &&
+    habit !== undefined;
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await Promise.all([
+          habitQuery.refetch(),
+          graduationQuery.refetch(),
+          completionsQuery.refetch(),
+        ]);
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [habitQuery, graduationQuery, completionsQuery],
+  );
+
+  const invalidateAll = useCallback(async (): Promise<void> => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: HABIT_QUERY_KEY(habitId) }),
+      queryClient.invalidateQueries({
+        queryKey: HABIT_GRADUATION_QUERY_KEY(habitId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: HABIT_COMPLETIONS_QUERY_KEY(habitId),
+      }),
+      queryClient.invalidateQueries({ queryKey: HABITS_LIST_QUERY_KEY }),
+    ]);
+  }, [habitId, queryClient]);
+
+  const onMarkComplete = useCallback(async (): Promise<void> => {
+    if (!habit) return;
+    const today = todayLocalDate();
+    await enqueueHabitCompletion({
+      habit_id: habit.id,
+      completed_date: today,
+      notes: null,
+      enqueued_at: new Date().toISOString(),
+    });
+    const summary = await flushAllQueues();
+    const habitFlush = summary.habitCompletions;
+    if (habitFlush.delivered > 0) {
+      await invalidateAll();
+      setToast({ open: true, message: 'Marked complete', color: 'success' });
+    } else if (
+      !habitFlush.coalesced &&
+      habitFlush.attempted > 0 &&
+      habitFlush.delivered === 0
+    ) {
+      setToast({
+        open: true,
+        message: 'Queued — will retry',
+        color: 'medium',
+      });
+    } else {
+      setToast({ open: true, message: 'Queued', color: 'medium' });
+    }
+  }, [habit, invalidateAll]);
+
+  const onPause = useCallback(async (): Promise<void> => {
+    setPauseAlertOpen(false);
+    setActionPending(true);
+    try {
+      const result = await patchHabitStatus(pairing, habitId, 'paused');
+      if (result.ok) {
+        await invalidateAll();
+        setToast({ open: true, message: 'Habit paused', color: 'success' });
+      } else if (result.reason === 'network' || result.reason === 'timeout') {
+        setToast({
+          open: true,
+          message: 'Action requires connection',
+          color: 'medium',
+        });
+      } else if (result.reason === 'not_found') {
+        setToast({
+          open: true,
+          message: 'Habit no longer exists',
+          color: 'danger',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: 'Could not pause habit',
+          color: 'danger',
+        });
+      }
+    } finally {
+      setActionPending(false);
+    }
+  }, [habitId, invalidateAll, pairing]);
+
+  const onResume = useCallback(async (): Promise<void> => {
+    setResumeAlertOpen(false);
+    setActionPending(true);
+    try {
+      const result = await patchHabitStatus(pairing, habitId, 'active');
+      if (result.ok) {
+        await invalidateAll();
+        setToast({ open: true, message: 'Habit resumed', color: 'success' });
+      } else if (result.reason === 'network' || result.reason === 'timeout') {
+        setToast({
+          open: true,
+          message: 'Action requires connection',
+          color: 'medium',
+        });
+      } else if (result.reason === 'not_found') {
+        setToast({
+          open: true,
+          message: 'Habit no longer exists',
+          color: 'danger',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: 'Could not resume habit',
+          color: 'danger',
+        });
+      }
+    } finally {
+      setActionPending(false);
+    }
+  }, [habitId, invalidateAll, pairing]);
+
+  const onStepDown = useCallback(async (): Promise<void> => {
+    if (!isOnline()) {
+      setToast({
+        open: true,
+        message: 'Action requires connection',
+        color: 'medium',
+      });
+      return;
+    }
+    setActionPending(true);
+    try {
+      const result = await postStepDownFrequency(pairing, habitId);
+      if (result.ok) {
+        await invalidateAll();
+        setToast({
+          open: true,
+          message: `Stepped down to ${result.result.new_frequency}`,
+          color: 'success',
+        });
+      } else if (result.reason === 'network' || result.reason === 'timeout') {
+        setToast({
+          open: true,
+          message: 'Action requires connection',
+          color: 'medium',
+        });
+      } else if (result.reason === 'not_recommended') {
+        setToast({
+          open: true,
+          message: result.detail ?? 'Step-down no longer recommended',
+          color: 'medium',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: 'Could not step down frequency',
+          color: 'danger',
+        });
+      }
+    } finally {
+      setActionPending(false);
+    }
+  }, [habitId, invalidateAll, pairing]);
+
+  const onReScaffoldConfirm = useCallback(async (): Promise<void> => {
+    setReScaffoldAlertOpen(false);
+    if (!isOnline()) {
+      setToast({
+        open: true,
+        message: 'Action requires connection',
+        color: 'medium',
+      });
+      return;
+    }
+    setActionPending(true);
+    try {
+      const result = await postReScaffold(pairing, habitId);
+      if (result.ok) {
+        await invalidateAll();
+        setToast({
+          open: true,
+          message: 'Habit re-scaffolded',
+          color: 'success',
+        });
+        history.replace('/habits');
+      } else if (result.reason === 'network' || result.reason === 'timeout') {
+        setToast({
+          open: true,
+          message: 'Action requires connection',
+          color: 'medium',
+        });
+      } else if (result.reason === 'invalid_state') {
+        setToast({
+          open: true,
+          message: result.detail ?? 'Habit is not in a graduated state',
+          color: 'medium',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: 'Could not re-scaffold habit',
+          color: 'danger',
+        });
+      }
+    } finally {
+      setActionPending(false);
+    }
+  }, [habitId, history, invalidateAll, pairing]);
+
+  if (isNotFoundError(habitQuery.error) && !habit) {
+    return (
+      <NotFoundCard
+        onBack={() => history.replace('/habits')}
+      />
+    );
+  }
+
+  if (!habit) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-neutral-300">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      {showCacheHint ? (
+        <div
+          className="px-4 pt-3 text-sm text-neutral-300"
+          role="status"
+          aria-live="polite"
+        >
+          Showing cached data
+        </div>
+      ) : null}
+
+      <DefinitionPane
+        habit={habit}
+        onRoutineTap={(routineId) => history.push(`/routines/${routineId}`)}
+      />
+
+      <GraduationDashboard
+        graduation={graduation}
+        habit={habit}
+        onStepDown={onStepDown}
+        actionPending={actionPending}
+        onReScaffold={() => setReScaffoldAlertOpen(true)}
+      />
+
+      <RecentCompletions completions={completions} />
+
+      <ActionFooter
+        habit={habit}
+        actionPending={actionPending}
+        onMarkComplete={onMarkComplete}
+        onPause={() => setPauseAlertOpen(true)}
+        onResume={() => setResumeAlertOpen(true)}
+      />
+
+      <IonAlert
+        isOpen={reScaffoldAlertOpen}
+        header="Re-scaffold habit?"
+        message="This will return the habit to daily accountability and reset the graduation progress. Continue?"
+        buttons={[
+          { text: 'Cancel', role: 'cancel' },
+          { text: 'Re-scaffold', role: 'destructive', handler: () => void onReScaffoldConfirm() },
+        ]}
+        onDidDismiss={() => setReScaffoldAlertOpen(false)}
+      />
+      <IonAlert
+        isOpen={pauseAlertOpen}
+        header="Pause this habit?"
+        message="It won't accept completions until resumed."
+        buttons={[
+          { text: 'Cancel', role: 'cancel' },
+          { text: 'Pause', handler: () => void onPause() },
+        ]}
+        onDidDismiss={() => setPauseAlertOpen(false)}
+      />
+      <IonAlert
+        isOpen={resumeAlertOpen}
+        header="Resume this habit?"
+        buttons={[
+          { text: 'Cancel', role: 'cancel' },
+          { text: 'Resume', handler: () => void onResume() },
+        ]}
+        onDidDismiss={() => setResumeAlertOpen(false)}
+      />
+
+      <IonToast
+        isOpen={toast.open}
+        message={toast.message}
+        color={toast.color}
+        duration={3000}
+        onDidDismiss={() => setToast({ open: false, message: '' })}
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Definition pane
+// ---------------------------------------------------------------------------
+
+interface DefinitionProps {
+  habit: HabitDetailResponse;
+  onRoutineTap: (routineId: string) => void;
+}
+
+const DefinitionPane: React.FC<DefinitionProps> = ({ habit, onRoutineTap }) => {
+  const lastCompletedLine = useMemo(() => {
+    if (habit.last_completed === null) return 'Never completed';
+    return `${formatAbsoluteDate(habit.last_completed)} (${formatDistanceToNowStrict(parseISO(habit.last_completed), { addSuffix: true })})`;
+  }, [habit.last_completed]);
+
+  return (
+    <section className="px-4 pt-4" data-testid="habit-definition-pane">
+      <div className="flex items-center gap-2">
+        <StatusPill status={habit.scaffolding_status} />
+        <h1 className="text-xl font-semibold">{habit.title}</h1>
+      </div>
+
+      {habit.description !== null ? (
+        <p
+          className="mt-2 whitespace-pre-wrap text-sm text-neutral-200"
+          data-testid="habit-description"
+        >
+          {habit.description}
+        </p>
+      ) : null}
+
+      <dl className="mt-4 grid grid-cols-1 gap-2 text-sm">
+        {habit.frequency !== null ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Frequency</dt>
+            <dd>{habit.frequency}</dd>
+          </div>
+        ) : null}
+        <div className="flex justify-between">
+          <dt className="text-neutral-400">Notification frequency</dt>
+          <dd>{habit.notification_frequency}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-neutral-400">Streak</dt>
+          <dd data-testid="habit-streak">
+            Streak {habit.current_streak} · Best {habit.best_streak}
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-neutral-400">Last completed</dt>
+          <dd>{lastCompletedLine}</dd>
+        </div>
+        {habit.accountable_since !== null ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Accountable since</dt>
+            <dd>{formatAbsoluteDate(habit.accountable_since)}</dd>
+          </div>
+        ) : null}
+        {habit.re_scaffold_count > 0 ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Re-scaffolded</dt>
+            <dd>{habit.re_scaffold_count} times</dd>
+          </div>
+        ) : null}
+        {habit.graduated_at !== null ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Graduated</dt>
+            <dd>{formatAbsoluteDate(habit.graduated_at)}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {habit.routine !== null ? (
+        <button
+          type="button"
+          className="mt-3 block w-full rounded border border-neutral-700 px-3 py-2 text-left text-sm text-neutral-100"
+          onClick={() => onRoutineTap(habit.routine!.id)}
+          data-testid="habit-routine-link"
+        >
+          Part of: {habit.routine.title}
+        </button>
+      ) : null}
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Graduation dashboard
+// ---------------------------------------------------------------------------
+
+interface GraduationProps {
+  graduation: GraduationStatusResponse | undefined;
+  habit: HabitDetailResponse;
+  actionPending: boolean;
+  onStepDown: () => void;
+  onReScaffold: () => void;
+}
+
+const GraduationDashboard: React.FC<GraduationProps> = ({
+  graduation,
+  habit,
+  actionPending,
+  onStepDown,
+  onReScaffold,
+}) => {
+  if (!graduation) {
+    return (
+      <section
+        className="mt-6 px-4 text-sm text-neutral-400"
+        data-testid="habit-graduation-pane"
+      >
+        Loading graduation status…
+      </section>
+    );
+  }
+
+  const status = graduation.scaffolding_status;
+
+  return (
+    <section
+      className="mt-6 px-4"
+      data-testid="habit-graduation-pane"
+      data-graduation-status={status}
+    >
+      <h2 className="text-base font-medium">Graduation</h2>
+      <p className="mt-1 text-sm text-neutral-300">
+        {graduation.progress_summary}
+      </p>
+
+      {status === 'accountable' ? (
+        <AccountableDashboard
+          graduation={graduation}
+          actionPending={actionPending}
+          onStepDown={onStepDown}
+        />
+      ) : null}
+
+      {status === 'graduated' ? (
+        <GraduatedDashboard
+          habit={habit}
+          actionPending={actionPending}
+          onReScaffold={onReScaffold}
+        />
+      ) : null}
+    </section>
+  );
+};
+
+interface AccountableProps {
+  graduation: GraduationStatusResponse;
+  actionPending: boolean;
+  onStepDown: () => void;
+}
+
+const AccountableDashboard: React.FC<AccountableProps> = ({
+  graduation,
+  actionPending,
+  onStepDown,
+}) => {
+  const { current_metrics, graduation_params, days_accountable } = graduation;
+  const ratePct = Math.round(current_metrics.already_done_rate * 100);
+  const targetPct = Math.round(graduation_params.target_rate * 100);
+  const remainingDays = Math.max(
+    0,
+    graduation_params.threshold_days - days_accountable,
+  );
+
+  return (
+    <div className="mt-3" data-testid="habit-graduation-accountable">
+      <div
+        className="relative"
+        aria-label={`Graduation progress: ${ratePct}% of ${targetPct}% target`}
+      >
+        <IonProgressBar
+          value={Math.min(1, current_metrics.already_done_rate)}
+        />
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute top-0 h-full w-px bg-amber-300"
+          style={{
+            left: `${Math.min(100, Math.max(0, graduation_params.target_rate * 100))}%`,
+          }}
+          data-testid="habit-graduation-target-marker"
+        />
+      </div>
+      <p
+        className="mt-2 text-xs text-neutral-400"
+        data-testid="habit-graduation-caption"
+      >
+        {ratePct}% of {targetPct}% target ·{' '}
+        {current_metrics.already_done_count}/
+        {current_metrics.total_notifications} completions this window
+      </p>
+      {remainingDays > 0 ? (
+        <p
+          className="mt-1 text-xs text-neutral-400"
+          data-testid="habit-graduation-days-line"
+        >
+          {remainingDays} days until minimum threshold met.
+        </p>
+      ) : null}
+      {graduation.frequency_step_down.eligible &&
+      graduation.frequency_step_down.recommended_frequency !== null ? (
+        <div className="mt-3 flex items-center justify-between rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2">
+          <span className="text-sm">
+            Stepping down to{' '}
+            <strong>
+              {graduation.frequency_step_down.recommended_frequency}
+            </strong>{' '}
+            is recommended
+          </span>
+          <IonButton
+            size="small"
+            color="warning"
+            onClick={onStepDown}
+            disabled={actionPending}
+            data-testid="habit-step-down-button"
+          >
+            Step down
+          </IonButton>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+interface GraduatedProps {
+  habit: HabitDetailResponse;
+  actionPending: boolean;
+  onReScaffold: () => void;
+}
+
+const GraduatedDashboard: React.FC<GraduatedProps> = ({
+  habit,
+  actionPending,
+  onReScaffold,
+}) => (
+  <div className="mt-3" data-testid="habit-graduation-graduated">
+    {habit.graduated_at !== null ? (
+      <p className="text-sm text-neutral-300">
+        Graduated on {formatAbsoluteDate(habit.graduated_at)}.
+      </p>
+    ) : null}
+    <IonButton
+      color="medium"
+      size="small"
+      className="mt-2"
+      onClick={onReScaffold}
+      disabled={actionPending}
+      data-testid="habit-re-scaffold-button"
+    >
+      Re-scaffold
+    </IonButton>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Recent completions
+// ---------------------------------------------------------------------------
+
+interface CompletionsProps {
+  completions: HabitCompletionItem[] | undefined;
+}
+
+const RecentCompletions: React.FC<CompletionsProps> = ({ completions }) => {
+  if (completions === undefined) {
+    return (
+      <section className="mt-6 px-4 text-sm text-neutral-400">
+        <h2 className="text-base font-medium">Recent completions</h2>
+        <p className="mt-1">Loading…</p>
+      </section>
+    );
+  }
+  if (completions.length === 0) {
+    return (
+      <section
+        className="mt-6 px-4 text-sm text-neutral-400"
+        data-testid="habit-completions-empty"
+      >
+        <h2 className="text-base font-medium">Recent completions</h2>
+        <p className="mt-1">No completions yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="mt-6" data-testid="habit-completions-list">
+      <h2 className="px-4 text-base font-medium">Recent completions</h2>
+      <IonList>
+        {completions.map((entry) => (
+          <CompletionRow key={entry.id} entry={entry} />
+        ))}
+      </IonList>
+    </section>
+  );
+};
+
+const CompletionRow: React.FC<{ entry: HabitCompletionItem }> = ({ entry }) => {
+  const dateLine = formatAbsoluteDate(entry.completed_at);
+  const relative = (() => {
+    try {
+      return formatDistanceToNowStrict(parseISO(entry.completed_at), {
+        addSuffix: true,
+      });
+    } catch {
+      return entry.completed_at;
+    }
+  })();
+  const subtitle =
+    entry.source === 'routine_cascade'
+      ? `${relative} · via routine`
+      : relative;
+  return (
+    <IonItem data-testid={`habit-completion-${entry.id}`}>
+      <IonLabel className="ion-text-wrap">
+        <h3>{dateLine}</h3>
+        <p>{subtitle}</p>
+        {entry.notes !== null ? (
+          <IonNote className="text-xs">{entry.notes}</IonNote>
+        ) : null}
+      </IonLabel>
+    </IonItem>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Action footer
+// ---------------------------------------------------------------------------
+
+interface ActionFooterProps {
+  habit: HabitDetailResponse;
+  actionPending: boolean;
+  onMarkComplete: () => void;
+  onPause: () => void;
+  onResume: () => void;
+}
+
+const ActionFooter: React.FC<ActionFooterProps> = ({
+  habit,
+  actionPending,
+  onMarkComplete,
+  onPause,
+  onResume,
+}) => {
+  const showMarkComplete: boolean = habit.status === 'active';
+  const showPause: boolean = habit.status === 'active';
+  const showResume: boolean = habit.status === 'paused';
+
+  return (
+    <section
+      className="mt-6 flex flex-col gap-2 px-4 pb-8"
+      data-testid="habit-action-footer"
+    >
+      {showMarkComplete ? (
+        <IonButton
+          color="primary"
+          onClick={onMarkComplete}
+          disabled={actionPending}
+          data-testid="habit-mark-complete-button"
+        >
+          Mark complete
+        </IonButton>
+      ) : null}
+      {showPause ? (
+        <IonButton
+          color="medium"
+          onClick={onPause}
+          disabled={actionPending}
+          data-testid="habit-pause-button"
+        >
+          Pause
+        </IonButton>
+      ) : null}
+      {showResume ? (
+        <IonButton
+          color="primary"
+          onClick={onResume}
+          disabled={actionPending}
+          data-testid="habit-resume-button"
+        >
+          Resume
+        </IonButton>
+      ) : null}
+      {habit.status === 'paused' ? (
+        <IonText color="medium" className="text-xs">
+          Paused — completions are not accepted.
+        </IonText>
+      ) : null}
+      {habit.status === 'graduated' ? (
+        <IonText color="medium" className="text-xs">
+          Graduated — completions are tracked but no longer affect streaks.
+        </IonText>
+      ) : null}
+      {habit.status === 'abandoned' ? (
+        <IonText color="medium" className="text-xs">
+          Abandoned.
+        </IonText>
+      ) : null}
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Not-found card
+// ---------------------------------------------------------------------------
+
+const NotFoundCard: React.FC<{ onBack: () => void }> = ({ onBack }) => (
+  <div
+    className="flex h-full w-full flex-col items-center justify-center px-4 text-center text-neutral-300"
+    data-testid="habit-not-found"
+  >
+    <p>Habit not found.</p>
+    <IonButton
+      fill="outline"
+      className="mt-3"
+      onClick={onBack}
+      data-testid="habit-not-found-back"
+    >
+      Back to habits
+    </IonButton>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAbsoluteDate(value: string): string {
+  try {
+    return format(parseISO(value), 'EEEE, MMMM d');
+  } catch {
+    return value;
+  }
+}
+
+function isOnline(): boolean {
+  if (typeof navigator === 'undefined') return true;
+  return navigator.onLine !== false;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'notFound' in error &&
+      (error as { notFound: unknown }).notFound === true,
+  );
+}
+
+export default HabitDetailPage;


### PR DESCRIPTION
## Summary

Resolves the dead `/habits/:id` link left by [2C-21]. The new `HabitDetailPage` renders four stacked sections inside an `IonContent`: a definition pane (status pill, title, description, frequency/streak/dates, optional routine link), a graduation dashboard with three per-status branches (tracking shows the summary line only; accountable shows progress bar + target marker + caption + days-to-threshold + step-down suggestion when eligible; graduated shows quiet "graduated" copy + re-scaffold button), a recent-completions list (limit 20), and an action footer (mark-complete via the [2C-23] queue; pause/resume PATCH; the lifecycle mutations).

The graduation, step-down, and re-scaffold endpoints are direct mutations rather than queue writes — they're discrete state transitions whose 422/409 details the UI surfaces and which are not idempotent retry candidates.

## Changes

- `src/lib/habit-detail.ts` — three GET fetchers (detail / graduation-status / completions), three direct mutations (`patchHabitStatus`, `postReScaffold`, `postStepDownFrequency`), and per-habit Capacitor Preferences caches under `brain.cache.habit.{id}` + `brain.cache.habit-graduation.{id}`. The cache write captures `fetched_at` so the page can thread it into TanStack Query's `initialDataUpdatedAt` and let the on-mount refetch fire (initialData alone reads as fresh — same gotcha [2C-21] flagged on its list cache).
- `src/pages/HabitDetailPage.tsx` — bootstrap pattern mirroring `HabitsPage` (loading → no-pairing → paired). The `DetailBody` owns three `useQuery` hooks (habit / graduation-status / completions) keyed independently so `mark-complete` can invalidate `["habits","active"]`, `["habit", id]`, `["habit-graduation", id]`, and `["habit-completions", id]` together. Lifecycle action handlers gate on `navigator.onLine` for the connection-required actions (re-scaffold, step-down) and surface result toasts via `IonToast`. `IonAlert` confirmations on pause/resume/re-scaffold per spec.
- `src/App.tsx` — wires `Route exact path="/habits/:habitId"` to `HabitDetailPage`.
- `src/lib/habit-detail.test.ts` — 11 unit tests covering the fetcher 200/401/404/422 paths, PATCH body shape, cache round-trip, and the nested-detail message extraction for step-down 422.
- `src/pages/HabitDetailPage.test.tsx` — 13 tests covering render-per-scaffolding-state, mark-complete flow, pause/resume flow, step-down flow (success + 422), re-scaffold flow + post-confirm navigation, not-found inline card, and offline guard for re-scaffold.

## How to Verify

1. From `develop`, check out `feat/2C-22-habit-detail-graduation`.
2. `npm run lint` — passes clean.
3. `npx vitest run` — 149 tests pass (15 files). Use `vitest run` directly per [2C-Bug-06] (#56); `npm run test.unit` enters watch mode in non-interactive shells.
4. `npx tsc --noEmit` — typecheck clean.
5. `npm run dev` and navigate to `/habits` (after pairing). Tap any habit row. The detail page should render the three sections and the action footer; pause/resume should round-trip via PATCH; for an accountable habit with `frequency_step_down.eligible === true` the step-down inline suggestion appears; for a graduated habit the re-scaffold button + confirm alert appear.

## Deviations

- **Recent completions endpoint gate is stale.** Issue body §Section 3 says: "this endpoint does not exist on `develop`. Implementation is gated on Escalation 1 resolving to Option A, which ships the endpoint as [2C-26]." Per the Group 3 brief and verified against `brain3` `develop`, [2C-26] / `brain3#206` merged in Group 2 — the endpoint is live at `app/routers/habits.py:294-319` (`GET /api/habits/{id}/completions`, accepts `limit` query, returns `list[HabitCompletionResponse]`). Implementing Section 3 per the spec's described behavior since the gate has resolved.
- **Description renders as plain text with `whitespace-pre-wrap`.** Spec says "markdown-rendered; reuse whatever primitive Chunk 4's [2C-19] used for check-in notes; if none exists, a light wrapper around `react-markdown` is fine." [2C-19] hasn't shipped yet so no shared primitive exists. Rather than introduce `react-markdown` as a single-consumer dep here, deferring to whichever of [2C-19] / [2C-22] follow-up lands the dep with multiple consumers. Line breaks in the description are preserved; explicit markdown syntax (e.g. `**bold**`) renders literally for now.
- **Test path is co-located.** Spec says `tests/unit/HabitDetailPage.spec.tsx`. Repo CLAUDE.md `Test Conventions` says co-locate (`src/pages/HabitDetailPage.test.tsx`) and explicitly phases out `tests/unit/`. Following the codified convention.
- **Warning surface (`subscribeHabitCompletionWarnings`) NOT wired.** Per the activation-prompt guidance: spec has no explicit hook for surfacing terminal `paused` / `not_found` warnings on this page, so deferring to [2C-25] (routine completion flow). Warning surface still deferred — no spec hook in [2C-22].
- **`IonAlert` and `IonToast` are mocked in the test file.** Their shadow-DOM rendering does not surface accessible names / message text through Testing Library queries in jsdom. The mocks replicate the prop contract via plain DOM (`role="alertdialog"`, `role="status"`) so the action paths can be exercised end-to-end. Production keeps the real Ionic implementations. Same constraint will hit [2C-24] / [2C-25] when they touch `IonAlert`; if a shared test helper is justified, [2C-25] is the natural site to introduce it.
- **Activation-prompt SHA reference.** Activation prompt says "Notable surfaces now live on develop from PR #59 (commit 1b15fab is the merge SHA)". `1b15fab` is actually PR #58's merge commit; PR #59 merged at `2e7ed66`. Not load-bearing for this work; flagging for the dispatch log.
- **Repo CLAUDE.md drift carry-forward.** Repo file is v2; BRAIN canonical is v3. Activation prompt called this out as a known carry-forward, not my responsibility to resolve.

## Test Results

`npm run lint` — exit 0, no output.

`npx vitest run --reporter=basic`:

```
 ✓ src/lib/device-registration.test.ts (13 tests) 10ms
 ✓ src/lib/completionQueues.routine.test.ts (13 tests) 12ms
 ✓ src/lib/habits.test.ts (13 tests) 22ms
 ✓ src/lib/completionQueues.habit.test.ts (8 tests) 11ms
 ✓ src/lib/habit-detail.test.ts (11 tests) 13ms
 ✓ src/lib/pairing.test.ts (8 tests) 6ms
 ✓ src/lib/health.test.ts (7 tests) 8ms
 ✓ src/lib/routines.test.ts (4 tests) 7ms
 ✓ src/lib/writeQueue.test.ts (22 tests) 17ms
 ✓ src/components/StatusPill.test.tsx (4 tests) 26ms
 ✓ src/lib/notifications.test.ts (16 tests) 11ms
 ✓ src/lib/local-date.test.ts (7 tests) 3ms
 ✓ src/App.test.tsx (1 test) 110ms
 ✓ src/pages/HabitsPage.test.tsx (9 tests) 507ms
 ✓ src/pages/HabitDetailPage.test.tsx (13 tests) 1119ms

 Test Files  15 passed (15)
      Tests  149 passed (149)
```

`npx tsc --noEmit` — exit 0, no output.

Compile-only / runtime Android gates not exercised on the agent dev env (no JDK + ANDROID_HOME). Per repo CLAUDE.md `Pre-PR Verification Gates`, the Dev Release workflow PR-trigger is queued in [2C-Gap-05] (#55) and not yet active, so the Android Gradle build is not exercised on this PR. This change is TS-only — no `android/` files modified, no Capacitor plugin added, no `npm run android:sync` needed.

## Acceptance Checklist

- [x] `/habits/{id}` loads, shows the three panes (definition, graduation, recent completions) in order. Unknown `habitId` → 404 surfaces as inline "Habit not found" card with a "Back to habits" action.
- [x] Tracking habits: graduation pane shows the tracking-state message only; no progress bar.
- [x] Accountable habits: graduation pane shows progress bar with target marker, days-to-threshold line when applicable, step-down suggestion when `frequency_step_down.eligible === true`.
- [x] Graduated habits: graduation pane shows "graduated" quietly, with a working "Re-scaffold" confirmation + execute flow.
- [x] "Mark complete" dispatches through [2C-23] queue; idempotent on same-day retry. Hidden for paused/graduated/abandoned.
- [x] "Pause" / "Resume" flows PATCH status correctly and re-render the button visibility.
- [x] Step-down suggestion only appears when `frequency_step_down.eligible === true`; tap fires the POST, UI reflects the new `notification_frequency` after cache invalidation.
- [x] Offline launch: cached panes render, "Showing cached data" hint visible. Re-scaffold and step-down require a live network and surface "Action requires connection" toast when offline.
- [x] `HabitDetailPage` test (co-located) covers: render per scaffolding state, mark-complete flow, pause/resume flow, step-down flow, re-scaffold flow, offline graceful degradation.

Closes #18
