### PR TITLE
[2C-24] App: Routine list view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
 import HabitsPage from './pages/HabitsPage';
 import HabitDetailPage from './pages/HabitDetailPage';
+import RoutinesPage from './pages/RoutinesPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -109,6 +110,9 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/habits/:habitId">
             <HabitDetailPage />
+          </Route>
+          <Route exact path="/routines">
+            <RoutinesPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/lib/routines.test.ts
+++ b/src/lib/routines.test.ts
@@ -1,14 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ROUTINES_PATH, fetchRoutine } from './routines';
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  ROUTINES_CACHE_KEY,
+  ROUTINES_PATH,
+  fetchActiveRoutines,
+  fetchRoutine,
+  readCachedRoutines,
+  sortRoutinesByTitle,
+  writeCachedRoutines,
+  type RoutineResponse,
+} from './routines';
 
 const PAIRING = {
   url: 'https://brain.local:8000',
   token: 'bearer-routine',
 } as const;
 
+const prefsStore = new Map<string, string>();
+
 beforeEach(() => {
-  vi.restoreAllMocks();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
 });
 
 afterEach(() => {
@@ -52,5 +80,121 @@ describe('fetchRoutine', () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('disconnected'));
     const result = await fetchRoutine(PAIRING, 'r-1');
     expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+});
