### PR TITLE
[2C-20] Recent check-ins view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import HabitsPage from './pages/HabitsPage';
 import HabitDetailPage from './pages/HabitDetailPage';
 import RoutinesPage from './pages/RoutinesPage';
 import RoutineDetailPage from './pages/RoutineDetailPage';
+import CheckinsPage from './pages/CheckinsPage';
+import CheckinDetailPage from './pages/CheckinDetailPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -117,6 +119,12 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/routines/:routineId">
             <RoutineDetailPage />
+          </Route>
+          <Route exact path="/checkins">
+            <CheckinsPage />
+          </Route>
+          <Route exact path="/checkins/:checkinId">
+            <CheckinDetailPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/lib/checkins.test.ts
+++ b/src/lib/checkins.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  CHECKINS_CACHE_KEY,
+  CHECKINS_PATH,
+  composeNumericSubtitle,
+  fetchCheckin,
+  fetchCheckins,
+  formatRelativeLoggedAt,
+  friendlyCheckinTypeLabel,
+  readCachedCheckins,
+  thirtyDaysAgoLocalMidnightUtc,
+  truncateFreeformPreview,
+  writeCachedCheckins,
+  type CheckinResponse,
+} from './checkins';
+import type { Pairing } from './pairing';
+
+const PAIRING: Pairing = { url: 'https://brain.local:8000', token: 'tk-1' };
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeCheckin(overrides: Partial<CheckinResponse> = {}): CheckinResponse {
+  return {
+    id: overrides.id ?? 'c-1',
+    checkin_type: overrides.checkin_type ?? 'morning',
+    energy_level: overrides.energy_level ?? null,
+    mood: overrides.mood ?? null,
+    focus_level: overrides.focus_level ?? null,
+    freeform_note: overrides.freeform_note ?? null,
+    context: overrides.context ?? null,
+    logged_at: overrides.logged_at ?? '2026-05-09T08:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// thirtyDaysAgoLocalMidnightUtc
+// ---------------------------------------------------------------------------
+
+describe('thirtyDaysAgoLocalMidnightUtc', () => {
+  it('returns local midnight 30 days before the supplied now', () => {
+    // 2026-05-09 12:34 local — 30 days back at local midnight = 2026-04-09 00:00 local.
+    const now = new Date(2026, 4, 9, 12, 34, 0);
+    const result = thirtyDaysAgoLocalMidnightUtc(now);
+    const parsed = new Date(result);
+    expect(parsed.getFullYear()).toBe(2026);
+    expect(parsed.getMonth()).toBe(3);
+    expect(parsed.getDate()).toBe(9);
+    expect(parsed.getHours()).toBe(0);
+    expect(parsed.getMinutes()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCheckins (list)
+// ---------------------------------------------------------------------------
+
+describe('fetchCheckins', () => {
+  it('calls the list endpoint with logged_after derived from now', async () => {
+    const now = new Date(2026, 4, 9, 12, 0, 0);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    await fetchCheckins(PAIRING, now);
+
+    const callUrl = (fetchSpy.mock.calls[0]?.[0] as string) ?? '';
+    expect(callUrl.startsWith(`${PAIRING.url}${CHECKINS_PATH}`)).toBe(true);
+    expect(callUrl).toContain('logged_after=');
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toEqual({ Authorization: 'Bearer tk-1' });
+  });
+
+  it('parses a bare-array body into items', async () => {
+    const items = [makeCheckin({ id: 'a' }), makeCheckin({ id: 'b' })];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(items), { status: 200 }),
+    );
+
+    const result = await fetchCheckins(PAIRING);
+    expect(result).toEqual({ ok: true, items });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 401 }),
+    );
+    const result = await fetchCheckins(PAIRING);
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unauthorized',
+      statusCode: 401,
+    });
+  });
+
+  it('returns server error on 5xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 500 }),
+    );
+    const result = await fetchCheckins(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'server', statusCode: 500 });
+  });
+
+  it('returns network on fetch rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    const result = await fetchCheckins(PAIRING);
+    expect(result).toEqual({ ok: false, reason: 'network' });
+  });
+
+  it('treats a non-array body as empty items', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+    );
+    const result = await fetchCheckins(PAIRING);
+    expect(result).toEqual({ ok: true, items: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCheckin (single)
+// ---------------------------------------------------------------------------
+
+describe('fetchCheckin', () => {
+  it('returns the parsed body on 200', async () => {
+    const checkin = makeCheckin({ id: 'c-9' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(checkin), { status: 200 }),
+    );
+
+    const result = await fetchCheckin(PAIRING, 'c-9');
+    expect(result).toEqual({ ok: true, checkin });
+  });
+
+  it('returns not_found on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
+    const result = await fetchCheckin(PAIRING, 'missing');
+    expect(result).toEqual({
+      ok: false,
+      reason: 'not_found',
+      statusCode: 404,
+    });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 401 }),
+    );
+    const result = await fetchCheckin(PAIRING, 'c-1');
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unauthorized',
+      statusCode: 401,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cache read/write
+// ---------------------------------------------------------------------------
+
+describe('checkins cache', () => {
+  it('readCachedCheckins returns null when nothing is stored', async () => {
+    const cached = await readCachedCheckins();
+    expect(cached).toBeNull();
+  });
+
+  it('round-trips items through writeCachedCheckins / readCachedCheckins', async () => {
+    const items = [makeCheckin({ id: 'r-1' })];
+    await writeCachedCheckins(items, new Date('2026-05-09T08:00:00Z'));
+    const cached = await readCachedCheckins();
+    expect(cached).toEqual({
+      fetched_at: '2026-05-09T08:00:00.000Z',
+      items,
+    });
+    expect(prefsStore.has(CHECKINS_CACHE_KEY)).toBe(true);
+  });
+
+  it('readCachedCheckins returns null on malformed JSON', async () => {
+    prefsStore.set(CHECKINS_CACHE_KEY, '{not-json');
+    const cached = await readCachedCheckins();
+    expect(cached).toBeNull();
+  });
+
+  it('readCachedCheckins returns null when shape is wrong', async () => {
+    prefsStore.set(CHECKINS_CACHE_KEY, JSON.stringify({ items: 'oops' }));
+    const cached = await readCachedCheckins();
+    expect(cached).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// presentation helpers
+// ---------------------------------------------------------------------------
+
+describe('friendlyCheckinTypeLabel', () => {
+  it('maps each enum value to a friendly label', () => {
+    expect(friendlyCheckinTypeLabel('morning')).toBe('Morning check-in');
+    expect(friendlyCheckinTypeLabel('midday')).toBe('Midday check-in');
+    expect(friendlyCheckinTypeLabel('evening')).toBe('Evening check-in');
+    expect(friendlyCheckinTypeLabel('micro')).toBe('Micro check-in');
+    expect(friendlyCheckinTypeLabel('freeform')).toBe('Freeform check-in');
+  });
+});
+
+describe('composeNumericSubtitle', () => {
+  it('returns null when all numeric values are null', () => {
+    expect(
+      composeNumericSubtitle({
+        energy_level: null,
+        focus_level: null,
+        mood: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('orders parts as Energy · Focus · Mood', () => {
+    expect(
+      composeNumericSubtitle({
+        energy_level: 4,
+        focus_level: 3,
+        mood: 5,
+      }),
+    ).toBe('Energy 4 · Focus 3 · Mood 5');
+  });
+
+  it('omits null fields', () => {
+    expect(
+      composeNumericSubtitle({
+        energy_level: null,
+        focus_level: 2,
+        mood: 5,
+      }),
+    ).toBe('Focus 2 · Mood 5');
+  });
+});
+
+describe('truncateFreeformPreview', () => {
+  it('returns short notes verbatim', () => {
+    expect(truncateFreeformPreview('hello')).toBe('hello');
+  });
+
+  it('truncates with ellipsis at 60 chars', () => {
+    const note = 'x'.repeat(75);
+    const out = truncateFreeformPreview(note);
+    expect(out.length).toBe(61); // 60 chars + ellipsis
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.startsWith('x'.repeat(60))).toBe(true);
+  });
+
+  it('does not truncate when length === 60', () => {
+    const note = 'y'.repeat(60);
+    expect(truncateFreeformPreview(note)).toBe(note);
+  });
+});
+
+describe('formatRelativeLoggedAt', () => {
+  const NOW = new Date('2026-05-09T12:00:00Z');
+
+  it('renders "just now" for sub-minute deltas', () => {
+    expect(formatRelativeLoggedAt('2026-05-09T11:59:30Z', NOW)).toBe('just now');
+  });
+
+  it('renders minutes for sub-hour deltas', () => {
+    expect(formatRelativeLoggedAt('2026-05-09T11:45:00Z', NOW)).toBe('15m ago');
+  });
+
+  it('renders hours for sub-day deltas', () => {
+    expect(formatRelativeLoggedAt('2026-05-09T10:00:00Z', NOW)).toBe('2h ago');
+  });
+
+  it('renders "yesterday" for ~1 day', () => {
+    expect(formatRelativeLoggedAt('2026-05-08T12:00:00Z', NOW)).toBe(
+      'yesterday',
+    );
+  });
+
+  it('renders multi-day deltas with d suffix', () => {
+    expect(formatRelativeLoggedAt('2026-05-06T12:00:00Z', NOW)).toBe('3d ago');
+  });
+
+  it('returns the raw string on parse failure', () => {
+    expect(formatRelativeLoggedAt('not-a-date', NOW)).toBe('not-a-date');
+  });
+});

--- a/src/lib/checkins.ts
+++ b/src/lib/checkins.ts
@@ -1,0 +1,242 @@
+/**
+ * Check-ins data layer for [2C-20] recent check-ins view.
+ *
+ * Fetches `/api/checkins/?logged_after=<30-days-ago>` with bearer auth and
+ * exposes the Capacitor Preferences cache that backs the offline-launch
+ * fallback. Cache pattern mirrors `lib/habits.ts` and `lib/notifications.ts`:
+ * a JSON blob under a `brain.cache.*` key, with `fetched_at` provenance for
+ * "Showing cached data" surfacing.
+ *
+ * Type shape mirrors `app/schemas/checkins.py:68-80` (CheckinResponse) on the
+ * brain3 server. The `list_checkins` endpoint returns a bare JSON array
+ * (not `{items, count}`) per `app/routers/checkins.py:42`, so the parser
+ * here differs slightly from the habits/routines envelope.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import { parseISO, startOfDay, subDays } from 'date-fns';
+import type { Pairing } from './pairing';
+
+export const CHECKINS_CACHE_KEY = 'brain.cache.checkins';
+export const CHECKINS_PATH = '/api/checkins/';
+
+const FETCH_TIMEOUT_MS = 10_000;
+const RECENT_WINDOW_DAYS = 30;
+const FREEFORM_PREVIEW_MAX = 60;
+
+export type CheckinType =
+  | 'morning'
+  | 'midday'
+  | 'evening'
+  | 'micro'
+  | 'freeform';
+
+export interface CheckinResponse {
+  id: string;
+  checkin_type: CheckinType;
+  energy_level: number | null;
+  mood: number | null;
+  focus_level: number | null;
+  freeform_note: string | null;
+  context: string | null;
+  /** ISO timestamp set server-side at insert time. */
+  logged_at: string;
+}
+
+export type FetchCheckinsResult =
+  | { ok: true; items: CheckinResponse[] }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout';
+      statusCode?: number;
+    };
+
+export type FetchCheckinResult =
+  | { ok: true; checkin: CheckinResponse }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
+      statusCode?: number;
+    };
+
+/**
+ * UTC ISO timestamp for local midnight 30 days ago. Anchors the
+ * `logged_after` filter on the device-local calendar so the window is a
+ * predictable 30 days regardless of TZ.
+ */
+export function thirtyDaysAgoLocalMidnightUtc(now: Date = new Date()): string {
+  return subDays(startOfDay(now), RECENT_WINDOW_DAYS).toISOString();
+}
+
+export async function fetchCheckins(
+  pairing: Pairing,
+  now: Date = new Date(),
+): Promise<FetchCheckinsResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const loggedAfter = thirtyDaysAgoLocalMidnightUtc(now);
+  const url = `${base}${CHECKINS_PATH}?logged_after=${encodeURIComponent(loggedAfter)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items = Array.isArray(body) ? (body as CheckinResponse[]) : [];
+      return { ok: true, items };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchCheckin(
+  pairing: Pairing,
+  checkinId: string,
+): Promise<FetchCheckinResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${CHECKINS_PATH}${checkinId}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as CheckinResponse;
+      return { ok: true, checkin: body };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface CachedCheckins {
+  fetched_at: string;
+  items: CheckinResponse[];
+}
+
+export async function readCachedCheckins(): Promise<CachedCheckins | null> {
+  const { value } = await Preferences.get({ key: CHECKINS_CACHE_KEY });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'items' in parsed &&
+      'fetched_at' in parsed &&
+      Array.isArray((parsed as CachedCheckins).items) &&
+      typeof (parsed as CachedCheckins).fetched_at === 'string'
+    ) {
+      return parsed as CachedCheckins;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedCheckins(
+  items: CheckinResponse[],
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedCheckins = {
+    fetched_at: now.toISOString(),
+    items,
+  };
+  await Preferences.set({
+    key: CHECKINS_CACHE_KEY,
+    value: JSON.stringify(payload),
+  });
+}
+
+const FRIENDLY_LABELS: Record<CheckinType, string> = {
+  morning: 'Morning check-in',
+  midday: 'Midday check-in',
+  evening: 'Evening check-in',
+  micro: 'Micro check-in',
+  freeform: 'Freeform check-in',
+};
+
+export function friendlyCheckinTypeLabel(type: CheckinType): string {
+  return FRIENDLY_LABELS[type];
+}
+
+/**
+ * Compose subtitle line 1 from non-null numeric values, in the spec's order
+ * (Energy · Focus · Mood). Returns null if all three are null so the caller
+ * can suppress the subtitle line entirely.
+ */
+export function composeNumericSubtitle(
+  checkin: Pick<CheckinResponse, 'energy_level' | 'focus_level' | 'mood'>,
+): string | null {
+  const parts: string[] = [];
+  if (checkin.energy_level !== null) parts.push(`Energy ${checkin.energy_level}`);
+  if (checkin.focus_level !== null) parts.push(`Focus ${checkin.focus_level}`);
+  if (checkin.mood !== null) parts.push(`Mood ${checkin.mood}`);
+  return parts.length === 0 ? null : parts.join(' · ');
+}
+
+/**
+ * Truncate a freeform note to `FREEFORM_PREVIEW_MAX` chars with an ellipsis
+ * suffix when it's longer. Used for the list-row subtitle preview only —
+ * the detail view renders the full note.
+ */
+export function truncateFreeformPreview(note: string): string {
+  if (note.length <= FREEFORM_PREVIEW_MAX) return note;
+  return `${note.slice(0, FREEFORM_PREVIEW_MAX)}…`;
+}
+
+/**
+ * Short relative-time labels per spec — "2h ago", "yesterday", "3d ago".
+ * Falls back to the raw ISO string on parse failure.
+ */
+export function formatRelativeLoggedAt(
+  iso: string,
+  now: Date = new Date(),
+): string {
+  try {
+    const then = parseISO(iso);
+    const deltaMs = now.getTime() - then.getTime();
+    if (Number.isNaN(deltaMs)) return iso;
+    const minutes = Math.floor(deltaMs / 60_000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return 'yesterday';
+    return `${days}d ago`;
+  } catch {
+    return iso;
+  }
+}

--- a/src/pages/CheckinDetailPage.test.tsx
+++ b/src/pages/CheckinDetailPage.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import type { CheckinResponse } from '../lib/checkins';
+import CheckinDetailPage from './CheckinDetailPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeCheckin(overrides: Partial<CheckinResponse> = {}): CheckinResponse {
+  return {
+    id: overrides.id ?? 'c-1',
+    checkin_type: overrides.checkin_type ?? 'morning',
+    energy_level: overrides.energy_level ?? null,
+    mood: overrides.mood ?? null,
+    focus_level: overrides.focus_level ?? null,
+    freeform_note: overrides.freeform_note ?? null,
+    context: overrides.context ?? null,
+    logged_at: overrides.logged_at ?? '2026-05-09T08:00:00Z',
+  };
+}
+
+interface FetchOptions {
+  response?: { status: number; checkin?: CheckinResponse };
+}
+
+function stubFetch(opts: FetchOptions = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/checkins/')) {
+        const r = opts.response ?? { status: 404 };
+        if (r.status === 200 && r.checkin) {
+          return new Response(JSON.stringify(r.checkin), { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderDetail(checkinId: string) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/checkins/${checkinId}`]}>
+        <Route path="/checkins/:checkinId">
+          <CheckinDetailPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('CheckinDetailPage — render', () => {
+  it('renders all populated fields including the full freeform note', async () => {
+    pair();
+    const longNote =
+      'this is the full freeform note text that should not be truncated on the detail surface — '
+      + 'it stretches well past sixty characters to confirm full render.';
+    stubFetch({
+      response: {
+        status: 200,
+        checkin: makeCheckin({
+          id: 'c-9',
+          checkin_type: 'evening',
+          energy_level: 3,
+          focus_level: 2,
+          mood: 4,
+          freeform_note: longNote,
+          context: 'after dinner',
+          logged_at: '2026-05-09T20:30:00Z',
+        }),
+      },
+    });
+
+    renderDetail('c-9');
+
+    expect(await screen.findByText('Evening check-in')).toBeInTheDocument();
+    expect(screen.getByText('after dinner')).toBeInTheDocument();
+    expect(screen.getByTestId('checkin-detail-energy')).toHaveTextContent(
+      '3 / 5',
+    );
+    expect(screen.getByTestId('checkin-detail-focus')).toHaveTextContent(
+      '2 / 5',
+    );
+    expect(screen.getByTestId('checkin-detail-mood')).toHaveTextContent(
+      '4 / 5',
+    );
+    expect(screen.getByTestId('checkin-detail-note')).toHaveTextContent(
+      longNote,
+    );
+  });
+
+  it('omits numeric rows for null fields', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        checkin: makeCheckin({
+          id: 'c-1',
+          checkin_type: 'micro',
+          energy_level: 2,
+          focus_level: null,
+          mood: null,
+        }),
+      },
+    });
+
+    renderDetail('c-1');
+
+    expect(await screen.findByText('Micro check-in')).toBeInTheDocument();
+    expect(screen.getByTestId('checkin-detail-energy')).toBeInTheDocument();
+    expect(screen.queryByTestId('checkin-detail-focus')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('checkin-detail-mood')).not.toBeInTheDocument();
+  });
+
+  it('omits the note section when freeform_note is null', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        checkin: makeCheckin({
+          id: 'c-2',
+          checkin_type: 'morning',
+          energy_level: 4,
+          freeform_note: null,
+        }),
+      },
+    });
+
+    renderDetail('c-2');
+
+    expect(await screen.findByText('Morning check-in')).toBeInTheDocument();
+    expect(screen.queryByTestId('checkin-detail-note')).not.toBeInTheDocument();
+  });
+
+  it('shows "Check-in not found." when the server returns 404', async () => {
+    pair();
+    stubFetch({ response: { status: 404 } });
+
+    renderDetail('c-missing');
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /check-in not found/i,
+      );
+    });
+  });
+
+  it('shows the unpaired message when the app is not paired', async () => {
+    stubFetch();
+    renderDetail('c-1');
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/CheckinDetailPage.tsx
+++ b/src/pages/CheckinDetailPage.tsx
@@ -1,0 +1,209 @@
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonText,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { useEffect, useState } from 'react';
+import { useQuery, type QueryKey } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchCheckin,
+  friendlyCheckinTypeLabel,
+  type CheckinResponse,
+} from '../lib/checkins';
+
+const CHECKIN_QUERY_KEY = (id: string): QueryKey => ['checkin', id];
+const STALE_MS = 5 * 60 * 1000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | { kind: 'paired'; pairing: Pairing };
+
+function formatLoggedAt(iso: string): string {
+  try {
+    return format(parseISO(iso), "EEE, MMM d 'at' h:mm a");
+  } catch {
+    return iso;
+  }
+}
+
+const CheckinDetailPage: React.FC = () => {
+  const { checkinId } = useParams<{ checkinId: string }>();
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const pairing = await loadPairing();
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      setBootstrap({ kind: 'paired', pairing });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/checkins" />
+          </IonButtons>
+          <IonTitle>Check-in</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to view this check-in.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <CheckinDetailBody pairing={bootstrap.pairing} checkinId={checkinId} />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  checkinId: string;
+}
+
+const CheckinDetailBody: React.FC<BodyProps> = ({ pairing, checkinId }) => {
+  const checkinQuery = useQuery<CheckinResponse>({
+    queryKey: CHECKIN_QUERY_KEY(checkinId),
+    queryFn: async () => {
+      const result = await fetchCheckin(pairing, checkinId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      return result.checkin;
+    },
+    staleTime: STALE_MS,
+  });
+
+  if (checkinQuery.isPending) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-neutral-300">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  if (checkinQuery.isError) {
+    const message =
+      (checkinQuery.error as Error | undefined)?.message === 'not_found'
+        ? "Check-in not found."
+        : "Couldn't load check-in.";
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-200"
+        role="alert"
+      >
+        <p>{message}</p>
+      </div>
+    );
+  }
+
+  const checkin = checkinQuery.data;
+
+  return (
+    <div className="px-4 pt-4">
+      <h1 className="text-2xl text-neutral-100">
+        {friendlyCheckinTypeLabel(checkin.checkin_type)}
+      </h1>
+      <p className="pt-1">
+        <IonText color="medium">
+          <small>{formatLoggedAt(checkin.logged_at)}</small>
+        </IonText>
+      </p>
+
+      <IonList className="ion-margin-top">
+        {checkin.context !== null ? (
+          <IonItem lines="full">
+            <IonLabel>
+              <IonNote>Context</IonNote>
+              <p>{checkin.context}</p>
+            </IonLabel>
+          </IonItem>
+        ) : null}
+
+        {checkin.energy_level !== null ? (
+          <IonItem lines="full">
+            <IonLabel>
+              <IonNote>Energy</IonNote>
+              <p data-testid="checkin-detail-energy">
+                {checkin.energy_level} / 5
+              </p>
+            </IonLabel>
+          </IonItem>
+        ) : null}
+
+        {checkin.focus_level !== null ? (
+          <IonItem lines="full">
+            <IonLabel>
+              <IonNote>Focus</IonNote>
+              <p data-testid="checkin-detail-focus">
+                {checkin.focus_level} / 5
+              </p>
+            </IonLabel>
+          </IonItem>
+        ) : null}
+
+        {checkin.mood !== null ? (
+          <IonItem lines="full">
+            <IonLabel>
+              <IonNote>Mood</IonNote>
+              <p data-testid="checkin-detail-mood">{checkin.mood} / 5</p>
+            </IonLabel>
+          </IonItem>
+        ) : null}
+      </IonList>
+
+      {checkin.freeform_note ? (
+        <div className="ion-margin-top px-1">
+          <IonText color="medium">
+            <small>Note</small>
+          </IonText>
+          <p
+            className="whitespace-pre-wrap pt-1 text-neutral-100"
+            data-testid="checkin-detail-note"
+          >
+            {checkin.freeform_note}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default CheckinDetailPage;

--- a/src/pages/CheckinsPage.test.tsx
+++ b/src/pages/CheckinsPage.test.tsx
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: vi.fn(),
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { CHECKINS_CACHE_KEY, type CheckinResponse } from '../lib/checkins';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import CheckinsPage from './CheckinsPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function seedCache(items: CheckinResponse[]): void {
+  prefsStore.set(
+    CHECKINS_CACHE_KEY,
+    JSON.stringify({ fetched_at: '2026-05-09T00:00:00Z', items }),
+  );
+}
+
+function makeCheckin(overrides: Partial<CheckinResponse> = {}): CheckinResponse {
+  return {
+    id: overrides.id ?? 'c-1',
+    checkin_type: overrides.checkin_type ?? 'morning',
+    energy_level: overrides.energy_level ?? null,
+    mood: overrides.mood ?? null,
+    focus_level: overrides.focus_level ?? null,
+    freeform_note: overrides.freeform_note ?? null,
+    context: overrides.context ?? null,
+    logged_at: overrides.logged_at ?? '2026-05-09T08:00:00Z',
+  };
+}
+
+interface FetchOptions {
+  response?: { status: number; items?: CheckinResponse[] };
+  rejection?: Error;
+}
+
+function stubFetch(opts: FetchOptions = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/checkins/')) {
+        if (opts.rejection) throw opts.rejection;
+        const r = opts.response ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          return new Response(JSON.stringify(r.items ?? []), { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/checkins']}>
+        <CheckinsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('CheckinsPage — bootstrap', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CheckinsPage — list render', () => {
+  it('renders rows with friendly type, numeric subtitle, note preview, and relative time', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [
+          makeCheckin({
+            id: 'c-1',
+            checkin_type: 'morning',
+            energy_level: 4,
+            focus_level: 3,
+            mood: 5,
+            freeform_note: 'Feeling sharp today after a solid night.',
+            // Two hours before the test render time — exact relative wording
+            // is not asserted here (drift between fixture and `Date.now()`),
+            // just that the row mounts.
+            logged_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Morning check-in')).toBeInTheDocument();
+    expect(screen.getByText('Energy 4 · Focus 3 · Mood 5')).toBeInTheDocument();
+    expect(
+      screen.getByText('Feeling sharp today after a solid night.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the numeric subtitle when no numeric values are populated', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [
+          makeCheckin({
+            id: 'c-2',
+            checkin_type: 'freeform',
+            freeform_note: 'just some thoughts',
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Freeform check-in')).toBeInTheDocument();
+    expect(screen.queryByText(/Energy /)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Mood /)).not.toBeInTheDocument();
+    expect(screen.getByText('just some thoughts')).toBeInTheDocument();
+  });
+
+  it('truncates long freeform notes to 60 chars with ellipsis', async () => {
+    pair();
+    const longNote =
+      'this is a long freeform note that exceeds the sixty character preview window for sure';
+    stubFetch({
+      response: {
+        status: 200,
+        items: [
+          makeCheckin({
+            id: 'c-3',
+            checkin_type: 'evening',
+            freeform_note: longNote,
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const expected = `${longNote.slice(0, 60)}…`;
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+  });
+});
+
+describe('CheckinsPage — empty state', () => {
+  it('shows the "no check-ins yet" empty-state message', async () => {
+    pair();
+    stubFetch({ response: { status: 200, items: [] } });
+    renderPage();
+    expect(
+      await screen.findByText(
+        /no check-ins yet\. they appear here when you respond/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CheckinsPage — navigation', () => {
+  it('pushes /checkins/:id when a row is tapped', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [makeCheckin({ id: 'c-9', checkin_type: 'morning' })],
+      },
+    });
+
+    renderPage();
+
+    const title = await screen.findByText('Morning check-in');
+    await userEvent.click(title);
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith('/checkins/c-9');
+    });
+  });
+});
+
+describe('CheckinsPage — offline cache', () => {
+  it('renders cached items + cache hint when the network fetch fails', async () => {
+    pair();
+    seedCache([
+      makeCheckin({
+        id: 'c-cache',
+        checkin_type: 'midday',
+        freeform_note: 'cached entry',
+      }),
+    ]);
+    stubFetch({ rejection: new Error('offline') });
+
+    renderPage();
+
+    expect(await screen.findByText('Midday check-in')).toBeInTheDocument();
+    expect(screen.getByText('cached entry')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/showing cached data/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CheckinsPage — fetch URL', () => {
+  it('issues GET against /api/checkins/ with logged_after and bearer token', async () => {
+    pair();
+    const fetchSpy = stubFetch({ response: { status: 200, items: [] } });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const checkinsCall = fetchSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string' && call[0].includes('/api/checkins/'),
+    );
+    expect(checkinsCall).toBeDefined();
+    const url = checkinsCall![0] as string;
+    expect(url.startsWith(`${PAIRED_URL}/api/checkins/`)).toBe(true);
+    expect(url).toContain('logged_after=');
+    const init = checkinsCall![1] as RequestInit;
+    expect(init.headers).toEqual({ Authorization: `Bearer ${PAIRED_TOKEN}` });
+  });
+});

--- a/src/pages/CheckinsPage.tsx
+++ b/src/pages/CheckinsPage.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import {
+  useQuery,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { useHistory } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  composeNumericSubtitle,
+  fetchCheckins,
+  formatRelativeLoggedAt,
+  friendlyCheckinTypeLabel,
+  readCachedCheckins,
+  truncateFreeformPreview,
+  writeCachedCheckins,
+  type CheckinResponse,
+} from '../lib/checkins';
+
+const CHECKINS_QUERY_KEY: QueryKey = ['checkins'];
+const CHECKINS_STALE_MS = 5 * 60 * 1000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedItems: CheckinResponse[] | null;
+      cachedFetchedAtMs: number | null;
+    };
+
+const CheckinsPage: React.FC = () => {
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cached] = await Promise.all([
+        loadPairing(),
+        readCachedCheckins(),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const cachedFetchedAtMs = cached?.fetched_at
+        ? Date.parse(cached.fetched_at)
+        : null;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedItems: cached?.items ?? null,
+        cachedFetchedAtMs: Number.isFinite(cachedFetchedAtMs)
+          ? cachedFetchedAtMs
+          : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Check-ins</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see check-ins.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <CheckinsBody
+            pairing={bootstrap.pairing}
+            initialCachedItems={bootstrap.cachedItems}
+            initialCachedFetchedAtMs={bootstrap.cachedFetchedAtMs}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  initialCachedItems: CheckinResponse[] | null;
+  initialCachedFetchedAtMs: number | null;
+}
+
+const CheckinsBody: React.FC<BodyProps> = ({
+  pairing,
+  initialCachedItems,
+  initialCachedFetchedAtMs,
+}) => {
+  const history = useHistory();
+
+  const checkinsQuery = useQuery<CheckinResponse[]>({
+    queryKey: CHECKINS_QUERY_KEY,
+    queryFn: async () => {
+      const result = await fetchCheckins(pairing);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedCheckins(result.items);
+      return result.items;
+    },
+    initialData: initialCachedItems ?? undefined,
+    initialDataUpdatedAt:
+      initialCachedItems !== null && initialCachedFetchedAtMs !== null
+        ? initialCachedFetchedAtMs
+        : undefined,
+    staleTime: CHECKINS_STALE_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  const items = checkinsQuery.data;
+  const showCacheHint =
+    checkinsQuery.isError && items !== undefined && items.length >= 0;
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await checkinsQuery.refetch();
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [checkinsQuery],
+  );
+
+  const onRowClick = useCallback(
+    (checkin: CheckinResponse): void => {
+      history.push(`/checkins/${checkin.id}`);
+    },
+    [history],
+  );
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      {showCacheHint ? (
+        <div
+          className="px-4 pt-3 text-sm text-neutral-300"
+          role="status"
+          aria-live="polite"
+        >
+          Showing cached data
+        </div>
+      ) : null}
+
+      {items !== undefined && items.length === 0 ? (
+        <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+          <p>
+            No check-ins yet. They appear here when you respond to check-in
+            prompts.
+          </p>
+        </div>
+      ) : null}
+
+      {items !== undefined && items.length > 0 ? (
+        <IonList>
+          {items.map((checkin) => (
+            <CheckinRow
+              key={checkin.id}
+              checkin={checkin}
+              onRowClick={onRowClick}
+            />
+          ))}
+        </IonList>
+      ) : null}
+    </>
+  );
+};
+
+interface RowProps {
+  checkin: CheckinResponse;
+  onRowClick: (checkin: CheckinResponse) => void;
+}
+
+const CheckinRow: React.FC<RowProps> = ({ checkin, onRowClick }) => {
+  const numericSubtitle = composeNumericSubtitle(checkin);
+  const notePreview = checkin.freeform_note
+    ? truncateFreeformPreview(checkin.freeform_note)
+    : null;
+  return (
+    <IonItem
+      button
+      onClick={() => onRowClick(checkin)}
+      data-testid={`checkin-row-${checkin.id}`}
+    >
+      <IonLabel className="ion-text-wrap">
+        <h2>{friendlyCheckinTypeLabel(checkin.checkin_type)}</h2>
+        {numericSubtitle ? (
+          <p>
+            <IonText color="medium">
+              <small>{numericSubtitle}</small>
+            </IonText>
+          </p>
+        ) : null}
+        {notePreview ? (
+          <p>
+            <IonText color="medium">
+              <em>{notePreview}</em>
+            </IonText>
+          </p>
+        ) : null}
+      </IonLabel>
+      <div slot="end" className="flex flex-col items-end">
+        <IonNote className="text-xs">
+          {formatRelativeLoggedAt(checkin.logged_at)}
+        </IonNote>
+      </div>
+    </IonItem>
+  );
+};
+
+export default CheckinsPage;


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (0 errors, 0 warnings)
- `npm run test.unit -- --run` — ✅ Pass (243 passed, 0 failed across 20 files; 40 of those are new in this PR)
- Migration applied locally on brain3-dev: ✅ N/A (client-only)
- Postgres-backed test confirmed: ✅ N/A (client-only)
- Android sync ran clean: ✅ N/A (no Capacitor plugin / native dependency changes)

Ran locally against develop HEAD at `09222d7` immediately before opening this PR.

## Summary

Adds the [2C-20] recent check-ins surface to the companion app: a list at `/checkins` showing the last 30 days of state check-ins, and a read-only detail screen at `/checkins/:checkinId`. The surface follows the modern Stream C pattern (TanStack Query + cache-first paint via `initialData` + `initialDataUpdatedAt`) established by [2C-21] habits and [2C-24]/[2C-25] routines, and uses the layout vocabulary from [2C-09] notifications (single `IonList` of rows, pull-to-refresh, "Showing cached data" hint, paired/no-pairing bootstrap).

The list endpoint on the server (`/api/checkins/`) returns a bare JSON array — not the `{items, count}` envelope used by habits/routines — so the client-side parser in `lib/checkins.ts` differs slightly. Verified against `origin/develop` `app/routers/checkins.py:42-62` and `app/schemas/checkins.py:68-80`.

## Changes

- **`src/lib/checkins.ts` (new)** — Data layer. Types match `CheckinResponse` on the server (`id`, `checkin_type`, `energy_level`, `mood`, `focus_level`, `freeform_note`, `context`, `logged_at`). `fetchCheckins(pairing, now)` issues `GET /api/checkins/?logged_after=<thirtyDaysAgoLocalMidnightUtc>` with bearer auth; `fetchCheckin(pairing, id)` is the by-id variant with explicit `not_found` reason on 404. `readCachedCheckins` / `writeCachedCheckins` use the `brain.cache.checkins` Preferences key with the same `{fetched_at, items}` shape as the habits/notifications caches. Presentation helpers (`friendlyCheckinTypeLabel`, `composeNumericSubtitle`, `truncateFreeformPreview`, `formatRelativeLoggedAt`) are colocated and unit-tested.
- **`src/pages/CheckinsPage.tsx` (new)** — List page. Bootstrap loads pairing + cache in parallel, then `CheckinsBody` runs the `['checkins']` TanStack Query with cache as `initialData`. Each row renders `friendlyCheckinTypeLabel(checkin_type)` as the title; subtitle line 1 is the non-null numeric values in spec order (Energy · Focus · Mood); subtitle line 2 is the freeform note truncated to 60 chars + ellipsis (italicised); trailing slot is the short relative-time label. Empty state, pull-to-refresh re-fetch, and cache-hint surface follow the [2C-21] habits pattern.
- **`src/pages/CheckinDetailPage.tsx` (new)** — Detail page. Single `useQuery(['checkin', id])` fetches the full record. Renders `checkin_type`, formatted `logged_at`, and rows for each populated field (`context`, `energy_level`, `focus_level`, `mood`); the freeform note appears below in full (no truncation). 404s render "Check-in not found." in an alert. **No edit, no delete, no add-note** — out-of-scope per spec.
- **`src/App.tsx`** — Imports the two new pages and registers `/checkins` and `/checkins/:checkinId` routes inside `IonRouterOutlet`, keeping `/` redirect behaviour unchanged.

## How to Verify

1. Pair the app to a brain3 dev server with at least one check-in row in the database.
2. Visit `/checkins`. Expect the list of check-ins logged in the last 30 days, sorted by `logged_at` descending. Each row should show the friendly type label, the populated numeric values, the 60-char note preview (italic), and the relative time on the right.
3. Pull down on the list. Expect the refresher spinner and a re-fetch.
4. Tap any row. Expect navigation to `/checkins/:id`. Detail screen should render every populated field, the full freeform note (untruncated), and a back button to `/checkins`.
5. With no rows in the database, `/checkins` should render the empty-state message: "No check-ins yet. They appear here when you respond to check-in prompts."
6. Kill the network and relaunch. The list should paint from cache; once a fetch attempt fails, the "Showing cached data" hint should appear.

## Deviations

- **Repo CLAUDE.md drift (minor, observation-only).** The repo working copy of `brain3-companion/CLAUDE.md` is at v2 (April 30) but BRAIN canonical is v3 (May 1). The v3 amendment is a hedge added to the Pre-PR Verification Gates section noting that the codified PR-trigger Dev Release workflow is queued behind issue [2C-Gap-05] (#55) and the workflow `on:` block remains push-only until that lands. v3 also cross-references [2C-Gap-04] (#54) under Android Sync Structural Guard. Neither amendment is material to [2C-20]. Per the org CLAUDE.md inheritance rule, BRAIN wins for the session's work; flagging here so PO can sync the working copy when convenient. Did not modify the file (CLAUDE.md is PO-controlled per directive `4ea28266`).

## Test Results

```
> brain3-companion@0.0.1 test.unit
> vitest --run

 Test Files  20 passed (20)
      Tests  243 passed (243)
   Duration  8.02s
```

```
> brain3-companion@0.0.1 lint
> eslint

(no output — clean)
```

40 of the 243 tests are new in this PR (27 in `lib/checkins.test.ts`, 8 in `CheckinsPage.test.tsx`, 5 in `CheckinDetailPage.test.tsx`).

## Acceptance Checklist

- [x] `/checkins` loads, shows last 30 days of check-ins (via `logged_after=<30-days-ago>` filter)
- [x] Numeric values + note preview render correctly per populated fields
- [x] Empty state renders when no check-ins exist
- [x] Tap → detail view (`/checkins/:checkinId`)
- [x] Pull-to-refresh works (re-issues the query)
- [x] `/checkins/{id}` renders full note text (not truncated)
- [x] Offline launch: shows cached list (cache-first paint via `initialData` + `initialDataUpdatedAt`)

Closes #15