### PR TITLE
[2C-25] App: Routine completion flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import NotificationsPage from './pages/NotificationsPage';
 import HabitsPage from './pages/HabitsPage';
 import HabitDetailPage from './pages/HabitDetailPage';
 import RoutinesPage from './pages/RoutinesPage';
+import RoutineDetailPage from './pages/RoutineDetailPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -113,6 +114,9 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/routines">
             <RoutinesPage />
+          </Route>
+          <Route exact path="/routines/:routineId">
+            <RoutineDetailPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -13,9 +13,13 @@ import {
   HABITS_CACHE_KEY,
   HABITS_PATH,
   fetchActiveHabits,
+  fetchActiveHabitsByRoutine,
+  habitsByRoutineCacheKey,
   partitionAndSortHabits,
   readCachedHabits,
+  readCachedHabitsByRoutine,
   writeCachedHabits,
+  writeCachedHabitsByRoutine,
   type HabitResponse,
 } from './habits';
 
@@ -173,6 +177,77 @@ describe('readCachedHabits / writeCachedHabits', () => {
   it('returns null when cache is missing required keys', async () => {
     prefsStore.set(HABITS_CACHE_KEY, JSON.stringify({ items: [] }));
     expect(await readCachedHabits()).toBeNull();
+  });
+});
+
+describe('fetchActiveHabitsByRoutine', () => {
+  it('GETs /api/habits/?routine_id={id}&status=active with bearer auth', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+    );
+
+    const result = await fetchActiveHabitsByRoutine(PAIRING, 'r-1');
+
+    expect(result).toEqual({ ok: true, items: [] });
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(
+      `${PAIRING.url}${HABITS_PATH}?routine_id=r-1&status=active`,
+    );
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${PAIRING.token}`);
+    expect(init?.method).toBe('GET');
+  });
+
+  it('returns the items list from the envelope', async () => {
+    const habit = makeHabit({ id: 'h-9', routine_id: 'r-1' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [habit], count: 1 }), { status: 200 }),
+    );
+    const result = await fetchActiveHabitsByRoutine(PAIRING, 'r-1');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe('h-9');
+    }
+  });
+
+  it('encodes the routine_id query parameter', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+    );
+    await fetchActiveHabitsByRoutine(PAIRING, 'r with spaces');
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toContain('routine_id=r%20with%20spaces');
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'));
+    const result = await fetchActiveHabitsByRoutine(PAIRING, 'r-1');
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+});
+
+describe('readCachedHabitsByRoutine / writeCachedHabitsByRoutine', () => {
+  it('round-trips items + fetched_at under the per-routine cache key', async () => {
+    const habit = makeHabit({ id: 'h-1', routine_id: 'r-1' });
+    const now = new Date('2026-05-02T12:00:00Z');
+
+    await writeCachedHabitsByRoutine('r-1', [habit], now);
+    const cached = await readCachedHabitsByRoutine('r-1');
+
+    expect(cached).not.toBeNull();
+    expect(cached?.fetched_at).toBe(now.toISOString());
+    expect(cached?.items).toEqual([habit]);
+    expect(prefsStore.has(habitsByRoutineCacheKey('r-1'))).toBe(true);
+  });
+
+  it('returns null when no cache exists', async () => {
+    expect(await readCachedHabitsByRoutine('r-missing')).toBeNull();
+  });
+
+  it('returns null on malformed cache JSON', async () => {
+    prefsStore.set(habitsByRoutineCacheKey('r-bad'), '{ not json');
+    expect(await readCachedHabitsByRoutine('r-bad')).toBeNull();
   });
 });
 

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -17,6 +17,8 @@ import type { Pairing } from './pairing';
 
 export const HABITS_CACHE_KEY = 'brain.cache.habits.active';
 export const HABITS_PATH = '/api/habits/';
+export const habitsByRoutineCacheKey = (routineId: string): string =>
+  `brain.cache.habits.byRoutine.${routineId}`;
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -115,6 +117,51 @@ export async function fetchActiveHabits(
   }
 }
 
+/**
+ * Fetch the active habits that belong to a specific routine. The brain3
+ * habits router treats `routine_id` as a query filter, so this is the same
+ * list endpoint as `fetchActiveHabits` with one extra constraint.
+ */
+export async function fetchActiveHabitsByRoutine(
+  pairing: Pairing,
+  routineId: string,
+): Promise<FetchHabitsResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${HABITS_PATH}?routine_id=${encodeURIComponent(routineId)}&status=active`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as HabitListResponseBody).items)
+          ? (body as HabitListResponseBody).items
+          : [];
+      return { ok: true, items };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export interface CachedHabits {
   fetched_at: string;
   items: HabitResponse[];
@@ -151,6 +198,56 @@ export async function writeCachedHabits(
   };
   await Preferences.set({
     key: HABITS_CACHE_KEY,
+    value: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Per-routine habits cache used by [2C-25] RoutineDetailPage. Mirrors the
+ * `readCachedHabits` shape but partitioned by `routineId` so each routine's
+ * checklist hydrates from its own slot.
+ */
+export interface CachedHabitsByRoutine {
+  fetched_at: string;
+  items: HabitResponse[];
+}
+
+export async function readCachedHabitsByRoutine(
+  routineId: string,
+): Promise<CachedHabitsByRoutine | null> {
+  const { value } = await Preferences.get({
+    key: habitsByRoutineCacheKey(routineId),
+  });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'items' in parsed &&
+      'fetched_at' in parsed &&
+      Array.isArray((parsed as CachedHabitsByRoutine).items) &&
+      typeof (parsed as CachedHabitsByRoutine).fetched_at === 'string'
+    ) {
+      return parsed as CachedHabitsByRoutine;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedHabitsByRoutine(
+  routineId: string,
+  items: HabitResponse[],
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedHabitsByRoutine = {
+    fetched_at: now.toISOString(),
+    items,
+  };
+  await Preferences.set({
+    key: habitsByRoutineCacheKey(routineId),
     value: JSON.stringify(payload),
   });
 }

--- a/src/lib/routines.test.ts
+++ b/src/lib/routines.test.ts
@@ -10,10 +10,16 @@ import {
   ROUTINES_PATH,
   fetchActiveRoutines,
   fetchRoutine,
+  fetchRoutineDetail,
+  readCachedRoutineDetail,
   readCachedRoutines,
+  routineDetailCacheKey,
   sortRoutinesByTitle,
+  writeCachedRoutineDetail,
   writeCachedRoutines,
+  type RoutineDetailResponse,
   type RoutineResponse,
+  type RoutineScheduleResponse,
 } from './routines';
 
 const PAIRING = {
@@ -168,6 +174,99 @@ describe('readCachedRoutines / writeCachedRoutines', () => {
     prefsStore.set(ROUTINES_CACHE_KEY, JSON.stringify({ items: [] }));
     const read = await readCachedRoutines();
     expect(read).toBeNull();
+  });
+});
+
+describe('fetchRoutineDetail', () => {
+  it('GETs /api/routines/{id} and parses RoutineDetailResponse with schedules', async () => {
+    const schedule: RoutineScheduleResponse = {
+      id: 's-1',
+      routine_id: 'r-1',
+      day_of_week: 'weekdays',
+      time_of_day: '07:00',
+      preferred_window: null,
+    };
+    const detail: RoutineDetailResponse = {
+      id: 'r-1',
+      title: 'Morning kit',
+      schedules: [schedule],
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(detail), { status: 200 }),
+    );
+
+    const result = await fetchRoutineDetail(PAIRING, 'r-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.routine.title).toBe('Morning kit');
+      expect(result.routine.schedules).toEqual([schedule]);
+    }
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url as string).toBe(`${PAIRING.url}${ROUTINES_PATH}r-1`);
+  });
+
+  it('defaults schedules to [] when the server omits the field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'r-1', title: 'Bare' }), { status: 200 }),
+    );
+    const result = await fetchRoutineDetail(PAIRING, 'r-1');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.routine.schedules).toEqual([]);
+    }
+  });
+
+  it('returns not_found on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
+    const result = await fetchRoutineDetail(PAIRING, 'missing');
+    expect(result).toEqual({
+      ok: false,
+      reason: 'not_found',
+      statusCode: 404,
+    });
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('disconnected'));
+    const result = await fetchRoutineDetail(PAIRING, 'r-1');
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+});
+
+describe('readCachedRoutineDetail / writeCachedRoutineDetail', () => {
+  it('round-trips a routine + fetched_at under the per-routine cache key', async () => {
+    const detail: RoutineDetailResponse = {
+      id: 'r-9',
+      title: 'Wind-down',
+      schedules: [],
+    };
+    const now = new Date('2026-05-02T11:00:00Z');
+
+    await writeCachedRoutineDetail('r-9', detail, now);
+    const read = await readCachedRoutineDetail('r-9');
+
+    expect(read).toEqual({ fetched_at: now.toISOString(), routine: detail });
+    expect(prefsStore.get(routineDetailCacheKey('r-9'))).toBeDefined();
+  });
+
+  it('returns null when the cache is empty', async () => {
+    expect(await readCachedRoutineDetail('r-missing')).toBeNull();
+  });
+
+  it('returns null when the cache is malformed', async () => {
+    prefsStore.set(routineDetailCacheKey('r-bad'), '{ not json');
+    expect(await readCachedRoutineDetail('r-bad')).toBeNull();
+  });
+
+  it('returns null when the cache is missing required fields', async () => {
+    prefsStore.set(
+      routineDetailCacheKey('r-bad2'),
+      JSON.stringify({ routine: { id: 'r' } }),
+    );
+    expect(await readCachedRoutineDetail('r-bad2')).toBeNull();
   });
 });
 

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -22,6 +22,8 @@ import type { Pairing } from './pairing';
 
 export const ROUTINES_PATH = '/api/routines/';
 export const ROUTINES_CACHE_KEY = 'brain.cache.routines.active';