+
+describe('fetchActiveRoutines', () => {
+  it('GETs /api/routines/?status=active and returns the items array', async () => {
+    const items: RoutineResponse[] = [
+      {
+        id: 'r-1',
+        title: 'Morning kit',
+        frequency: 'daily',
+        status: 'active',
+        current_streak: 3,
+        best_streak: 7,
+        last_completed: '2026-05-01',
+      },
+    ];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items, count: items.length }), { status: 200 }),
+    );
+
+    const result = await fetchActiveRoutines(PAIRING);
+
+    expect(result).toEqual({ ok: true, items });
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(`${PAIRING.url}${ROUTINES_PATH}?status=active`);
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${PAIRING.token}`);
+    expect(init?.method).toBe('GET');
+  });
+
+  it('returns an empty list when the response body is malformed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+    );
+    const result = await fetchActiveRoutines(PAIRING);
+    expect(result).toEqual({ ok: true, items: [] });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 401 }),
+    );
+    const result = await fetchActiveRoutines(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'unauthorized', statusCode: 401 });
+  });
+
+  it('returns server on 500', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 500 }),
+    );
+    const result = await fetchActiveRoutines(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'server', statusCode: 500 });
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('disconnected'));
+    const result = await fetchActiveRoutines(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+});
+
+describe('readCachedRoutines / writeCachedRoutines', () => {
+  it('round-trips items + fetched_at through Capacitor Preferences', async () => {
+    const items: RoutineResponse[] = [{ id: 'r-1', title: 'Morning kit' }];
+    const now = new Date('2026-05-02T10:00:00Z');
+
+    await writeCachedRoutines(items, now);
+    const read = await readCachedRoutines();
+
+    expect(read).toEqual({ fetched_at: now.toISOString(), items });
+    expect(prefsStore.get(ROUTINES_CACHE_KEY)).toBeDefined();
+  });
+
+  it('returns null when nothing has been cached', async () => {
+    const read = await readCachedRoutines();
+    expect(read).toBeNull();
+  });
+
+  it('returns null when the cache is malformed', async () => {
+    prefsStore.set(ROUTINES_CACHE_KEY, '{ this is not valid json');
+    const read = await readCachedRoutines();
+    expect(read).toBeNull();
+  });
+
+  it('returns null when the cache is missing required fields', async () => {
+    prefsStore.set(ROUTINES_CACHE_KEY, JSON.stringify({ items: [] }));
+    const read = await readCachedRoutines();
+    expect(read).toBeNull();
+  });
+});
+
+describe('sortRoutinesByTitle', () => {
+  it('returns a new array sorted alphabetically by title (locale-aware)', () => {
+    const items: RoutineResponse[] = [
+      { id: '1', title: 'Wind-down' },
+      { id: '2', title: 'Morning kit' },
+      { id: '3', title: 'Evening reset' },
+    ];
+
+    const sorted = sortRoutinesByTitle(items);
+
+    expect(sorted.map((r) => r.title)).toEqual([
+      'Evening reset',
+      'Morning kit',
+      'Wind-down',
+    ]);
+    // Pure: input array is not mutated.
+    expect(items.map((r) => r.title)).toEqual([
+      'Wind-down',
+      'Morning kit',
+      'Evening reset',
+    ]);
+  });
+
+  it('handles an empty list', () => {
+    expect(sortRoutinesByTitle([])).toEqual([]);
   });
 });

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -1,31 +1,58 @@
 /**
- * Routines data layer for [2C-21] habit list view.
+ * Routines data layer.
  *
- * Per-row routine-name resolution: each habit with a non-null `routine_id`
- * fans out a `GET /api/routines/{routine_id}` query keyed by the routine id
- * so TanStack Query deduplicates fetches across rows. Type shape follows
- * `app/schemas/routines.py` RoutineResponse on the brain3 server. Only the
- * fields [2C-21] consumes are typed — sibling tickets ([2C-22], [2C-24])
- * extend this module as their views surface more fields.
+ * Two read paths share this module:
  *
- * First-consumer-instantiates: this module is being introduced for the first
- * time by [2C-21]. The fetcher shape mirrors `lib/habits.ts` so the two
- * read-paths stay congruent for [2C-22] reuse.
+ * - Per-row routine-name resolution from [2C-21]: HabitsPage fans out
+ *   `GET /api/routines/{id}` per habit with a non-null `routine_id`. Only
+ *   `id` and `title` are read on that path.
+ * - Active-routines list from [2C-24]: RoutinesPage fetches
+ *   `GET /api/routines/?status=active` once and renders every field. Cache
+ *   pattern mirrors `lib/habits.ts` — JSON blob under a `brain.cache.*` key
+ *   with `fetched_at` provenance for the offline cache hint.
+ *
+ * Type shape mirrors `app/schemas/routines.py:75-92` (RoutineResponse) on the
+ * brain3 server. `RoutineDetailResponse` (which adds nested schedules) is the
+ * shape returned by GET /api/routines/{id}; for the list-view consumers here,
+ * the schedule list is unused so we model the base RoutineResponse only.
  */
 
+import { Preferences } from '@capacitor/preferences';
 import type { Pairing } from './pairing';
 
 export const ROUTINES_PATH = '/api/routines/';
+export const ROUTINES_CACHE_KEY = 'brain.cache.routines.active';
 
 const FETCH_TIMEOUT_MS = 10_000;
 
+export type RoutineFrequency =
+  | 'daily'
+  | 'weekdays'
+  | 'weekends'
+  | 'weekly'
+  | 'custom';
+export type RoutineStatus = 'active' | 'paused' | 'retired';
+
 export interface RoutineResponse {
   id: string;
+  domain_id?: string;
   title: string;
-  /**
-   * Additional fields exist server-side (domain_id, frequency, status,
-   * current_streak, etc.). Sibling tickets extend this interface as needed.
-   */
+  description?: string | null;
+  frequency?: RoutineFrequency;
+  status?: RoutineStatus;
+  energy_cost?: number | null;
+  activation_friction?: number | null;
+  current_streak?: number;
+  best_streak?: number;
+  /** YYYY-MM-DD device-local calendar date, or null if never completed. */
+  last_completed?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface RoutineListResponseBody {
+  items: RoutineResponse[];
+  count: number;
 }
 
 export type FetchRoutineResult =
@@ -33,6 +60,14 @@ export type FetchRoutineResult =
   | {
       ok: false;
       reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
+      statusCode?: number;
+    };
+
+export type FetchRoutinesResult =
+  | { ok: true; items: RoutineResponse[] }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout';
       statusCode?: number;
     };
 
@@ -70,4 +105,96 @@ export async function fetchRoutine(
   } finally {
     clearTimeout(timer);
   }
+}
+
+export async function fetchActiveRoutines(
+  pairing: Pairing,
+): Promise<FetchRoutinesResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${ROUTINES_PATH}?status=active`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as RoutineListResponseBody).items)
+          ? (body as RoutineListResponseBody).items
+          : [];
+      return { ok: true, items };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface CachedRoutines {
+  fetched_at: string;
+  items: RoutineResponse[];
+}
+
+export async function readCachedRoutines(): Promise<CachedRoutines | null> {
+  const { value } = await Preferences.get({ key: ROUTINES_CACHE_KEY });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'items' in parsed &&
+      'fetched_at' in parsed &&
+      Array.isArray((parsed as CachedRoutines).items) &&
+      typeof (parsed as CachedRoutines).fetched_at === 'string'
+    ) {
+      return parsed as CachedRoutines;
+    }
+  } catch {
+    // Fall through — treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedRoutines(
+  items: RoutineResponse[],
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedRoutines = {
+    fetched_at: now.toISOString(),
+    items,
+  };
+  await Preferences.set({
+    key: ROUTINES_CACHE_KEY,
+    value: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Sort routines alphabetically by title (ASC, locale-aware). Per spec [2C-24]
+ * Escalation 7: today-scheduled-first sort was rejected because the list
+ * endpoint does not return schedules inline. PO may overturn.
+ *
+ * Pure function — caller owns the input array.
+ */
+export function sortRoutinesByTitle(
+  items: RoutineResponse[],
+): RoutineResponse[] {
+  return [...items].sort((a, b) => a.title.localeCompare(b.title));
 }

--- a/src/pages/RoutinesPage.test.tsx
+++ b/src/pages/RoutinesPage.test.tsx
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: vi.fn(),
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../lib/local-date', async () => {
+  const actual = await vi.importActual<typeof import('../lib/local-date')>(
+    '../lib/local-date',
+  );
+  return {
+    ...actual,
+    todayLocalDate: () => '2026-05-02',
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  ROUTINES_CACHE_KEY,
+  type RoutineResponse,
+} from '../lib/routines';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import RoutinesPage from './RoutinesPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function seedCache(items: RoutineResponse[]): void {
+  prefsStore.set(
+    ROUTINES_CACHE_KEY,
+    JSON.stringify({ fetched_at: '2026-05-01T00:00:00Z', items }),
+  );
+}
+
+function makeRoutine(overrides: Partial<RoutineResponse> = {}): RoutineResponse {
+  return {
+    id: overrides.id ?? 'r-1',
+    title: overrides.title ?? 'Morning kit',
+    frequency: overrides.frequency ?? 'daily',
+    status: overrides.status ?? 'active',
+    current_streak: overrides.current_streak ?? 3,
+    best_streak: overrides.best_streak ?? 7,
+    last_completed: overrides.last_completed ?? '2026-05-01',
+  };
+}
+
+interface FetchOptions {
+  routinesResponse?: { status: number; items?: RoutineResponse[] };
+  routinesRejection?: Error;
+}
+
+function stubFetch(opts: FetchOptions = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/routines/')) {
+        if (opts.routinesRejection) throw opts.routinesRejection;
+        const r = opts.routinesResponse ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          return new Response(
+            JSON.stringify({
+              items: r.items ?? [],
+              count: (r.items ?? []).length,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response('', { status: r.status });
+      }
+      // ConnectionIndicator pings /api/health — return 200 to keep it quiet.
+      if (url.includes('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/routines']}>
+        <RoutinesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('RoutinesPage — bootstrap states', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RoutinesPage — list render', () => {
+  it('queries /api/routines/?status=active and renders each routine row', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: 'r-1', title: 'Morning kit', frequency: 'daily' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning kit')).toBeInTheDocument();
+    expect(screen.getByText('Daily')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-streak-r-1')).toHaveTextContent(
+      'Streak: 3 · Best: 7',
+    );
+
+    const routineFetch = fetchSpy.mock.calls
+      .map(([url]) => (typeof url === 'string' ? url : url.toString()))
+      .find((url) => url.includes('/api/routines/'));
+    expect(routineFetch).toBe(`${PAIRED_URL}/api/routines/?status=active`);
+  });
+
+  it('renders routines alphabetically by title', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: 'c', title: 'Wind-down' }),
+          makeRoutine({ id: 'a', title: 'Evening reset' }),
+          makeRoutine({ id: 'b', title: 'Morning kit' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    await screen.findByText('Wind-down');
+
+    const titles = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((el) => el.textContent);
+    expect(titles).toEqual(['Evening reset', 'Morning kit', 'Wind-down']);
+  });
+
+  it('renders each frequency value with the spec-mandated label', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: '1', title: 'A daily', frequency: 'daily' }),
+          makeRoutine({ id: '2', title: 'B weekdays', frequency: 'weekdays' }),
+          makeRoutine({ id: '3', title: 'C weekends', frequency: 'weekends' }),
+          makeRoutine({ id: '4', title: 'D weekly', frequency: 'weekly' }),
+          makeRoutine({ id: '5', title: 'E custom', frequency: 'custom' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('A daily')).toBeInTheDocument();
+    expect(screen.getByText('Daily')).toBeInTheDocument();
+    expect(screen.getByText('Weekdays')).toBeInTheDocument();
+    expect(screen.getByText('Weekends')).toBeInTheDocument();
+    expect(screen.getByText('Weekly')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+  });
+});
+
+describe('RoutinesPage — today completion pill', () => {
+  it('shows "Done today" (green) when last_completed equals today', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: 'r-1', title: 'Morning kit', last_completed: '2026-05-02' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning kit')).toBeInTheDocument();
+    expect(screen.getByTestId('today-pill-done-r-1')).toHaveTextContent(
+      'Done today',
+    );
+    expect(screen.queryByTestId('today-pill-not-yet-r-1')).toBeNull();
+  });
+
+  it('shows "Not yet" (gray) when last_completed is before today', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: 'r-1', title: 'Morning kit', last_completed: '2026-05-01' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning kit')).toBeInTheDocument();
+    expect(screen.getByTestId('today-pill-not-yet-r-1')).toHaveTextContent(
+      'Not yet',
+    );
+    expect(screen.queryByTestId('today-pill-done-r-1')).toBeNull();
+  });
+
+  it('shows "Not yet" when last_completed is null', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [
+          makeRoutine({ id: 'r-1', title: 'Morning kit', last_completed: null }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning kit')).toBeInTheDocument();
+    expect(screen.getByTestId('today-pill-not-yet-r-1')).toHaveTextContent(
+      'Not yet',
+    );
+  });
+});
+
+describe('RoutinesPage — empty state', () => {
+  it('shows the create-via-CLI message when there are no routines', async () => {
+    pair();
+    stubFetch({ routinesResponse: { status: 200, items: [] } });
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/no routines yet\. create routines via brain3/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RoutinesPage — navigation', () => {
+  it('navigates to /routines/{id} when a row is tapped', async () => {
+    pair();
+    stubFetch({
+      routinesResponse: {
+        status: 200,
+        items: [makeRoutine({ id: 'r-9', title: 'Evening reset' })],
+      },
+    });
+
+    renderPage();
+
+    const titleEl = await screen.findByText('Evening reset');
+    await userEvent.click(titleEl);
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith('/routines/r-9');
+    });
+  });
+});
+
+describe('RoutinesPage — offline cache render', () => {
+  it('renders cached items and the cache hint when the network fetch fails', async () => {
+    pair();
+    seedCache([
+      makeRoutine({
+        id: 'r-cache',
+        title: 'Cached routine',
+        current_streak: 2,
+        best_streak: 6,
+      }),
+    ]);
+    stubFetch({ routinesRejection: new Error('offline') });
+
+    renderPage();
+
+    // Cached item paints immediately from initialData.
+    expect(await screen.findByText('Cached routine')).toBeInTheDocument();
+
+    // The fetch failure surfaces the cache hint.
+    expect(
+      await screen.findByText(/showing cached data/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import {
+  useQuery,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { useHistory } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchActiveRoutines,
+  readCachedRoutines,
+  sortRoutinesByTitle,
+  writeCachedRoutines,
+  type RoutineFrequency,
+  type RoutineResponse,
+} from '../lib/routines';
+import { todayLocalDate } from '../lib/local-date';
+
+const ROUTINES_QUERY_KEY: QueryKey = ['routines', 'active'];
+const ROUTINES_STALE_MS = 5 * 60 * 1000;
+
+const FREQUENCY_LABEL: Record<RoutineFrequency, string> = {
+  daily: 'Daily',
+  weekdays: 'Weekdays',
+  weekends: 'Weekends',
+  weekly: 'Weekly',
+  custom: 'Custom',
+};
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedItems: RoutineResponse[] | null;
+      /**
+       * Epoch ms of the cache's `fetched_at`, threaded into TanStack Query as
+       * `initialDataUpdatedAt`. Without this, initialData is treated as just
+       * loaded and the on-mount refetch that hydrates the offline cache hint
+       * (and overwrites stale cache) never fires.
+       */
+      cachedFetchedAtMs: number | null;
+    };
+
+const RoutinesPage: React.FC = () => {
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cached] = await Promise.all([
+        loadPairing(),
+        readCachedRoutines(),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const cachedFetchedAtMs = cached?.fetched_at
+        ? Date.parse(cached.fetched_at)
+        : null;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedItems: cached?.items ?? null,
+        cachedFetchedAtMs: Number.isFinite(cachedFetchedAtMs)
+          ? cachedFetchedAtMs
+          : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Routines</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see routines.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <RoutinesBody
+            pairing={bootstrap.pairing}
+            initialCachedItems={bootstrap.cachedItems}
+            initialCachedFetchedAtMs={bootstrap.cachedFetchedAtMs}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  initialCachedItems: RoutineResponse[] | null;
+  initialCachedFetchedAtMs: number | null;
+}
+
+const RoutinesBody: React.FC<BodyProps> = ({
+  pairing,
+  initialCachedItems,
+  initialCachedFetchedAtMs,
+}) => {
+  const history = useHistory();
+
+  const routinesQuery = useQuery<RoutineResponse[]>({
+    queryKey: ROUTINES_QUERY_KEY,
+    queryFn: async () => {
+      const result = await fetchActiveRoutines(pairing);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedRoutines(result.items);
+      return result.items;
+    },
+    initialData: initialCachedItems ?? undefined,
+    initialDataUpdatedAt:
+      initialCachedItems !== null && initialCachedFetchedAtMs !== null
+        ? initialCachedFetchedAtMs
+        : undefined,
+    staleTime: ROUTINES_STALE_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  const items = routinesQuery.data;
+  const showCacheHint =
+    routinesQuery.isError && items !== undefined && items.length >= 0;
+
+  const sortedItems = useMemo(
+    () => (items ? sortRoutinesByTitle(items) : null),
+    [items],
+  );
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await routinesQuery.refetch();
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [routinesQuery],
+  );
+
+  const onRowClick = useCallback(
+    (routine: RoutineResponse): void => {
+      history.push(`/routines/${routine.id}`);
+    },
+    [history],
+  );
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      {showCacheHint ? (
+        <div
+          className="px-4 pt-3 text-sm text-neutral-300"
+          role="status"
+          aria-live="polite"
+        >
+          Showing cached data
+        </div>
+      ) : null}
+
+      {sortedItems && sortedItems.length === 0 ? (
+        <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+          <p>No routines yet. Create routines via brain3 CLI or API.</p>
+        </div>
+      ) : null}
+
+      {sortedItems && sortedItems.length > 0 ? (
+        <IonList>
+          {sortedItems.map((routine) => (
+            <RoutineRow
+              key={routine.id}
+              routine={routine}
+              onRowClick={onRowClick}
+            />
+          ))}
+        </IonList>
+      ) : null}
+    </>
+  );
+};
+
+interface RowProps {
+  routine: RoutineResponse;
+  onRowClick: (routine: RoutineResponse) => void;
+}
+
+function relativeLastCompleted(lastCompleted: string | null | undefined): string {
+  if (lastCompleted === null || lastCompleted === undefined) return 'never';
+  try {
+    return formatDistanceToNowStrict(parseISO(lastCompleted), {
+      addSuffix: true,
+    });
+  } catch {
+    return lastCompleted;
+  }
+}
+
+interface PillProps {
+  done: boolean;
+  routineId: string;
+}
+
+const TodayPill: React.FC<PillProps> = ({ done, routineId }) => {
+  const cls = done
+    ? 'bg-emerald-100 text-emerald-800 ring-emerald-200'
+    : 'bg-neutral-100 text-neutral-700 ring-neutral-300';
+  const label = done ? 'Done today' : 'Not yet';
+  return (
+    <span
+      data-testid={`today-pill-${done ? 'done' : 'not-yet'}-${routineId}`}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${cls}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+const RoutineRow: React.FC<RowProps> = ({ routine, onRowClick }) => {
+  const today = todayLocalDate();
+  const doneToday = routine.last_completed === today;
+  const frequencyLabel = routine.frequency
+    ? FREQUENCY_LABEL[routine.frequency]
+    : null;
+  const lastCompletedLabel = relativeLastCompleted(routine.last_completed);
+
+  return (
+    <IonItem
+      button
+      onClick={() => onRowClick(routine)}
+      data-testid={`routine-row-${routine.id}`}
+    >
+      <div slot="start" className="pe-2">
+        <TodayPill done={doneToday} routineId={routine.id} />
+      </div>
+      <IonLabel className="ion-text-wrap">
+        <h2>{routine.title}</h2>
+        {frequencyLabel ? <p>{frequencyLabel}</p> : null}
+        <p data-testid={`routine-streak-${routine.id}`}>
+          <IonText color="medium">
+            <small>
+              Streak: {routine.current_streak ?? 0} · Best:{' '}
+              {routine.best_streak ?? 0}
+            </small>
+          </IonText>
+        </p>
+      </IonLabel>
+      <IonNote slot="end" className="text-xs">
+        {lastCompletedLabel}
+      </IonNote>
+    </IonItem>
+  );
+};
+
+export default RoutinesPage;


### PR DESCRIPTION
## Summary

Adds the `/routines` route to the companion app: an active-routines list rendered alphabetically by title, with a binary "Done today" / "Not yet" pill computed client-side from `last_completed` against device-local today, the spec's frequency label, and a "Streak: X · Best: Y" line. Pull-to-refresh, offline-cache fallback via TanStack Query `initialData`, and an empty state are wired in. Tap a row to navigate to `/routines/{id}`, which `[2C-25]` will own.

## Changes

- **`src/lib/routines.ts`** — extended the existing module (which already carried a first-consumer comment inviting `[2C-22]` / `[2C-24]` to extend its types and fetchers). Added `RoutineFrequency` / `RoutineStatus` types, expanded `RoutineResponse` to the full `app/schemas/routines.py:75-92` server shape, and introduced `fetchActiveRoutines`, `readCachedRoutines`, `writeCachedRoutines`, `sortRoutinesByTitle`, plus the `ROUTINES_CACHE_KEY = 'brain.cache.routines.active'` constant. Existing `fetchRoutine` (used per-row by `[2C-21]` HabitsPage) is untouched.
- **`src/pages/RoutinesPage.tsx`** — new route component. Bootstrap-then-paired pattern mirrors `HabitsPage`: `loadPairing()` + `readCachedRoutines()` run in parallel during mount, then a `RoutinesBody` paints with TanStack `initialData` + `initialDataUpdatedAt` threaded through (the `[2C-21]` carry-forward — without `initialDataUpdatedAt`, the on-mount refetch never fires because TanStack treats the cache as fresh). Inline `TodayPill` for the binary leading pill — only consumer is this row; no abstraction beyond the row file.
- **`src/lib/routines.test.ts`** — added `fetchActiveRoutines`, cache round-trip, and `sortRoutinesByTitle` tests alongside the existing `fetchRoutine` tests.
- **`src/pages/RoutinesPage.test.tsx`** — new page test covering the AC bullet points: list render, alphabetical sort, frequency label values, binary pill state transitions (done today vs. before today vs. null), empty state, navigation on row tap, offline cache hint on fetch failure.
- **`src/App.tsx`** — wired `/routines` route. The `/routines/:routineId` detail route is intentionally not added here — that's `[2C-25]`'s contract.

## How to Verify

1. `cd brain3-companion && npm install`
2. `npm run lint` — should pass clean.
3. `npx vitest run src/lib/routines.test.ts src/pages/RoutinesPage.test.tsx` — should pass clean (25 tests across both files).
4. `npx vitest run` — full suite, 170 tests across 16 files (was 145 before this PR).
5. With BRAIN running locally and the app paired: navigate to `/routines`. Confirm list renders alphabetical by title, "Done today" pill is green when a routine's `last_completed` is the device-local date, otherwise "Not yet" is gray. Pull down to refresh. Tap a row — URL changes to `/routines/{id}` (renders blank until `[2C-25]` lands).

## Deviations

1. **Test file location.** Spec acceptance criteria names `tests/unit/RoutinesPage.spec.tsx`. Repo CLAUDE.md (v2 on disk, v3 in BRAIN) explicitly states tests are co-located with the module they test and that `tests/unit/` is being phased out — no new files there. Per directive `ba044399` (briefs/specs that conflict with repo CLAUDE.md follow CLAUDE.md), located at `src/pages/RoutinesPage.test.tsx`. The lib-level tests for `fetchActiveRoutines` / cache helpers / sort util live in the existing `src/lib/routines.test.ts` (extended in place rather than created at `routines.spec.tsx`).
2. **No quick-action button or flush-stop toast.** The activation prompt suggested mirroring `[2C-21]`'s quick-complete button + queued-retry toast (consuming `enqueueRoutineCompletion` + `flushAllQueues` from `[2C-23]`). Issue #19 spec contradicts this: tap → `/routines/{id}` is the only interaction and the routine completion flow lives in `[2C-25]`. Followed the spec — this list view does not import `lib/completionQueues` and does not enqueue or flush. The activation prompt's hint that the queue infrastructure is consumed in `[2C-24]` was preempted by the spec.
3. **No active-vs-paused section split.** The activation prompt suggested a section split mirroring `[2C-21]`'s tracking/graduated split. Spec uses `?status=active` to filter paused at the server boundary and renders a flat alphabetical list. Followed spec.
4. **No `subscribeRoutineCompletionWarnings` UI consumer.** Already covered by the activation prompt — flagging for the deviation log so the `[2C-25]` dispatcher can confirm that surface lands there. The `[2C-23]` warning subscribe API has no UI consumer in this PR.
5. **Directive resolution gap (logging-only, no action).** The brief and activation prompt cite three directive IDs by number: `5cb98368` Shape A (codebase verification before authoring), `55e13fd1` (verification evidence in PR body), and `4ea28266` (CLAUDE.md PO-controlled). When I called `resolve_directives(scope_ref="<desmond-ops tag UUID>")`, `5cb98368` and `4ea28266` resolved cleanly in the global set; `55e13fd1` did not appear, and `skill_directives` / `agent_directives` came back empty. The substance is covered by org CLAUDE.md v6's mandatory Test Results section, so this PR satisfies the requirement either way — flagging the resolve gap as observation only. Likely a skill-scoped directive that needs an explicit `skill_id`, or a stale citation in the brief.

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint
(no output — clean)

$ npx vitest run
 ✓ src/lib/routines.test.ts (15 tests) 13ms
 ✓ src/pages/RoutinesPage.test.tsx (10 tests) 331ms
 ✓ src/lib/device-registration.test.ts (13 tests)
 ✓ src/lib/writeQueue.test.ts (22 tests)
 ✓ src/lib/completionQueues.routine.test.ts (13 tests)
 ✓ src/lib/habit-detail.test.ts (11 tests)
 ✓ src/lib/completionQueues.habit.test.ts (8 tests)
 ✓ src/lib/habits.test.ts (13 tests)
 ✓ src/lib/pairing.test.ts (8 tests)
 ✓ src/lib/health.test.ts (7 tests)
 ✓ src/components/StatusPill.test.tsx (4 tests)
 ✓ src/lib/notifications.test.ts (16 tests)
 ✓ src/lib/local-date.test.ts (7 tests)
 ✓ src/App.test.tsx (1 test)
 ✓ src/pages/HabitsPage.test.tsx (9 tests)
 ✓ src/pages/HabitDetailPage.test.tsx (13 tests)

 Test Files  16 passed (16)
      Tests  170 passed (170)
```

**Agent-environment caveat.** Per repo CLAUDE.md "Pre-PR Verification Gates", `npm run android:build:debug` is the compile-only safety gate — but this dev environment has no JDK + ANDROID_HOME, so that gate ran blind. The PR-trigger Dev Release CI workflow (`[2C-Gap-05]` #55) is queued, not yet active. This PR does not touch `android/`, does not add or change any Capacitor plugins, and does not modify `capacitor.config.ts` — `npm run android:sync` is not required and was not run. The compile-only failure surface that the Android Gradle build catches (the Bug-02 / Bug-03 class) does not apply to this TS-only change.

**Manual verification.** Issue #19 has no `#### Manual verification` section. Per repo CLAUDE.md "Stream C Specifics" — _"If the issue body has no MV section, no MV obligations apply for that ticket. Auto-verifiable tickets are valid without MV."_ — none preserved.

## Acceptance Checklist

- [x] `/routines` loads, shows all active routines alphabetically with today's-completion pill computed from `last_completed`.
- [x] Paused routines (`status === 'paused'`) are NOT in the list (filter `?status=active`).
- [x] Empty state renders when no active routines exist.
- [x] Offline launch renders cached list with stale hint.
- [x] Tap → navigates to `/routines/{id}`.
- [x] Test file covers: list render, binary pill state transitions, empty state, offline cache. (Located at `src/pages/RoutinesPage.test.tsx` per repo CLAUDE.md co-location rule — see Deviation 1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)