+export const routineDetailCacheKey = (routineId: string): string =>
+  `brain.cache.routine.${routineId}`;
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -50,6 +52,28 @@ export interface RoutineResponse {
   updated_at?: string;
 }
 
+export interface RoutineScheduleResponse {
+  id: string;
+  routine_id: string;
+  day_of_week: string | null;
+  time_of_day: string | null;
+  preferred_window: string | null;
+}
+
+/**
+ * RoutineDetailResponse is the shape returned by GET /api/routines/{id}, which
+ * includes the nested schedules joined via SQLAlchemy joinedload (per
+ * `app/routers/routines.py:95-106`). The base list endpoint does not include
+ * schedules, so this is a superset of RoutineResponse.
+ *
+ * The existing per-row `fetchRoutine` from [2C-21] keeps its RoutineResponse
+ * return type (callers there only read id + title); [2C-25] adds
+ * `fetchRoutineDetail` that parses to this richer shape for the detail page.
+ */
+export interface RoutineDetailResponse extends RoutineResponse {
+  schedules: RoutineScheduleResponse[];
+}
+
 interface RoutineListResponseBody {
   items: RoutineResponse[];
   count: number;
@@ -57,6 +81,14 @@ interface RoutineListResponseBody {
 
 export type FetchRoutineResult =
   | { ok: true; routine: RoutineResponse }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
+      statusCode?: number;
+    };
+
+export type FetchRoutineDetailResult =
+  | { ok: true; routine: RoutineDetailResponse }
   | {
       ok: false;
       reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
@@ -89,6 +121,48 @@ export async function fetchRoutine(
     if (response.status === 200) {
       const body = (await response.json()) as RoutineResponse;
       return { ok: true, routine: body };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchRoutineDetail(
+  pairing: Pairing,
+  routineId: string,
+): Promise<FetchRoutineDetailResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${ROUTINES_PATH}${routineId}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as RoutineDetailResponse;
+      // Server always returns a schedules list (possibly empty). Defensive
+      // default for older payloads or test fixtures that omit it.
+      const routine: RoutineDetailResponse = {
+        ...body,
+        schedules: Array.isArray(body.schedules) ? body.schedules : [],
+      };
+      return { ok: true, routine };
     }
     if (response.status === 401) {
       return { ok: false, reason: 'unauthorized', statusCode: 401 };
@@ -197,4 +271,52 @@ export function sortRoutinesByTitle(
   items: RoutineResponse[],
 ): RoutineResponse[] {
   return [...items].sort((a, b) => a.title.localeCompare(b.title));
+}
+
+// ---------------------------------------------------------------------------
+// Per-routine detail cache (used by [2C-25] RoutineDetailPage)
+// ---------------------------------------------------------------------------
+
+export interface CachedRoutineDetail {
+  fetched_at: string;
+  routine: RoutineDetailResponse;
+}
+
+export async function readCachedRoutineDetail(
+  routineId: string,
+): Promise<CachedRoutineDetail | null> {
+  const { value } = await Preferences.get({
+    key: routineDetailCacheKey(routineId),
+  });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'routine' in parsed &&
+      'fetched_at' in parsed &&
+      typeof (parsed as CachedRoutineDetail).fetched_at === 'string'
+    ) {
+      return parsed as CachedRoutineDetail;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedRoutineDetail(
+  routineId: string,
+  routine: RoutineDetailResponse,
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedRoutineDetail = {
+    fetched_at: now.toISOString(),
+    routine,
+  };
+  await Preferences.set({
+    key: routineDetailCacheKey(routineId),
+    value: JSON.stringify(payload),
+  });
 }

--- a/src/pages/HabitDetailPage.test.tsx
+++ b/src/pages/HabitDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route } from 'react-router-dom';
@@ -94,14 +94,30 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const { enqueueSpy, flushSpy } = vi.hoisted(() => ({
-  enqueueSpy: vi.fn(),
-  flushSpy: vi.fn(),
-}));
+const {
+  enqueueSpy,
+  flushSpy,
+  subscribeHabitWarningSpy,
+  latestHabitWarningListener,
+} = vi.hoisted(() => {
+  const ref: { current: ((w: unknown) => void) | null } = { current: null };
+  return {
+    enqueueSpy: vi.fn(),
+    flushSpy: vi.fn(),
+    subscribeHabitWarningSpy: vi.fn((listener: (w: unknown) => void) => {
+      ref.current = listener;
+      return () => {
+        ref.current = null;
+      };
+    }),
+    latestHabitWarningListener: ref,
+  };
+});
 
 vi.mock('../lib/completionQueues', () => ({
   enqueueHabitCompletion: enqueueSpy,
   flushAllQueues: flushSpy,
+  subscribeHabitCompletionWarnings: subscribeHabitWarningSpy,
 }));
 
 vi.mock('../lib/local-date', async () => {
@@ -168,6 +184,8 @@ beforeEach(() => {
   replaceSpy.mockReset();
   enqueueSpy.mockReset().mockResolvedValue(undefined);
   flushSpy.mockReset().mockResolvedValue(successFlush);
+  subscribeHabitWarningSpy.mockClear();
+  latestHabitWarningListener.current = null;
 
   vi.mocked(Preferences.get).mockReset();
   vi.mocked(Preferences.set).mockReset();
@@ -739,6 +757,69 @@ describe('HabitDetailPage — re-scaffold', () => {
     await waitFor(() => {
       expect(replaceSpy).toHaveBeenCalledWith('/habits');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warning surface (Group 3 close-ledger carry-forward — see [2C-25] PR body)
+// ---------------------------------------------------------------------------
+
+describe('HabitDetailPage — warning surface', () => {
+  it('subscribes on mount and surfaces a danger toast when paused fires for this habit', async () => {
+    pair();
+    stubFetch();
+
+    renderPage();
+
+    await screen.findByTestId('habit-mark-complete-button');
+    expect(subscribeHabitWarningSpy).toHaveBeenCalled();
+    expect(latestHabitWarningListener.current).not.toBeNull();
+
+    await act(async () => {
+      latestHabitWarningListener.current?.({
+        kind: 'paused',
+        habit_id: HABIT_ID,
+      });
+    });
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/habit is paused/i);
+    expect(toast).toHaveAttribute('data-color', 'danger');
+  });
+
+  it('surfaces the not_found warning copy', async () => {
+    pair();
+    stubFetch();
+
+    renderPage();
+
+    await screen.findByTestId('habit-mark-complete-button');
+    await act(async () => {
+      latestHabitWarningListener.current?.({
+        kind: 'not_found',
+        habit_id: HABIT_ID,
+      });
+    });
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/habit no longer exists/i);
+  });
+
+  it('ignores warnings for a different habit_id', async () => {
+    pair();
+    stubFetch();
+
+    renderPage();
+
+    await screen.findByTestId('habit-mark-complete-button');
+    await act(async () => {
+      latestHabitWarningListener.current?.({
+        kind: 'paused',
+        habit_id: 'other-habit',
+      });
+    });
+
+    expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
   });
 });
 

--- a/src/pages/HabitDetailPage.tsx
+++ b/src/pages/HabitDetailPage.tsx
@@ -49,6 +49,8 @@ import {
 import {
   enqueueHabitCompletion,
   flushAllQueues,
+  subscribeHabitCompletionWarnings,
+  type HabitCompletionWarning,
 } from '../lib/completionQueues';
 import { todayLocalDate } from '../lib/local-date';
 
@@ -255,6 +257,23 @@ const DetailBody: React.FC<BodyProps> = ({
     habitQuery.isError &&
     !isNotFoundError(habitQuery.error) &&
     habit !== undefined;
+
+  // Wire the [2C-23] habit-completion warning subscription. Per the Group 3
+  // close ledger this surface lands in [2C-25] alongside the routine warning
+  // surface in RoutineDetailPage — see PR body Deviation §1 + §2.
+  useEffect(() => {
+    const unsubscribe = subscribeHabitCompletionWarnings(
+      (warning: HabitCompletionWarning) => {
+        if (warning.habit_id !== habitId) return;
+        const message =
+          warning.kind === 'paused'
+            ? 'Habit is paused — completion was discarded'
+            : 'Habit no longer exists — completion was discarded';
+        setToast({ open: true, message, color: 'danger' });
+      },
+    );
+    return () => unsubscribe();
+  }, [habitId]);
 
   const handleRefresh = useCallback(
     async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
@@ -554,7 +573,7 @@ const DetailBody: React.FC<BodyProps> = ({
         isOpen={toast.open}
         message={toast.message}
         color={toast.color}
-        duration={3000}
+        duration={toast.color === 'danger' ? 5000 : 3000}
         onDidDismiss={() => setToast({ open: false, message: '' })}
       />
     </>

--- a/src/pages/RoutineDetailPage.test.tsx
+++ b/src/pages/RoutineDetailPage.test.tsx
@@ -1,0 +1,756 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+// Replace shadow-DOM Ionic components that jsdom cannot exercise. Same
+// approach as HabitDetailPage.test.tsx; here we additionally stub IonCheckbox
+// + IonTextarea + IonFooter so checkbox state and the textarea value are
+// queryable / settable through standard DOM APIs.
+vi.mock('@ionic/react', async () => {
+  const actual = await vi.importActual<typeof import('@ionic/react')>(
+    '@ionic/react',
+  );
+  interface IonToastProps {
+    isOpen: boolean;
+    message?: string;
+    color?: string;
+    onDidDismiss?: () => void;
+  }
+  interface IonCheckboxProps {
+    checked: boolean;
+    onIonChange?: () => void;
+    'aria-label'?: string;
+    'data-testid'?: string;
+    slot?: string;
+  }
+  interface IonTextareaProps {
+    value?: string;
+    placeholder?: string;
+    maxlength?: number;
+    rows?: number;
+    autoGrow?: boolean;
+    'data-testid'?: string;
+    onIonInput?: (e: { detail: { value: string | null } }) => void;
+  }
+  interface IonFooterProps {
+    children?: React.ReactNode;
+  }
+  const IonToast: React.FC<IonToastProps> = ({ isOpen, message, color }) =>
+    isOpen ? (
+      <div role="status" data-testid="toast" data-color={color ?? ''}>
+        {message ?? ''}
+      </div>
+    ) : null;
+  const IonCheckbox: React.FC<IonCheckboxProps> = ({
+    checked,
+    onIonChange,
+    ...rest
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={() => onIonChange?.()}
+      aria-label={rest['aria-label']}
+      data-testid={rest['data-testid']}
+    />
+  );
+  const IonTextarea = forwardRef<
+    { setFocus: () => Promise<void> },
+    IonTextareaProps
+  >((props, ref) => {
+    const localRef = useRef<HTMLTextAreaElement | null>(null);
+    useImperativeHandle(
+      ref,
+      () => ({
+        setFocus: async () => {
+          localRef.current?.focus();
+        },
+      }),
+      [],
+    );
+    return (
+      <textarea
+        ref={localRef}
+        value={props.value ?? ''}
+        placeholder={props.placeholder}
+        maxLength={props.maxlength}
+        rows={props.rows}
+        data-testid={props['data-testid']}
+        onChange={(e) =>
+          props.onIonInput?.({ detail: { value: e.target.value } })
+        }
+      />
+    );
+  });
+  IonTextarea.displayName = 'IonTextarea';
+  const IonFooter: React.FC<IonFooterProps> = ({ children }) => (
+    <div data-testid="ion-footer">{children}</div>
+  );
+  return { ...actual, IonToast, IonCheckbox, IonTextarea, IonFooter };
+});
+
+const { replaceSpy, pushSpy } = vi.hoisted(() => ({
+  replaceSpy: vi.fn(),
+  pushSpy: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: replaceSpy,
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+const { enqueueSpy, flushSpy, subscribeRoutineWarningSpy, latestRoutineWarningListener } =
+  vi.hoisted(() => {
+    const ref: { current: ((w: unknown) => void) | null } = { current: null };
+    return {
+      enqueueSpy: vi.fn(),
+      flushSpy: vi.fn(),
+      subscribeRoutineWarningSpy: vi.fn((listener: (w: unknown) => void) => {
+        ref.current = listener;
+        return () => {
+          ref.current = null;
+        };
+      }),
+      latestRoutineWarningListener: ref,
+    };
+  });
+
+vi.mock('../lib/completionQueues', () => ({
+  enqueueRoutineCompletion: enqueueSpy,
+  flushAllQueues: flushSpy,
+  subscribeRoutineCompletionWarnings: subscribeRoutineWarningSpy,
+}));
+
+vi.mock('../lib/local-date', async () => {
+  const actual = await vi.importActual<typeof import('../lib/local-date')>(
+    '../lib/local-date',
+  );
+  return {
+    ...actual,
+    todayLocalDate: () => '2026-05-02',
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import type { HabitResponse } from '../lib/habits';
+import type {
+  RoutineDetailResponse,
+  RoutineScheduleResponse,
+} from '../lib/routines';
+import RoutineDetailPage from './RoutineDetailPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+const ROUTINE_ID = 'r-1';
+
+const prefsStore = new Map<string, string>();
+
+const successFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 1,
+    delivered: 1,
+    remaining: 0,
+    coalesced: false,
+  },
+};
+
+const stopFlush = {
+  notifications: { attempted: 0, delivered: 0, remaining: 0 },
+  habitCompletions: {
+    attempted: 0,
+    delivered: 0,
+    remaining: 0,
+    coalesced: false,
+  },
+  routineCompletions: {
+    attempted: 1,
+    delivered: 0,
+    remaining: 1,
+    coalesced: false,
+  },
+};
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+  enqueueSpy.mockReset().mockResolvedValue(undefined);
+  flushSpy.mockReset().mockResolvedValue(successFlush);
+  subscribeRoutineWarningSpy.mockClear();
+  latestRoutineWarningListener.current = null;
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeRoutine(
+  overrides: Partial<RoutineDetailResponse> = {},
+): RoutineDetailResponse {
+  return {
+    id: ROUTINE_ID,
+    title: 'Morning kit',
+    description: 'Three things before coffee',
+    frequency: 'weekdays',
+    status: 'active',
+    current_streak: 3,
+    best_streak: 7,
+    last_completed: '2026-05-01',
+    schedules: [],
+    ...overrides,
+  };
+}
+
+function makeSchedule(
+  overrides: Partial<RoutineScheduleResponse> = {},
+): RoutineScheduleResponse {
+  return {
+    id: 's-1',
+    routine_id: ROUTINE_ID,
+    day_of_week: 'weekdays',
+    time_of_day: '07:00',
+    preferred_window: null,
+    ...overrides,
+  };
+}
+
+function makeHabit(
+  id: string,
+  overrides: Partial<HabitResponse> = {},
+): HabitResponse {
+  return {
+    id,
+    routine_id: ROUTINE_ID,
+    title: `Habit ${id}`,
+    description: null,
+    status: 'active',
+    frequency: 'daily',
+    notification_frequency: 'daily',
+    scaffolding_status: 'tracking',
+    accountable_since: null,
+    graduation_window: null,
+    graduation_target: null,
+    graduation_threshold: null,
+    friction_score: null,
+    position: null,
+    re_scaffold_count: 0,
+    last_frequency_changed_at: null,
+    graduated_at: null,
+    current_streak: 0,
+    best_streak: 0,
+    last_completed: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    effective_graduation_params: {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+    ...overrides,
+  };
+}
+
+interface FetchOpts {
+  routine?: { status: number; body?: RoutineDetailResponse };
+  habits?: { status: number; body?: HabitResponse[] };
+}
+
+function stubFetch(opts: FetchOpts = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (
+        url.includes(`/api/routines/${ROUTINE_ID}`) &&
+        !url.includes('/complete') &&
+        !url.includes('/completions') &&
+        !url.includes('/schedules') &&
+        method === 'GET'
+      ) {
+        const r = opts.routine ?? { status: 200, body: makeRoutine() };
+        return new Response(
+          r.body !== undefined ? JSON.stringify(r.body) : '',
+          { status: r.status },
+        );
+      }
+      if (url.includes(`routine_id=${ROUTINE_ID}`) && method === 'GET') {
+        const items = opts.habits?.body ?? [];
+        const status = opts.habits?.status ?? 200;
+        return new Response(JSON.stringify({ items, count: items.length }), {
+          status,
+        });
+      }
+      if (url.includes('/api/health')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/routines/${ROUTINE_ID}`]}>
+        <Route path="/routines/:routineId">
+          <RoutineDetailPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Render — scripted vs freeform
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — scripted render', () => {
+  it('renders header pane, checklist, freeform note, and three actions', async () => {
+    pair();
+    stubFetch({
+      routine: {
+        status: 200,
+        body: makeRoutine({
+          schedules: [
+            makeSchedule({ day_of_week: 'weekdays', time_of_day: '7:00' }),
+            makeSchedule({
+              id: 's-2',
+              day_of_week: 'weekends',
+              time_of_day: '9:00',
+            }),
+            makeSchedule({
+              id: 's-3',
+              day_of_week: 'sunday',
+              time_of_day: '10:00',
+            }),
+          ],
+        }),
+      },
+      habits: {
+        status: 200,
+        body: [makeHabit('h-1'), makeHabit('h-2')],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning kit')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-description')).toHaveTextContent(
+      /three things before coffee/i,
+    );
+    // Schedule summary uses only the first two entries with " · " separator.
+    expect(screen.getByTestId('routine-schedule-summary')).toHaveTextContent(
+      'Weekdays 7:00 · Weekends 9:00',
+    );
+    expect(screen.getByTestId('routine-streak')).toHaveTextContent(
+      'Streak 3 · Best 7',
+    );
+
+    expect(screen.getByTestId('routine-checklist-pane')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-checkbox-h-1')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-checkbox-h-2')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-freeform-note')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-all-done-button')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-partial-button')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-skipped-button')).toBeInTheDocument();
+  });
+
+  it('renders the trailing "Not in today\'s checklist" section for graduated habits', async () => {
+    pair();
+    stubFetch({
+      habits: {
+        status: 200,
+        body: [
+          makeHabit('h-active'),
+          makeHabit('h-grad', { scaffolding_status: 'graduated' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('routine-checklist-row-h-active'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('routine-trailing-section'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('routine-trailing-h-grad'),
+    ).toBeInTheDocument();
+    // Graduated habit does NOT get a checkbox.
+    expect(
+      screen.queryByTestId('routine-checkbox-h-grad'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('RoutineDetailPage — freeform render', () => {
+  it('shows the freeform message and hides the Partial button when no habits exist', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [] } });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('routine-checklist-freeform'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('routine-partial-button'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('routine-all-done-button')).toBeInTheDocument();
+    expect(screen.getByTestId('routine-skipped-button')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Checkbox initial state
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — checkbox initialisation', () => {
+  it('checks habits whose last_completed equals today and leaves others unchecked', async () => {
+    pair();
+    stubFetch({
+      habits: {
+        status: 200,
+        body: [
+          makeHabit('h-done', { last_completed: '2026-05-02' }),
+          makeHabit('h-pending', { last_completed: '2026-05-01' }),
+          makeHabit('h-never', { last_completed: null }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const done = (await screen.findByTestId(
+      'routine-checkbox-h-done',
+    )) as HTMLInputElement;
+    const pending = screen.getByTestId(
+      'routine-checkbox-h-pending',
+    ) as HTMLInputElement;
+    const never = screen.getByTestId(
+      'routine-checkbox-h-never',
+    ) as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(done.checked).toBe(true);
+      expect(pending.checked).toBe(false);
+      expect(never.checked).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// All Done path
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — All Done path', () => {
+  it('enqueues with status=all_done and child_habit_completions=null', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [makeHabit('h-1')] } });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('routine-all-done-button'),
+    );
+
+    await waitFor(() => {
+      expect(enqueueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          routine_id: ROUTINE_ID,
+          completed_date: '2026-05-02',
+          status: 'all_done',
+          child_habit_completions: null,
+        }),
+      );
+    });
+    expect(flushSpy).toHaveBeenCalled();
+  });
+
+  it('shows the unchecked-habits warning when at least one row is not checked', async () => {
+    pair();
+    stubFetch({
+      habits: {
+        status: 200,
+        body: [
+          makeHabit('h-1', { last_completed: '2026-05-02' }),
+          makeHabit('h-2', { last_completed: null }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('routine-all-done-warning'),
+    ).toHaveTextContent(/all done marks every habit/i);
+  });
+
+  it('hides the warning when every habit is checked', async () => {
+    pair();
+    stubFetch({
+      habits: {
+        status: 200,
+        body: [
+          makeHabit('h-1', { last_completed: '2026-05-02' }),
+          makeHabit('h-2', { last_completed: '2026-05-02' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    // Wait for first checkbox to render so initialisation has run.
+    await screen.findByTestId('routine-checkbox-h-1');
+    expect(
+      screen.queryByTestId('routine-all-done-warning'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial path
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — Partial path', () => {
+  it('enqueues only CHECKED habits as child_habit_completions', async () => {
+    pair();
+    stubFetch({
+      habits: {
+        status: 200,
+        body: [
+          makeHabit('h-1', { last_completed: '2026-05-02' }), // checked init
+          makeHabit('h-2', { last_completed: null }), // unchecked init
+        ],
+      },
+    });
+
+    renderPage();
+
+    await screen.findByTestId('routine-checkbox-h-1');
+    // Toggle h-1 OFF — it was checked from last_completed init.
+    await userEvent.click(screen.getByTestId('routine-checklist-row-h-1'));
+    // Toggle h-2 ON.
+    await userEvent.click(screen.getByTestId('routine-checklist-row-h-2'));
+
+    await userEvent.click(screen.getByTestId('routine-partial-button'));
+
+    await waitFor(() => {
+      expect(enqueueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          routine_id: ROUTINE_ID,
+          status: 'partial',
+          child_habit_completions: [
+            { habit_id: 'h-2', completed_date: '2026-05-02' },
+          ],
+        }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skipped path
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — Skipped path', () => {
+  it('refuses to enqueue and surfaces the inline error when the note is empty', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [makeHabit('h-1')] } });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('routine-skipped-button'),
+    );
+
+    expect(
+      await screen.findByTestId('routine-skipped-error'),
+    ).toHaveTextContent(/note is required/i);
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it('enqueues with status=skipped + freeform_note when the note is non-empty', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [makeHabit('h-1')] } });
+
+    renderPage();
+
+    const note = (await screen.findByTestId(
+      'routine-freeform-note',
+    )) as HTMLTextAreaElement;
+    await userEvent.type(note, 'busy day');
+    await userEvent.click(screen.getByTestId('routine-skipped-button'));
+
+    await waitFor(() => {
+      expect(enqueueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'skipped',
+          freeform_note: 'busy day',
+          child_habit_completions: null,
+        }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flush feedback toasts
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — flush feedback', () => {
+  it('shows the queued retry toast when the flush halts before delivering', async () => {
+    pair();
+    flushSpy.mockResolvedValueOnce(stopFlush);
+    stubFetch({ habits: { status: 200, body: [] } });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByTestId('routine-all-done-button'),
+    );
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/queued — will retry/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warning surface (Group 3 close-ledger carry-forward)
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — warning surface', () => {
+  it('subscribes on mount and surfaces a danger toast when a not_active warning fires for this routine', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [] } });
+
+    renderPage();
+
+    await screen.findByTestId('routine-all-done-button');
+    expect(subscribeRoutineWarningSpy).toHaveBeenCalled();
+    expect(latestRoutineWarningListener.current).not.toBeNull();
+
+    await act(async () => {
+      latestRoutineWarningListener.current?.({
+        kind: 'not_active',
+        routine_id: ROUTINE_ID,
+        status: 'all_done',
+      });
+    });
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/routine is paused/i);
+    expect(toast).toHaveAttribute('data-color', 'danger');
+  });
+
+  it('surfaces a not_found warning with the corresponding message', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [] } });
+
+    renderPage();
+
+    await screen.findByTestId('routine-all-done-button');
+
+    await act(async () => {
+      latestRoutineWarningListener.current?.({
+        kind: 'not_found',
+        routine_id: ROUTINE_ID,
+        status: 'skipped',
+      });
+    });
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(/routine no longer exists/i);
+  });
+
+  it('ignores warnings for a different routine_id', async () => {
+    pair();
+    stubFetch({ habits: { status: 200, body: [] } });
+
+    renderPage();
+
+    await screen.findByTestId('routine-all-done-button');
+
+    await act(async () => {
+      latestRoutineWarningListener.current?.({
+        kind: 'not_active',
+        routine_id: 'other-routine',
+        status: 'all_done',
+      });
+    });
+
+    expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Not-found
+// ---------------------------------------------------------------------------
+
+describe('RoutineDetailPage — not-found card', () => {
+  it('renders the not-found card and routes back to /routines on tap', async () => {
+    pair();
+    stubFetch({
+      routine: { status: 404 },
+      habits: { status: 200, body: [] },
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('routine-not-found')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('routine-not-found-back'));
+    expect(replaceSpy).toHaveBeenCalledWith('/routines');
+  });
+});

--- a/src/pages/RoutineDetailPage.tsx
+++ b/src/pages/RoutineDetailPage.tsx
@@ -1,0 +1,841 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCheckbox,
+  IonContent,
+  IonFooter,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTextarea,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import {
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { format, formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { useHistory, useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchRoutineDetail,
+  readCachedRoutineDetail,
+  writeCachedRoutineDetail,
+  type RoutineDetailResponse,
+  type RoutineFrequency,
+  type RoutineScheduleResponse,
+} from '../lib/routines';
+import {
+  fetchActiveHabitsByRoutine,
+  readCachedHabitsByRoutine,
+  writeCachedHabitsByRoutine,
+  type HabitResponse,
+} from '../lib/habits';
+import {
+  enqueueRoutineCompletion,
+  flushAllQueues,
+  subscribeRoutineCompletionWarnings,
+  type RoutineChildHabitCompletion,
+  type RoutineCompletionStatus,
+  type RoutineCompletionWarning,
+} from '../lib/completionQueues';
+import { todayLocalDate } from '../lib/local-date';
+
+const ROUTINE_QUERY_KEY = (id: string): QueryKey => ['routine', id];
+const HABITS_BY_ROUTINE_QUERY_KEY = (id: string): QueryKey => [
+  'habits',
+  'by-routine',
+  id,
+];
+const ROUTINES_LIST_QUERY_KEY: QueryKey = ['routines', 'active'];
+const STALE_MS = 5 * 60 * 1000;
+const ACTION_DISABLE_MS = 2000;
+const FREEFORM_NOTE_MAX = 5000;
+
+const FREQUENCY_LABEL: Record<RoutineFrequency, string> = {
+  daily: 'Daily',
+  weekdays: 'Weekdays',
+  weekends: 'Weekends',
+  weekly: 'Weekly',
+  custom: 'Custom',
+};
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedRoutine: RoutineDetailResponse | null;
+      cachedRoutineFetchedAtMs: number | null;
+      cachedHabits: HabitResponse[] | null;
+      cachedHabitsFetchedAtMs: number | null;
+    };
+
+const RoutineDetailPage: React.FC = () => {
+  const { routineId } = useParams<{ routineId: string }>();
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cachedRoutine, cachedHabits] = await Promise.all([
+        loadPairing(),
+        readCachedRoutineDetail(routineId),
+        readCachedHabitsByRoutine(routineId),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const routineMs = cachedRoutine?.fetched_at
+        ? Date.parse(cachedRoutine.fetched_at)
+        : NaN;
+      const habitsMs = cachedHabits?.fetched_at
+        ? Date.parse(cachedHabits.fetched_at)
+        : NaN;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedRoutine: cachedRoutine?.routine ?? null,
+        cachedRoutineFetchedAtMs: Number.isFinite(routineMs) ? routineMs : null,
+        cachedHabits: cachedHabits?.items ?? null,
+        cachedHabitsFetchedAtMs: Number.isFinite(habitsMs) ? habitsMs : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [routineId]);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/routines" />
+          </IonButtons>
+          <IonTitle>Routine</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+
+      {bootstrap.kind === 'loading' ? (
+        <IonContent fullscreen>
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        </IonContent>
+      ) : null}
+
+      {bootstrap.kind === 'no-pairing' ? (
+        <IonContent fullscreen>
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see this routine.</p>
+          </div>
+        </IonContent>
+      ) : null}
+
+      {bootstrap.kind === 'paired' ? (
+        <DetailBody
+          routineId={routineId}
+          pairing={bootstrap.pairing}
+          initialRoutine={bootstrap.cachedRoutine}
+          initialRoutineFetchedAtMs={bootstrap.cachedRoutineFetchedAtMs}
+          initialHabits={bootstrap.cachedHabits}
+          initialHabitsFetchedAtMs={bootstrap.cachedHabitsFetchedAtMs}
+        />
+      ) : null}
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  routineId: string;
+  pairing: Pairing;
+  initialRoutine: RoutineDetailResponse | null;
+  initialRoutineFetchedAtMs: number | null;
+  initialHabits: HabitResponse[] | null;
+  initialHabitsFetchedAtMs: number | null;
+}
+
+interface ToastState {
+  open: boolean;
+  message: string;
+  color?: 'success' | 'danger' | 'medium';
+  duration?: number;
+}
+
+const DetailBody: React.FC<BodyProps> = ({
+  routineId,
+  pairing,
+  initialRoutine,
+  initialRoutineFetchedAtMs,
+  initialHabits,
+  initialHabitsFetchedAtMs,
+}) => {
+  const history = useHistory();
+  const queryClient = useQueryClient();
+  const today = todayLocalDate();
+
+  const [toast, setToast] = useState<ToastState>({ open: false, message: '' });
+  const [actionPending, setActionPending] = useState(false);
+  const [freeformNote, setFreeformNote] = useState('');
+  const [skippedError, setSkippedError] = useState(false);
+  const [checkedHabitIds, setCheckedHabitIds] = useState<
+    Record<string, boolean>
+  >({});
+  const checkedInitialised = useRef(false);
+  const noteRef = useRef<HTMLIonTextareaElement | null>(null);
+
+  const routineQuery = useQuery<RoutineDetailResponse>({
+    queryKey: ROUTINE_QUERY_KEY(routineId),
+    queryFn: async () => {
+      const result = await fetchRoutineDetail(pairing, routineId);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      await writeCachedRoutineDetail(routineId, result.routine);
+      return result.routine;
+    },
+    initialData: initialRoutine ?? undefined,
+    initialDataUpdatedAt:
+      initialRoutine !== null && initialRoutineFetchedAtMs !== null
+        ? initialRoutineFetchedAtMs
+        : undefined,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  const habitsQuery = useQuery<HabitResponse[]>({
+    queryKey: HABITS_BY_ROUTINE_QUERY_KEY(routineId),
+    queryFn: async () => {
+      const result = await fetchActiveHabitsByRoutine(pairing, routineId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedHabitsByRoutine(routineId, result.items);
+      return result.items;
+    },
+    initialData: initialHabits ?? undefined,
+    initialDataUpdatedAt:
+      initialHabits !== null && initialHabitsFetchedAtMs !== null
+        ? initialHabitsFetchedAtMs
+        : undefined,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    enabled: !isNotFoundError(routineQuery.error),
+    retry: false,
+  });
+
+  const routine = routineQuery.data;
+  const habits = habitsQuery.data;
+
+  // Partition habits per spec: active checklist (active + non-graduated) and
+  // an informational trailing section (status !== 'active' or
+  // scaffolding_status === 'graduated'). The query filters by status=active so
+  // the trailing section in practice contains graduated-scaffolding habits.
+  const partitioned = useMemo(() => {
+    if (!habits) return { active: [] as HabitResponse[], trailing: [] as HabitResponse[] };
+    const active: HabitResponse[] = [];
+    const trailing: HabitResponse[] = [];
+    for (const h of habits) {
+      if (h.status === 'active' && h.scaffolding_status !== 'graduated') {
+        active.push(h);
+      } else {
+        trailing.push(h);
+      }
+    }
+    return { active, trailing };
+  }, [habits]);
+
+  const isFreeform = (habits?.length ?? 0) === 0;
+  const hasUncheckedActive =
+    partitioned.active.length > 0 &&
+    partitioned.active.some((h) => !checkedHabitIds[h.id]);
+
+  // Initialise checkbox state from each habit's last_completed === today
+  // exactly once per habits-load. The user's subsequent toggles are preserved
+  // until the page unmounts or habits refetch with new IDs.
+  useEffect(() => {
+    if (!habits || checkedInitialised.current) return;
+    const next: Record<string, boolean> = {};
+    for (const h of partitioned.active) {
+      next[h.id] = h.last_completed === today;
+    }
+    setCheckedHabitIds(next);
+    checkedInitialised.current = true;
+  }, [habits, partitioned.active, today]);
+
+  // Wire the [2C-23] routine-completion warning subscription. Per the close
+  // ledger this surface lands in [2C-25] — see PR body Deviation §1.
+  useEffect(() => {
+    const unsubscribe = subscribeRoutineCompletionWarnings(
+      (warning: RoutineCompletionWarning) => {
+        if (warning.routine_id !== routineId) return;
+        const message =
+          warning.kind === 'not_active'
+            ? 'Routine is paused — completion was discarded'
+            : 'Routine no longer exists — completion was discarded';
+        setToast({ open: true, message, color: 'danger', duration: 5000 });
+      },
+    );
+    return () => unsubscribe();
+  }, [routineId]);
+
+  const showCacheHint =
+    routineQuery.isError &&
+    !isNotFoundError(routineQuery.error) &&
+    routine !== undefined;
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await Promise.all([routineQuery.refetch(), habitsQuery.refetch()]);
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [routineQuery, habitsQuery],
+  );
+
+  const invalidateAll = useCallback(async (): Promise<void> => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ROUTINE_QUERY_KEY(routineId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: HABITS_BY_ROUTINE_QUERY_KEY(routineId),
+      }),
+      queryClient.invalidateQueries({ queryKey: ROUTINES_LIST_QUERY_KEY }),
+    ]);
+  }, [queryClient, routineId]);
+
+  // Optimistic streak/last_completed bump per spec. Refetched server values
+  // overwrite this once the flush + invalidation completes; if the entry
+  // was queued offline, the optimistic update remains visible until the
+  // next online refetch.
+  const applyOptimisticStreak = useCallback((): void => {
+    queryClient.setQueryData<RoutineDetailResponse | undefined>(
+      ROUTINE_QUERY_KEY(routineId),
+      (prev) => {
+        if (!prev) return prev;
+        if (prev.last_completed === today) return prev;
+        const nextStreak = (prev.current_streak ?? 0) + 1;
+        const nextBest = Math.max(prev.best_streak ?? 0, nextStreak);
+        return {
+          ...prev,
+          last_completed: today,
+          current_streak: nextStreak,
+          best_streak: nextBest,
+        };
+      },
+    );
+  }, [queryClient, routineId, today]);
+
+  const beginAction = useCallback((): void => {
+    setActionPending(true);
+    setTimeout(() => setActionPending(false), ACTION_DISABLE_MS);
+  }, []);
+
+  const handleEnqueueResult = useCallback(
+    async (delivered: boolean): Promise<void> => {
+      await invalidateAll();
+      if (delivered) {
+        setToast({ open: true, message: 'Routine recorded', color: 'success' });
+      } else {
+        setToast({
+          open: true,
+          message: 'Queued — will retry',
+          color: 'medium',
+        });
+      }
+    },
+    [invalidateAll],
+  );
+
+  const onAllDone = useCallback(async (): Promise<void> => {
+    if (!routine) return;
+    beginAction();
+    applyOptimisticStreak();
+    await enqueueRoutineCompletion({
+      routine_id: routine.id,
+      completed_date: today,
+      status: 'all_done',
+      freeform_note: freeformNote.trim() || null,
+      child_habit_completions: null,
+      enqueued_at: new Date().toISOString(),
+    });
+    const summary = await flushAllQueues();
+    await handleEnqueueResult(summary.routineCompletions.delivered > 0);
+  }, [
+    routine,
+    today,
+    freeformNote,
+    beginAction,
+    applyOptimisticStreak,
+    handleEnqueueResult,
+  ]);
+
+  const onPartial = useCallback(async (): Promise<void> => {
+    if (!routine) return;
+    beginAction();
+    applyOptimisticStreak();
+    const childCompletions: RoutineChildHabitCompletion[] = partitioned.active
+      .filter((h) => checkedHabitIds[h.id])
+      .map((h) => ({ habit_id: h.id, completed_date: today }));
+    await enqueueRoutineCompletion({
+      routine_id: routine.id,
+      completed_date: today,
+      status: 'partial',
+      freeform_note: freeformNote.trim() || null,
+      child_habit_completions: childCompletions,
+      enqueued_at: new Date().toISOString(),
+    });
+    const summary = await flushAllQueues();
+    await handleEnqueueResult(summary.routineCompletions.delivered > 0);
+  }, [
+    routine,
+    today,
+    freeformNote,
+    partitioned.active,
+    checkedHabitIds,
+    beginAction,
+    applyOptimisticStreak,
+    handleEnqueueResult,
+  ]);
+
+  const onSkipped = useCallback(async (): Promise<void> => {
+    if (!routine) return;
+    if (!freeformNote.trim()) {
+      setSkippedError(true);
+      const el = noteRef.current as unknown as
+        | { setFocus?: () => Promise<void> }
+        | null;
+      if (el && typeof el.setFocus === 'function') {
+        el.setFocus().catch(() => undefined);
+      }
+      return;
+    }
+    setSkippedError(false);
+    beginAction();
+    // Skipped freezes the streak server-side — no optimistic streak bump.
+    await enqueueRoutineCompletion({
+      routine_id: routine.id,
+      completed_date: today,
+      status: 'skipped',
+      freeform_note: freeformNote.trim(),
+      child_habit_completions: null,
+      enqueued_at: new Date().toISOString(),
+    });
+    const summary = await flushAllQueues();
+    await handleEnqueueResult(summary.routineCompletions.delivered > 0);
+  }, [routine, today, freeformNote, beginAction, handleEnqueueResult]);
+
+  const toggleHabit = useCallback((habitId: string): void => {
+    setCheckedHabitIds((prev) => ({ ...prev, [habitId]: !prev[habitId] }));
+  }, []);
+
+  if (isNotFoundError(routineQuery.error) && !routine) {
+    return (
+      <IonContent fullscreen>
+        <NotFoundCard onBack={() => history.replace('/routines')} />
+      </IonContent>
+    );
+  }
+
+  if (!routine) {
+    return (
+      <IonContent fullscreen>
+        <div className="flex h-full w-full items-center justify-center text-neutral-300">
+          <p>Loading…</p>
+        </div>
+      </IonContent>
+    );
+  }
+
+  return (
+    <>
+      <IonContent fullscreen>
+        <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+          <IonRefresherContent />
+        </IonRefresher>
+
+        {showCacheHint ? (
+          <div
+            className="px-4 pt-3 text-sm text-neutral-300"
+            role="status"
+            aria-live="polite"
+          >
+            Showing cached data
+          </div>
+        ) : null}
+
+        <HeaderPane routine={routine} />
+
+        {isFreeform ? (
+          <FreeformChecklistMessage />
+        ) : (
+          <ChecklistPane
+            active={partitioned.active}
+            trailing={partitioned.trailing}
+            checkedHabitIds={checkedHabitIds}
+            onToggleHabit={toggleHabit}
+          />
+        )}
+
+        <FreeformNotePane
+          value={freeformNote}
+          onChange={(v) => {
+            setFreeformNote(v);
+            if (v.trim()) setSkippedError(false);
+          }}
+          showRequiredError={skippedError}
+          textareaRef={noteRef}
+        />
+
+        {!isFreeform && hasUncheckedActive ? (
+          <div
+            className="mx-4 mb-2 mt-1 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100"
+            data-testid="routine-all-done-warning"
+          >
+            All Done marks every habit in the routine complete, even unchecked
+            ones. Consider Partial.
+          </div>
+        ) : null}
+      </IonContent>
+
+      <IonFooter>
+        <IonToolbar>
+          <div
+            className="flex flex-col gap-2 px-3 py-2"
+            data-testid="routine-action-footer"
+          >
+            <IonButton
+              color="success"
+              onClick={onAllDone}
+              disabled={actionPending}
+              data-testid="routine-all-done-button"
+            >
+              All done
+            </IonButton>
+            {!isFreeform ? (
+              <IonButton
+                color="warning"
+                onClick={onPartial}
+                disabled={actionPending}
+                data-testid="routine-partial-button"
+              >
+                Partial
+              </IonButton>
+            ) : null}
+            <IonButton
+              color="medium"
+              onClick={onSkipped}
+              disabled={actionPending}
+              data-testid="routine-skipped-button"
+            >
+              Skipped
+            </IonButton>
+          </div>
+        </IonToolbar>
+      </IonFooter>
+
+      <IonToast
+        isOpen={toast.open}
+        message={toast.message}
+        color={toast.color}
+        duration={toast.duration ?? 3000}
+        onDidDismiss={() => setToast({ open: false, message: '' })}
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Header pane
+// ---------------------------------------------------------------------------
+
+const HeaderPane: React.FC<{ routine: RoutineDetailResponse }> = ({ routine }) => {
+  const lastCompletedLine = useMemo(() => {
+    if (routine.last_completed === null || routine.last_completed === undefined) {
+      return 'Never completed';
+    }
+    return `${formatAbsoluteDate(routine.last_completed)} (${formatDistanceToNowStrict(parseISO(routine.last_completed), { addSuffix: true })})`;
+  }, [routine.last_completed]);
+
+  const frequencyLabel = routine.frequency
+    ? FREQUENCY_LABEL[routine.frequency]
+    : null;
+  const scheduleSummary = formatScheduleSummary(routine.schedules);
+
+  return (
+    <section className="px-4 pt-4" data-testid="routine-header-pane">
+      <h1 className="text-xl font-semibold">{routine.title}</h1>
+      {routine.description ? (
+        <p
+          className="mt-2 whitespace-pre-wrap text-sm text-neutral-200"
+          data-testid="routine-description"
+        >
+          {routine.description}
+        </p>
+      ) : null}
+      <dl className="mt-4 grid grid-cols-1 gap-2 text-sm">
+        {frequencyLabel ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Frequency</dt>
+            <dd>{frequencyLabel}</dd>
+          </div>
+        ) : null}
+        {scheduleSummary ? (
+          <div className="flex justify-between">
+            <dt className="text-neutral-400">Schedule</dt>
+            <dd data-testid="routine-schedule-summary">{scheduleSummary}</dd>
+          </div>
+        ) : null}
+        <div className="flex justify-between">
+          <dt className="text-neutral-400">Streak</dt>
+          <dd data-testid="routine-streak">
+            Streak {routine.current_streak ?? 0} · Best{' '}
+            {routine.best_streak ?? 0}
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-neutral-400">Last completed</dt>
+          <dd data-testid="routine-last-completed">{lastCompletedLine}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Checklist pane
+// ---------------------------------------------------------------------------
+
+interface ChecklistProps {
+  active: HabitResponse[];
+  trailing: HabitResponse[];
+  checkedHabitIds: Record<string, boolean>;
+  onToggleHabit: (habitId: string) => void;
+}
+
+const ChecklistPane: React.FC<ChecklistProps> = ({
+  active,
+  trailing,
+  checkedHabitIds,
+  onToggleHabit,
+}) => (
+  <section className="mt-6" data-testid="routine-checklist-pane">
+    <h2 className="px-4 text-base font-medium">Today&apos;s checklist</h2>
+    {active.length === 0 ? (
+      <p className="px-4 pt-2 text-sm text-neutral-400">
+        No active habits left to check off.
+      </p>
+    ) : (
+      <IonList>
+        {active.map((habit) => (
+          <ChecklistRow
+            key={habit.id}
+            habit={habit}
+            checked={Boolean(checkedHabitIds[habit.id])}
+            onToggle={() => onToggleHabit(habit.id)}
+          />
+        ))}
+      </IonList>
+    )}
+
+    {trailing.length > 0 ? (
+      <div className="mt-4" data-testid="routine-trailing-section">
+        <h3 className="px-4 text-sm font-medium text-neutral-400">
+          Not in today&apos;s checklist
+        </h3>
+        <IonList>
+          {trailing.map((habit) => (
+            <IonItem key={habit.id} data-testid={`routine-trailing-${habit.id}`}>
+              <IonLabel className="ion-text-wrap">
+                <h3>{habit.title}</h3>
+                {habit.description ? (
+                  <IonNote className="text-xs">
+                    {snippet(habit.description)}
+                  </IonNote>
+                ) : null}
+              </IonLabel>
+            </IonItem>
+          ))}
+        </IonList>
+      </div>
+    ) : null}
+  </section>
+);
+
+interface RowProps {
+  habit: HabitResponse;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+const ChecklistRow: React.FC<RowProps> = ({ habit, checked, onToggle }) => (
+  <IonItem
+    button
+    onClick={onToggle}
+    data-testid={`routine-checklist-row-${habit.id}`}
+  >
+    <IonCheckbox
+      slot="start"
+      checked={checked}
+      onIonChange={onToggle}
+      aria-label={`Mark ${habit.title} done`}
+      data-testid={`routine-checkbox-${habit.id}`}
+    />
+    <IonLabel className="ion-text-wrap">
+      <h3>{habit.title}</h3>
+      {habit.description ? (
+        <p className="text-xs text-neutral-400">{snippet(habit.description)}</p>
+      ) : null}
+      <p className="text-xs text-neutral-500">
+        Streak {habit.current_streak ?? 0}
+      </p>
+    </IonLabel>
+  </IonItem>
+);
+
+const FreeformChecklistMessage: React.FC = () => (
+  <section
+    className="mt-6 px-4 text-sm text-neutral-300"
+    data-testid="routine-checklist-freeform"
+  >
+    This routine is freeform — tap an action below to record completion.
+  </section>
+);
+
+// ---------------------------------------------------------------------------
+// Freeform note pane
+// ---------------------------------------------------------------------------
+
+interface NoteProps {
+  value: string;
+  onChange: (value: string) => void;
+  showRequiredError: boolean;
+  textareaRef: React.MutableRefObject<HTMLIonTextareaElement | null>;
+}
+
+const FreeformNotePane: React.FC<NoteProps> = ({
+  value,
+  onChange,
+  showRequiredError,
+  textareaRef,
+}) => (
+  <section className="mt-6 px-4" data-testid="routine-note-pane">
+    <IonTextarea
+      ref={textareaRef}
+      value={value}
+      onIonInput={(e) => onChange(((e.detail.value ?? '') as string))}
+      placeholder="Anything worth noting? (Optional for All Done and Partial. Required for Skipped.)"
+      maxlength={FREEFORM_NOTE_MAX}
+      autoGrow
+      rows={3}
+      data-testid="routine-freeform-note"
+    />
+    {showRequiredError ? (
+      <IonText
+        color="danger"
+        className="text-xs"
+        data-testid="routine-skipped-error"
+      >
+        A note is required when marking the routine skipped.
+      </IonText>
+    ) : null}
+  </section>
+);
+
+// ---------------------------------------------------------------------------
+// Not-found card
+// ---------------------------------------------------------------------------
+
+const NotFoundCard: React.FC<{ onBack: () => void }> = ({ onBack }) => (
+  <div
+    className="flex h-full w-full flex-col items-center justify-center px-4 text-center text-neutral-300"
+    data-testid="routine-not-found"
+  >
+    <p>Routine not found.</p>
+    <IonButton
+      fill="outline"
+      className="mt-3"
+      onClick={onBack}
+      data-testid="routine-not-found-back"
+    >
+      Back to routines
+    </IonButton>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAbsoluteDate(value: string): string {
+  try {
+    return format(parseISO(value), 'EEEE, MMMM d');
+  } catch {
+    return value;
+  }
+}
+
+function snippet(value: string, max = 80): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max).trimEnd()}…`;
+}
+
+function formatScheduleSummary(
+  schedules: RoutineScheduleResponse[],
+): string | null {
+  if (!schedules || schedules.length === 0) return null;
+  const parts = schedules
+    .slice(0, 2)
+    .map((s) => {
+      const day = s.day_of_week
+        ? s.day_of_week.charAt(0).toUpperCase() + s.day_of_week.slice(1)
+        : null;
+      const time = s.time_of_day ?? null;
+      if (day && time) return `${day} ${time}`;
+      return day ?? time ?? null;
+    })
+    .filter((p): p is string => p !== null);
+  if (parts.length === 0) return null;
+  return parts.join(' · ');
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'notFound' in error &&
+      (error as { notFound: unknown }).notFound === true,
+  );
+}
+
+// `RoutineCompletionStatus` is consumed indirectly via enqueueRoutineCompletion
+// but referenced here as a named import to keep the spec contract visible at
+// the consumer site. Re-export is intentional for downstream test imports.
+export type { RoutineCompletionStatus };
+
+export default RoutineDetailPage;


### PR DESCRIPTION
Closes #20

## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npx tsc --noEmit` — ✅ Pass (no type errors)
- `npx vitest run` — ✅ Pass (203 passed across 17 files; +33 new tests vs. the 170/16 baseline at [2C-24] merge)
- `npm run android:build:debug` — ⚠️ Not run (agent dev env has no JDK + ANDROID_HOME). TS-only change with no `android/` modifications and no Capacitor plugin add — `npm run android:sync` not required, low-risk for this gate.

Ran locally against develop HEAD at `743ca01` immediately before opening this PR.

## Summary

Adds the `/routines/:routineId` route that closes the Group 3 user journey: tap a row in `[2C-24]`'s active-routines list, land on a detail page that shows the routine's header (title, description, schedule summary, streak, last completed), today's checklist (active non-graduated habits with checkboxes initialised from `last_completed === today`, plus a quieter trailing section for graduated habits), a freeform note field, and three actions (All Done / Partial / Skipped) in an `<IonFooter>`. Honors `[2C-26]`'s three-tuple idempotency contract by routing every completion through `[2C-23]`'s `enqueueRoutineCompletion`, which composes the partial path's child-habit prerequisite ordering automatically.

Also wires the previously-deferred `subscribeRoutineCompletionWarnings` and `subscribeHabitCompletionWarnings` UI consumers exported by `[2C-23]`'s `src/lib/completionQueues.ts`. The Group 3 close ledger named `[2C-25]` as the wiring point; `[2C-22]` (PR #58 Dev §7) and `[2C-24]` (PR #61 Dev §4) both explicitly deferred their consumers here. Spec body for #20 was silent on this — surfaced as a scope mismatch and confirmed with L before implementation. See Deviations §1 + §2.

## Changes

- **`src/lib/routines.ts`** — adds `RoutineDetailResponse` (extends `RoutineResponse` with `schedules: RoutineScheduleResponse[]`), `fetchRoutineDetail`, and per-routine cache helpers (`readCachedRoutineDetail`, `writeCachedRoutineDetail`, `routineDetailCacheKey`). Existing `fetchRoutine` from `[2C-21]` per-row resolution is untouched — `[2C-21]` callers only read `id` + `title` and stay typed against the leaner `RoutineResponse` (see Deviation §4).
- **`src/lib/habits.ts`** — adds `fetchActiveHabitsByRoutine` (URL `/api/habits/?routine_id={id}&status=active`, encodes the routine_id query param) and `readCachedHabitsByRoutine` / `writeCachedHabitsByRoutine` per the spec's `brain.cache.habits.byRoutine.{routineId}` cache key.
- **`src/pages/RoutineDetailPage.tsx`** — new route component. Bootstrap-then-paired pattern mirrors `HabitDetailPage`: parallel pairing + cache loads in `useEffect`, then `DetailBody` with two `useQuery` hooks threading `initialData` + `initialDataUpdatedAt` from the cache `fetched_at` (the `[2C-21]`/`[2C-24]` carry-forward — without `initialDataUpdatedAt`, TanStack treats `initialData` as fresh and the on-mount refetch never fires). Header pane, scripted-vs-freeform checklist branch, freeform note `IonTextarea` (`maxlength={5000}`), inline All-Done-with-unchecked warning, `IonFooter` with three actions. 2 s post-tap disable; optimistic `last_completed` + `current_streak` bump via `setQueryData` (refetch corrects on flush + invalidate). `subscribeRoutineCompletionWarnings` mounts in a `useEffect`; warnings scoped to this `routine_id` surface as `IonToast color="danger" duration={5000}`.
- **`src/pages/HabitDetailPage.tsx`** — adds a `subscribeHabitCompletionWarnings` `useEffect` that reuses the existing toast surface (`paused` and `not_found` warnings → 5 s danger toast). Existing toast duration logic now branches on `color === 'danger'` (5 s) vs default (3 s) so the warning toast lingers long enough to be readable.
- **`src/App.tsx`** — wires `/routines/:routineId` → `<RoutineDetailPage />` between the `/routines` list and the `/` redirect.
- **Tests:** new `src/pages/RoutineDetailPage.test.tsx` (15 tests covering scripted/freeform render, schedule-summary formatting, checkbox initialisation from `last_completed === today`, all three completion paths, partial child-habit composition, skipped validation, warning surface for both `not_active` and `not_found`, scoped routing on `routine_id` mismatch, queued-retry toast, not-found card). Extended `src/lib/routines.test.ts` (+8: `fetchRoutineDetail` × 4 + cache round-trip × 4), `src/lib/habits.test.ts` (+7: `fetchActiveHabitsByRoutine` × 4 + cache round-trip × 3), and `src/pages/HabitDetailPage.test.tsx` (+3: warning surface × 3). Total: 203 tests across 17 files (was 170 across 16).

## How to Verify

1. `git checkout feat/2C-25-routine-completion-flow && npm install` (no new deps).
2. `npm run lint` — clean.
3. `npx tsc --noEmit` — clean.
4. `npx vitest run` — 203 passed across 17 files.
5. With BRAIN running locally and the app paired:
   - Navigate `/routines`, tap a routine row → lands on `/routines/{id}` detail page.
   - For a scripted routine: header shows title/description/schedule/streak/last-completed; checklist renders each active non-graduated habit with a checkbox initialised from `last_completed === today`; graduated habits in the trailing "Not in today's checklist" section.
   - Tap **All Done** → "Routine recorded" toast (or "Queued — will retry" if offline). Server cascade handles child habits.
   - Toggle some checkboxes, tap **Partial** → only the CHECKED habits are pre-enqueued; routine partial entry follows. Inline "All Done with unchecked" warning is visible while any active habit is unchecked.
   - Clear the note, tap **Skipped** → inline `A note is required when marking the routine skipped` error + textarea focus; no enqueue. Add a note, tap **Skipped** again → enqueues with `status: skipped`.
   - For a freeform routine (no child habits): "This routine is freeform" message; **Partial** button hidden; **All Done** + **Skipped** remain.
   - Pause the routine in BRAIN, then trigger a queued completion (offline → online) → `Routine is paused — completion was discarded` danger toast (5 s).
   - Pause a habit in BRAIN, complete that habit on `HabitDetailPage` (offline → online) → `Habit is paused — completion was discarded` danger toast (5 s).

## Deviations

1. **Spec was silent on the queue-warning UI consumer; wired here per the Group 3 close ledger.** Issue #20's body mentions only the inline All-Done-with-unchecked soft confirm. The activation prompt named `[2C-25]` as the wiring point per the close ledger and explicitly authorized raising the scope mismatch with L before implementation rather than silently re-deferring. After confirmation from L, both `subscribeRoutineCompletionWarnings` (on `RoutineDetailPage`) and `subscribeHabitCompletionWarnings` (on `HabitDetailPage`) are wired here. Surface choice = page-local `IonToast color="danger" duration={5000}` to match the existing toast pattern in `HabitDetailPage`. Per directive `ba044399` the close-ledger-as-source wins where the spec is silent.

2. **Cross-page edit to `HabitDetailPage.tsx` in this PR.** Strictly read against `17cc8ad0` ("one fix per branch"), wiring the habit warning consumer in `[2C-22]`'s file from `[2C-25]`'s branch is bundling. The edit is authorized by the close ledger (which scoped both deferred warning subscriptions to `[2C-25]` as the wiring point) and was confirmed with L before implementation. Splitting it into a follow-up ticket would have been worse — the same close-ledger work item, two PRs, with the second one only being mechanically separated. Flagging per `17cc8ad0`.

3. **Optimistic streak update interpretation.** Spec: *"On any successful enqueue + flush-attempt: optimistic update to the routine's `last_completed` and `current_streak` (incrementing per `evaluate_streak` rules if today is a streak-relevant day)."* Exact `evaluate_streak` logic (custom-frequency scheduled-days handling, prior streak-broken state) is server-side and depends on routine state the client does not always know. Implemented the closest honest approximation: optimistically set `last_completed = today` and bump `current_streak` by 1 (with `best_streak = max(prev_best, new_current)`) only when `last_completed !== today`, then invalidate to refetch the authoritative server values. For Skipped, no optimistic streak bump (the server freezes the streak per `app/routers/routines.py:247`). Flagged for visibility — refetch corrects any drift within a few hundred ms.

4. **`fetchRoutine` vs `fetchRoutineDetail` split.** Existing `fetchRoutine` from `[2C-21]` returns `RoutineResponse` (no `schedules`); its callers in `HabitsPage` only read `id` + `title`. Rather than tightening `fetchRoutine`'s return type to `RoutineDetailResponse` (which would force `[2C-21]` test fixtures to add `schedules: []`), added a sibling `fetchRoutineDetail` returning `RoutineDetailResponse`. Both hit the same endpoint; both work; type contracts are clear at each call site.

5. **First Consumer Instantiates** (org CLAUDE.md v6 §"First Consumer Instantiates"). New scaffolds whose only current consumer is this PR: (a) `fetchRoutineDetail` + `routineDetailCacheKey` + `readCachedRoutineDetail` / `writeCachedRoutineDetail` — only consumed by `RoutineDetailPage`; second consumer would be a routine-edit ticket (Phase 3 per spec Out of Scope); (b) `fetchActiveHabitsByRoutine` + `habitsByRoutineCacheKey` + cache helpers — only consumed by `RoutineDetailPage`'s checklist; second consumer would also be a routine-edit ticket. Flagging per the convention.

6. **Manual verification section absent from issue body.** Per repo CLAUDE.md *"If the issue body has no MV section, no MV obligations apply for that ticket. Auto-verifiable tickets are valid without MV."* — issue #20 has no `#### Manual verification` section. The activation prompt nonetheless flags `[2C-25]` as the highest-stakes Group 3 MV given three-tuple idempotency + partial paths + warning surface + offline → flush reconciliation. The "How to Verify" section above provides a working MV procedure in lieu of a preserved one; treat it as authored-by-Desmond rather than preserved-from-spec. **Items I could not self-test in this dev environment** (call out for L's MV pass at Group 3 close):
    - Offline → flush → server reconciliation on a real device (Capacitor `App` foreground listener + `online` event integration). Unit tests exercise the deterministic equivalent (queue retention + idempotent retry) but not the live native bridge.
    - The `npm run android:build:debug` compile-only gate (no JDK + ANDROID_HOME on agent host — Group 2 carry-forward).
    - Three-tuple idempotency live across status transitions on the same date (e.g., user marks Skipped, then later Partial). Unit-tested at the queue layer in `[2C-23]`; the new RoutineDetailPage tests do not exercise cross-status retries since the page only emits one status per tap.

7. **CLAUDE.md drift (informational only).** Repo `CLAUDE.md` is v2 on disk; BRAIN canonical is v3 (`908baa66` v3, last updated 2026-05-01). v3 hedges Pre-PR Verification Gates item 1 to acknowledge the workflow `on:` block remains push-only until `[2C-Gap-05]` (#55) lands. Per `4ea28266`, agents flag — PO updates. Same drift was flagged in PRs #58 + #61 — known carry-forward, not this ticket's fix.

8. **stderr noise from Ionic `offsetHeight` reads in jsdom.** Several `RoutineDetailPage.test.tsx` tests emit `TypeError: Cannot read properties of null (reading 'offsetHeight')` to stderr from `@ionic/core`'s internal `IonContent` color/transparency animation-frame handler reading layout dimensions that jsdom doesn't compute. Tests pass through it (the errors are caught by Ionic's animation runtime). Suppressing would require mocking `IonContent`, which is more invasive than the value of quieting the noise. The same noise appears at lower volume in pre-existing page tests.

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint
(no output — clean)

$ npx tsc --noEmit
(no output — clean)

$ npx vitest run
 ✓ src/lib/habits.test.ts (20 tests)               [+7]
 ✓ src/lib/writeQueue.test.ts (22 tests)
 ✓ src/lib/routines.test.ts (23 tests)             [+8]
 ✓ src/lib/completionQueues.routine.test.ts (13 tests)
 ✓ src/lib/pairing.test.ts (8 tests)
 ✓ src/lib/habit-detail.test.ts (11 tests)
 ✓ src/lib/health.test.ts (7 tests)
 ✓ src/lib/device-registration.test.ts (13 tests)
 ✓ src/lib/completionQueues.habit.test.ts (8 tests)
 ✓ src/components/StatusPill.test.tsx (4 tests)
 ✓ src/lib/local-date.test.ts (7 tests)
 ✓ src/lib/notifications.test.ts (16 tests)
 ✓ src/pages/RoutinesPage.test.tsx (10 tests)
 ✓ src/App.test.tsx (1 test)
 ✓ src/pages/HabitsPage.test.tsx (9 tests)
 ✓ src/pages/RoutineDetailPage.test.tsx (15 tests) [new]
 ✓ src/pages/HabitDetailPage.test.tsx (16 tests)   [+3]

 Test Files  17 passed (17)
      Tests  203 passed (203)
   Duration  ~8s
```

## Acceptance Checklist

(From issue #20.)

- [x] `/routines/{id}` loads with header, checklist (for scripted routines) or freeform message (for freeform routines), freeform note field, three action buttons.
- [x] Checkbox state reflects each habit's `last_completed === today-local` on initial render.
- [x] **All done** path: enqueues with `status: "all_done"`, optimistic streak update, button disables briefly. Server cascade handles child habits — no client-side child-habit enqueue needed.
- [x] **Partial** path: enqueues child habit completions for CHECKED habits, then the routine partial entry. Flush ordering preserved (verified by `[2C-23]`'s `completionQueues.routine.test.ts` and the new `RoutineDetailPage.test.tsx` partial-path test).
- [x] **Skipped** path: requires non-empty freeform note; surfaces inline validation error if empty.
- [x] Freeform routines: Partial button hidden; All Done + Skipped remain.
- [x] Offline: all enqueue paths succeed optimistically; queue flushes on network return. (Unit-tested via the queued-retry toast path; live device verification in MV.)
- [x] Unknown `routineId` → inline "Routine not found" card.
- [x] `tests/unit/RoutineDetailPage.spec.tsx` covers: scripted routine render, freeform routine render, three-action paths, checkbox state initialization, skipped validation, partial child-habit composition. (Located at `src/pages/RoutineDetailPage.test.tsx` per repo CLAUDE.md test co-location convention — see also `[2C-24]` PR #61 Deviation §1 precedent.)
