### PR TITLE
[2C-16] Rules list screen + rule detail view (read-only)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import RoutinesPage from './pages/RoutinesPage';
 import RoutineDetailPage from './pages/RoutineDetailPage';
 import CheckinsPage from './pages/CheckinsPage';
 import CheckinDetailPage from './pages/CheckinDetailPage';
+import RulesPage from './pages/RulesPage';
+import RuleDetailPage from './pages/RuleDetailPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
 import {
   clearDeviceRegistration,
@@ -125,6 +127,12 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/checkins/:checkinId">
             <CheckinDetailPage />
+          </Route>
+          <Route exact path="/rules">
+            <RulesPage />
+          </Route>
+          <Route exact path="/rules/:ruleId">
+            <RuleDetailPage />
           </Route>
           <Route exact path="/">
             <RootRedirect />

--- a/src/components/RuleEnabledPill.test.tsx
+++ b/src/components/RuleEnabledPill.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import RuleEnabledPill from './RuleEnabledPill';
+
+describe('RuleEnabledPill', () => {
+  it('renders the Enabled pill in emerald tone when enabled', () => {
+    render(<RuleEnabledPill enabled={true} />);
+    const pill = screen.getByTestId('rule-enabled-pill-enabled');
+    expect(pill).toHaveTextContent('Enabled');
+    expect(pill.className).toMatch(/emerald/);
+  });
+
+  it('renders the Disabled pill in neutral tone when disabled', () => {
+    render(<RuleEnabledPill enabled={false} />);
+    const pill = screen.getByTestId('rule-enabled-pill-disabled');
+    expect(pill).toHaveTextContent('Disabled');
+    expect(pill.className).toMatch(/neutral/);
+  });
+});

--- a/src/components/RuleEnabledPill.tsx
+++ b/src/components/RuleEnabledPill.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  enabled: boolean;
+}
+
+/**
+ * Read-only pill showing whether a rule is enabled. Lives next to
+ * `StatusPill` rather than reusing it because that component is typed
+ * against the 3-way scaffolding-status enum and the rule's binary enabled
+ * state doesn't fit that shape cleanly. See PR body for the
+ * first-consumer-instantiates note from [2C-21].
+ */
+const RuleEnabledPill: React.FC<Props> = ({ enabled }) => {
+  const tone = enabled
+    ? 'bg-emerald-100 text-emerald-800 ring-emerald-200'
+    : 'bg-neutral-100 text-neutral-700 ring-neutral-300';
+  const label = enabled ? 'Enabled' : 'Disabled';
+  return (
+    <span
+      data-testid={`rule-enabled-pill-${enabled ? 'enabled' : 'disabled'}`}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${tone}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default RuleEnabledPill;

--- a/src/lib/rules.test.ts
+++ b/src/lib/rules.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  RECENT_FIRES_LIMIT,
+  RULES_CACHE_KEY,
+  fetchRule,
+  fetchRuleFires,
+  fetchRules,
+  formatRelativeFiredAt,
+  readCachedRules,
+  sortRulesForList,
+  writeCachedRules,
+  type RuleRead,
+} from './rules';
+import type { NotificationItem } from './notifications';
+import type { Pairing } from './pairing';
+
+const PAIRING: Pairing = { url: 'https://brain.local:8000', token: 'tk-1' };
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRule(overrides: Partial<RuleRead> = {}): RuleRead {
+  return {
+    id: overrides.id ?? 'r-1',
+    name: overrides.name ?? 'Habit nudge — 3 skips',
+    entity_type: overrides.entity_type ?? 'habit',
+    entity_id: overrides.entity_id ?? null,
+    metric: overrides.metric ?? 'consecutive_skips',
+    operator: overrides.operator ?? '>=',
+    threshold: overrides.threshold ?? 3,
+    action: overrides.action ?? 'create_notification',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message_template:
+      overrides.message_template ??
+      "{entity_name} hasn't been touched in {metric_value} days",
+    enabled: overrides.enabled ?? true,
+    cooldown_hours: overrides.cooldown_hours ?? 24,
+    is_default: overrides.is_default ?? false,
+    last_triggered_at: overrides.last_triggered_at ?? null,
+    created_at: overrides.created_at ?? '2026-05-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-01T00:00:00Z',
+  };
+}
+
+function makeNotification(
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  return {
+    id: overrides.id ?? 'n-1',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message: overrides.message ?? 'Test message',
+    scheduled_at: overrides.scheduled_at ?? '2026-05-09T08:00:00Z',
+    scheduled_date: overrides.scheduled_date ?? '2026-05-09',
+    status: overrides.status ?? 'delivered',
+    expires_at: overrides.expires_at ?? '2026-05-09T20:00:00Z',
+    response: overrides.response ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('fetchRules — envelope handling', () => {
+  it('unwraps {items, count} envelope from /api/rules/', async () => {
+    const items = [makeRule({ id: 'r-a' }), makeRule({ id: 'r-b' })];
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ items, count: 2 }), { status: 200 }),
+      );
+
+    const result = await fetchRules(PAIRING);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items).toHaveLength(2);
+      expect(result.items.map((r) => r.id)).toEqual(['r-a', 'r-b']);
+    }
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PAIRING.url}/api/rules/`,
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${PAIRING.token}` },
+      }),
+    );
+  });
+
+  it('returns empty list when the server returns a non-envelope shape', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('null', { status: 200 }),
+    );
+    const result = await fetchRules(PAIRING);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.items).toEqual([]);
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [500, 'server'],
+  ] as const)('maps %i to reason "%s"', async (status, reason) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('', { status }),
+    );
+    const result = await fetchRules(PAIRING);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe(reason);
+  });
+});
+
+describe('fetchRule', () => {
+  it('returns the rule on 200', async () => {
+    const rule = makeRule({ id: 'r-9', name: 'Streak loss' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(rule), { status: 200 }),
+    );
+    const result = await fetchRule(PAIRING, 'r-9');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.rule.name).toBe('Streak loss');
+  });
+
+  it('maps 404 to not_found', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('', { status: 404 }),
+    );
+    const result = await fetchRule(PAIRING, 'r-x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('not_found');
+  });
+});
+
+describe('fetchRuleFires', () => {
+  it('queries /api/notifications/?rule_id=<id> and trims to limit', async () => {
+    const items = Array.from({ length: 25 }, (_, i) =>
+      makeNotification({ id: `n-${i}` }),
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ items, count: 25 }), { status: 200 }),
+      );
+
+    const result = await fetchRuleFires(PAIRING, 'r-1');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PAIRING.url}/api/notifications/?rule_id=r-1`,
+      expect.any(Object),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.items).toHaveLength(RECENT_FIRES_LIMIT);
+  });
+
+  it('honors a custom limit', async () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeNotification({ id: `n-${i}` }),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ items, count: 5 }), { status: 200 }),
+    );
+
+    const result = await fetchRuleFires(PAIRING, 'r-1', 2);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.items).toHaveLength(2);
+  });
+});
+
+describe('readCachedRules / writeCachedRules', () => {
+  it('round-trips cached rules through Preferences', async () => {
+    const items = [makeRule({ id: 'r-a' })];
+    await writeCachedRules(items, new Date('2026-05-09T12:00:00Z'));
+    const cached = await readCachedRules();
+    expect(cached).not.toBeNull();
+    expect(cached?.items).toEqual(items);
+    expect(cached?.fetched_at).toBe('2026-05-09T12:00:00.000Z');
+  });
+
+  it('returns null when no cache is present', async () => {
+    expect(await readCachedRules()).toBeNull();
+  });
+
+  it('returns null when the cache is malformed', async () => {
+    prefsStore.set(RULES_CACHE_KEY, 'not-json');
+    expect(await readCachedRules()).toBeNull();
+  });
+});
+
+describe('sortRulesForList', () => {
+  it('orders by last_triggered_at desc, with never-fired rules pushed below', () => {
+    const a = makeRule({
+      id: 'a',
+      last_triggered_at: '2026-05-08T00:00:00Z',
+      created_at: '2026-04-01T00:00:00Z',
+    });
+    const b = makeRule({
+      id: 'b',
+      last_triggered_at: '2026-05-09T00:00:00Z',
+      created_at: '2026-04-01T00:00:00Z',
+    });
+    const c = makeRule({
+      id: 'c',
+      last_triggered_at: null,
+      created_at: '2026-05-01T00:00:00Z',
+    });
+    const d = makeRule({
+      id: 'd',
+      last_triggered_at: null,
+      created_at: '2026-04-15T00:00:00Z',
+    });
+
+    expect(sortRulesForList([a, b, c, d]).map((r) => r.id)).toEqual([
+      'b',
+      'a',
+      'c',
+      'd',
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      makeRule({ id: '1', last_triggered_at: null }),
+      makeRule({ id: '2', last_triggered_at: '2026-05-09T00:00:00Z' }),
+    ];
+    const original = [...input];
+    sortRulesForList(input);
+    expect(input).toEqual(original);
+  });
+});
+
+describe('formatRelativeFiredAt', () => {
+  const now = new Date('2026-05-09T12:00:00Z');
+
+  it.each([
+    [null, 'never fired'],
+    [new Date('2026-05-09T11:59:30Z').toISOString(), 'fired just now'],
+    [new Date('2026-05-09T11:55:00Z').toISOString(), 'fired 5m ago'],
+    [new Date('2026-05-09T10:00:00Z').toISOString(), 'fired 2h ago'],
+    [new Date('2026-05-08T12:00:00Z').toISOString(), 'fired yesterday'],
+    [new Date('2026-05-06T12:00:00Z').toISOString(), 'fired 3d ago'],
+  ])('formats %s as %s', (iso, expected) => {
+    expect(formatRelativeFiredAt(iso, now)).toBe(expected);
+  });
+
+  it('returns the raw value on parse failure', () => {
+    expect(formatRelativeFiredAt('not-a-date', now)).toBe('not-a-date');
+  });
+});

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,0 +1,297 @@
+/**
+ * Rules data layer for [2C-16] read-only rules list + detail surfaces.
+ *
+ * Fetches `/api/rules/` (list) and `/api/rules/{id}` (detail) with bearer
+ * auth, plus `/api/notifications/?rule_id={id}` (recent fires). Mirrors the
+ * envelope-aware parsing pattern used in `lib/habits.ts` — the rules and
+ * notifications list endpoints both return `{items, count}` envelopes per
+ * `brain3/app/schemas/rule.py:178` (RuleListResponse) and
+ * `brain3/app/schemas/notifications.py:125` (NotificationListResponse).
+ *
+ * Type shape mirrors `app/schemas/rule.py:155-175` (RuleRead) on the brain3
+ * server, verified per the spec's Pass 3 Summary §B.2.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { QueryKey } from '@tanstack/react-query';
+import type { Pairing } from './pairing';
+import type { NotificationItem } from './notifications';
+
+export const RULES_PATH = '/api/rules/';
+export const NOTIFICATIONS_PATH = '/api/notifications/';
+export const RULES_CACHE_KEY = 'brain.cache.rules';
+
+/**
+ * Shared query key for the rules list. Exported so [2C-18]'s notification
+ * detail view can read the same TanStack cache entry for client-side
+ * rule-name resolution per its issue body.
+ */
+export const RULES_QUERY_KEY: QueryKey = ['rules'];
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export const RECENT_FIRES_LIMIT = 20;
+
+export type RuleEntityType = 'habit' | 'task' | 'routine' | 'checkin';
+
+export type RuleMetric =
+  | 'consecutive_skips'
+  | 'days_untouched'
+  | 'non_responses'
+  | 'streak_length';
+
+/** Operator values are the symbols the server stores, not the enum names. */
+export type RuleOperator = '>=' | '<=' | '==';
+
+export type RuleAction = 'create_notification';
+
+export interface RuleRead {
+  id: string;
+  name: string;
+  entity_type: RuleEntityType;
+  entity_id: string | null;
+  metric: RuleMetric;
+  operator: RuleOperator;
+  threshold: number;
+  action: RuleAction;
+  notification_type: string;
+  message_template: string;
+  enabled: boolean;
+  cooldown_hours: number;
+  is_default: boolean;
+  last_triggered_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RuleListResponseBody {
+  items: RuleRead[];
+  count: number;
+}
+
+interface NotificationListResponseBody {
+  items: NotificationItem[];
+  count: number;
+}
+
+export type FetchRulesResult =
+  | { ok: true; items: RuleRead[] }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout';
+      statusCode?: number;
+    };
+
+export type FetchRuleResult =
+  | { ok: true; rule: RuleRead }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
+      statusCode?: number;
+    };
+
+export type FetchRuleFiresResult =
+  | { ok: true; items: NotificationItem[] }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout';
+      statusCode?: number;
+    };
+
+export async function fetchRules(pairing: Pairing): Promise<FetchRulesResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${RULES_PATH}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as RuleListResponseBody).items)
+          ? (body as RuleListResponseBody).items
+          : [];
+      return { ok: true, items };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchRule(
+  pairing: Pairing,
+  ruleId: string,
+): Promise<FetchRuleResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${RULES_PATH}${ruleId}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as RuleRead;
+      return { ok: true, rule: body };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch notifications fired by a specific rule. Spec asks for the last 20;
+ * the server returns the full list ordered by `scheduled_at desc` so the
+ * client trims to `RECENT_FIRES_LIMIT` after parsing.
+ */
+export async function fetchRuleFires(
+  pairing: Pairing,
+  ruleId: string,
+  limit: number = RECENT_FIRES_LIMIT,
+): Promise<FetchRuleFiresResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${NOTIFICATIONS_PATH}?rule_id=${encodeURIComponent(ruleId)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as unknown;
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as NotificationListResponseBody).items)
+          ? (body as NotificationListResponseBody).items
+          : [];
+      return { ok: true, items: items.slice(0, limit) };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface CachedRules {
+  fetched_at: string;
+  items: RuleRead[];
+}
+
+export async function readCachedRules(): Promise<CachedRules | null> {
+  const { value } = await Preferences.get({ key: RULES_CACHE_KEY });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'items' in parsed &&
+      'fetched_at' in parsed &&
+      Array.isArray((parsed as CachedRules).items) &&
+      typeof (parsed as CachedRules).fetched_at === 'string'
+    ) {
+      return parsed as CachedRules;
+    }
+  } catch {
+    // Treat malformed cache as empty.
+  }
+  return null;
+}
+
+export async function writeCachedRules(
+  items: RuleRead[],
+  now: Date = new Date(),
+): Promise<void> {
+  const payload: CachedRules = {
+    fetched_at: now.toISOString(),
+    items,
+  };
+  await Preferences.set({
+    key: RULES_CACHE_KEY,
+    value: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Sort rules most-recently-triggered first, then most-recently-created.
+ * Rules that have never fired (`last_triggered_at === null`) sort below all
+ * triggered rules, then among themselves by `created_at` descending.
+ */
+export function sortRulesForList(rules: RuleRead[]): RuleRead[] {
+  return [...rules].sort((a, b) => {
+    if (a.last_triggered_at !== null && b.last_triggered_at !== null) {
+      return b.last_triggered_at.localeCompare(a.last_triggered_at);
+    }
+    if (a.last_triggered_at !== null) return -1;
+    if (b.last_triggered_at !== null) return 1;
+    return b.created_at.localeCompare(a.created_at);
+  });
+}
+
+/**
+ * Short relative-time label for the list trailing slot — "fired 2h ago",
+ * "fired yesterday", "fired 3d ago", or "never fired" when `null`. Falls
+ * back to the raw ISO string on parse failure to preserve information.
+ */
+export function formatRelativeFiredAt(
+  iso: string | null,
+  now: Date = new Date(),
+): string {
+  if (iso === null) return 'never fired';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return iso;
+  const deltaMs = now.getTime() - then;
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 1) return 'fired just now';
+  if (minutes < 60) return `fired ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `fired ${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'fired yesterday';
+  return `fired ${days}d ago`;
+}

--- a/src/pages/RuleDetailPage.test.tsx
+++ b/src/pages/RuleDetailPage.test.tsx
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy, replaceSpy } = vi.hoisted(() => ({
+  pushSpy: vi.fn(),
+  replaceSpy: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: replaceSpy,
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import type { RuleRead } from '../lib/rules';
+import type { NotificationItem } from '../lib/notifications';
+import RuleDetailPage from './RuleDetailPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeRule(overrides: Partial<RuleRead> = {}): RuleRead {
+  return {
+    id: overrides.id ?? 'r-1',
+    name: overrides.name ?? 'Habit nudge — 3 skips',
+    entity_type: overrides.entity_type ?? 'habit',
+    entity_id: overrides.entity_id ?? null,
+    metric: overrides.metric ?? 'consecutive_skips',
+    operator: overrides.operator ?? '>=',
+    threshold: overrides.threshold ?? 3,
+    action: overrides.action ?? 'create_notification',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message_template:
+      overrides.message_template ??
+      "{entity_name} hasn't been touched in {metric_value} days",
+    enabled: overrides.enabled ?? true,
+    cooldown_hours: overrides.cooldown_hours ?? 24,
+    is_default: overrides.is_default ?? false,
+    last_triggered_at: overrides.last_triggered_at ?? null,
+    created_at: overrides.created_at ?? '2026-05-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-01T00:00:00Z',
+  };
+}
+
+function makeFire(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: overrides.id ?? 'n-1',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message: overrides.message ?? 'Test message',
+    scheduled_at: overrides.scheduled_at ?? '2026-05-09T08:00:00Z',
+    scheduled_date: overrides.scheduled_date ?? '2026-05-09',
+    status: overrides.status ?? 'delivered',
+    expires_at: overrides.expires_at ?? '2026-05-09T20:00:00Z',
+    response: overrides.response ?? null,
+  };
+}
+
+interface RuleStub {
+  detail?: { status: number; rule?: RuleRead };
+  fires?: { status: number; items?: NotificationItem[] };
+}
+
+function stubFetch(stub: RuleStub = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/notifications/')) {
+        const r = stub.fires ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          return new Response(
+            JSON.stringify({ items: r.items ?? [], count: (r.items ?? []).length }),
+            { status: 200 },
+          );
+        }
+        return new Response('', { status: r.status });
+      }
+      if (url.includes('/api/rules/')) {
+        const r = stub.detail ?? { status: 200, rule: makeRule() };
+        if (r.status === 200 && r.rule) {
+          return new Response(JSON.stringify(r.rule), { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage(ruleId: string = 'r-1') {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/rules/${ruleId}`]}>
+        <Route path="/rules/:ruleId">
+          <RuleDetailPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('RuleDetailPage — bootstrap', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RuleDetailPage — definition render', () => {
+  it('renders the full rule definition with name, condition, template, and timestamps', async () => {
+    pair();
+    stubFetch({
+      detail: {
+        status: 200,
+        rule: makeRule({
+          id: 'r-1',
+          name: 'Habit nudge — 3 skips',
+          metric: 'consecutive_skips',
+          operator: '>=',
+          threshold: 3,
+          notification_type: 'habit_nudge',
+          message_template: '{entity_name} skipped {metric_value} times',
+          cooldown_hours: 12,
+          is_default: true,
+          last_triggered_at: '2026-05-09T08:00:00Z',
+        }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Habit nudge — 3 skips'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('consecutive_skips >= 3')).toBeInTheDocument();
+    expect(screen.getByText('habit_nudge')).toBeInTheDocument();
+    expect(screen.getByText('12 hours')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByTestId('rule-message-template')).toHaveTextContent(
+      '{entity_name} skipped {metric_value} times',
+    );
+    expect(screen.getByTestId('rule-phase3-footer')).toHaveTextContent(
+      /editing rules will arrive in phase 3/i,
+    );
+  });
+
+  it('shows entity_id with copy button when entity_id is set', async () => {
+    pair();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    stubFetch({
+      detail: {
+        status: 200,
+        rule: makeRule({ entity_id: 'abc-123-def' }),
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('rule-entity-id')).toHaveTextContent(
+      'abc-123-def',
+    );
+    await userEvent.click(screen.getByTestId('rule-entity-copy'));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('abc-123-def');
+    });
+  });
+
+  it('shows "Default rule" labelling when entity_id is null', async () => {
+    pair();
+    stubFetch({
+      detail: {
+        status: 200,
+        rule: makeRule({ entity_id: null, entity_type: 'habit' }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('rule-entity-default'),
+    ).toHaveTextContent(/default rule \(matches all habits\)/i);
+  });
+
+  it('shows "Never" when last_triggered_at is null', async () => {
+    pair();
+    stubFetch({
+      detail: { status: 200, rule: makeRule({ last_triggered_at: null }) },
+    });
+
+    renderPage();
+
+    await screen.findByText('Habit nudge — 3 skips');
+    expect(screen.getByText('Never')).toBeInTheDocument();
+  });
+});
+
+describe('RuleDetailPage — recent fires', () => {
+  it('renders the recent fires list when notifications exist', async () => {
+    pair();
+    stubFetch({
+      detail: { status: 200, rule: makeRule() },
+      fires: {
+        status: 200,
+        items: [
+          makeFire({ id: 'n-a', message: 'First fire', status: 'delivered' }),
+          makeFire({ id: 'n-b', message: 'Second fire', status: 'responded' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('First fire')).toBeInTheDocument();
+    expect(screen.getByText('Second fire')).toBeInTheDocument();
+  });
+
+  it('shows the empty fires message when the rule has not fired', async () => {
+    pair();
+    stubFetch({
+      detail: { status: 200, rule: makeRule() },
+      fires: { status: 200, items: [] },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/this rule has not fired yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to /notifications/:id when a fire is tapped', async () => {
+    pair();
+    stubFetch({
+      detail: { status: 200, rule: makeRule() },
+      fires: {
+        status: 200,
+        items: [makeFire({ id: 'n-x', message: 'Tap me' })],
+      },
+    });
+
+    renderPage();
+
+    const fire = await screen.findByText('Tap me');
+    await userEvent.click(fire);
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith('/notifications/n-x');
+    });
+  });
+});
+
+describe('RuleDetailPage — not found', () => {
+  it('shows the not-found card when the rule 404s', async () => {
+    pair();
+    stubFetch({ detail: { status: 404 } });
+    renderPage('r-missing');
+
+    expect(await screen.findByTestId('rule-not-found')).toBeInTheDocument();
+    expect(screen.getByText(/rule not found/i)).toBeInTheDocument();
+  });
+});
+
+describe('RuleDetailPage — fetch URLs', () => {
+  it('issues GET against /api/rules/{id} and /api/notifications/?rule_id with bearer token', async () => {
+    pair();
+    const fetchSpy = stubFetch({
+      detail: { status: 200, rule: makeRule({ id: 'r-1' }) },
+      fires: { status: 200, items: [] },
+    });
+
+    renderPage('r-1');
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    const detailCall = fetchSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' && call[0].endsWith('/api/rules/r-1'),
+    );
+    expect(detailCall).toBeDefined();
+
+    const firesCall = fetchSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('/api/notifications/?rule_id=r-1'),
+    );
+    expect(firesCall).toBeDefined();
+
+    const init = detailCall![1] as RequestInit;
+    expect(init.headers).toEqual({ Authorization: `Bearer ${PAIRED_TOKEN}` });
+  });
+});

--- a/src/pages/RuleDetailPage.tsx
+++ b/src/pages/RuleDetailPage.tsx
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import { useQuery, type QueryKey } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { useHistory, useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import RuleEnabledPill from '../components/RuleEnabledPill';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchRule,
+  fetchRuleFires,
+  type RuleRead,
+} from '../lib/rules';
+import type { NotificationItem } from '../lib/notifications';
+
+const RULE_QUERY_KEY = (id: string): QueryKey => ['rule', id];
+const RULE_FIRES_QUERY_KEY = (id: string): QueryKey => ['rule-fires', id];
+const STALE_MS = 5 * 60 * 1000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | { kind: 'paired'; pairing: Pairing };
+
+function formatAbsolute(iso: string): string {
+  try {
+    return format(parseISO(iso), "EEE, MMM d 'at' h:mm a");
+  } catch {
+    return iso;
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    return format(parseISO(iso), 'h:mm a');
+  } catch {
+    return iso;
+  }
+}
+
+const RuleDetailPage: React.FC = () => {
+  const { ruleId } = useParams<{ ruleId: string }>();
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const pairing = await loadPairing();
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      setBootstrap({ kind: 'paired', pairing });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/rules" />
+          </IonButtons>
+          <IonTitle>Rule</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see this rule.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <DetailBody ruleId={ruleId} pairing={bootstrap.pairing} />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  ruleId: string;
+  pairing: Pairing;
+}
+
+const DetailBody: React.FC<BodyProps> = ({ ruleId, pairing }) => {
+  const history = useHistory();
+  const [toastOpen, setToastOpen] = useState(false);
+
+  const ruleQuery = useQuery<RuleRead>({
+    queryKey: RULE_QUERY_KEY(ruleId),
+    queryFn: async () => {
+      const result = await fetchRule(pairing, ruleId);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      return result.rule;
+    },
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  const firesQuery = useQuery<NotificationItem[]>({
+    queryKey: RULE_FIRES_QUERY_KEY(ruleId),
+    queryFn: async () => {
+      const result = await fetchRuleFires(pairing, ruleId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      return result.items;
+    },
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    enabled: !isNotFoundError(ruleQuery.error),
+    retry: false,
+  });
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await Promise.all([ruleQuery.refetch(), firesQuery.refetch()]);
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [ruleQuery, firesQuery],
+  );
+
+  const onCopyEntityId = useCallback(
+    async (entityId: string): Promise<void> => {
+      try {
+        await navigator.clipboard.writeText(entityId);
+        setToastOpen(true);
+      } catch {
+        // Clipboard unavailable — surface nothing rather than a hard error.
+      }
+    },
+    [],
+  );
+
+  const onFireTap = useCallback(
+    (notification: NotificationItem): void => {
+      history.push(`/notifications/${notification.id}`);
+    },
+    [history],
+  );
+
+  if (isNotFoundError(ruleQuery.error) && !ruleQuery.data) {
+    return (
+      <NotFoundCard onBack={() => history.replace('/rules')} />
+    );
+  }
+
+  const rule = ruleQuery.data;
+  if (!rule) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-neutral-300">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      <DefinitionPane rule={rule} onCopyEntityId={onCopyEntityId} />
+
+      <RecentFiresPane
+        fires={firesQuery.data}
+        loading={firesQuery.isLoading}
+        onFireTap={onFireTap}
+      />
+
+      <p
+        className="mt-6 px-4 pb-8 text-xs text-neutral-400"
+        data-testid="rule-phase3-footer"
+      >
+        Editing rules will arrive in Phase 3.
+      </p>
+
+      <IonToast
+        isOpen={toastOpen}
+        message="Copied to clipboard"
+        duration={1500}
+        onDidDismiss={() => setToastOpen(false)}
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Definition pane
+// ---------------------------------------------------------------------------
+
+interface DefinitionProps {
+  rule: RuleRead;
+  onCopyEntityId: (entityId: string) => void;
+}
+
+const DefinitionPane: React.FC<DefinitionProps> = ({ rule, onCopyEntityId }) => {
+  const lastTriggered =
+    rule.last_triggered_at !== null
+      ? formatAbsolute(rule.last_triggered_at)
+      : 'Never';
+
+  return (
+    <section className="px-4 pt-4" data-testid="rule-definition-pane">
+      <div className="flex items-center gap-2">
+        <RuleEnabledPill enabled={rule.enabled} />
+        <h1 className="text-xl font-semibold">{rule.name}</h1>
+      </div>
+
+      <dl className="mt-4 grid grid-cols-1 gap-2 text-sm">
+        <Row label="Entity type">{rule.entity_type}</Row>
+        <Row label="Entity">
+          {rule.entity_id !== null ? (
+            <span className="flex items-center gap-2">
+              <code
+                className="font-mono text-xs"
+                data-testid="rule-entity-id"
+              >
+                {rule.entity_id}
+              </code>
+              <IonButton
+                size="small"
+                fill="clear"
+                onClick={() => onCopyEntityId(rule.entity_id!)}
+                data-testid="rule-entity-copy"
+              >
+                Copy
+              </IonButton>
+            </span>
+          ) : (
+            <span data-testid="rule-entity-default">
+              Default rule (matches all {rule.entity_type}s)
+            </span>
+          )}
+        </Row>
+        <Row label="Condition">
+          {rule.metric} {rule.operator} {rule.threshold}
+        </Row>
+        <Row label="Action">{rule.action}</Row>
+        <Row label="Notification type">{rule.notification_type}</Row>
+        <Row label="Cooldown">{rule.cooldown_hours} hours</Row>
+        <Row label="Default rule">{rule.is_default ? 'Yes' : 'No'}</Row>
+        <Row label="Last triggered">{lastTriggered}</Row>
+        <Row label="Created">{formatAbsolute(rule.created_at)}</Row>
+        <Row label="Updated">{formatAbsolute(rule.updated_at)}</Row>
+      </dl>
+
+      <div className="mt-4">
+        <h2 className="text-sm font-medium text-neutral-300">
+          Message template
+        </h2>
+        <pre
+          className="mt-1 whitespace-pre-wrap rounded border border-neutral-700 bg-neutral-900 px-3 py-2 font-mono text-xs"
+          data-testid="rule-message-template"
+        >
+          {rule.message_template}
+        </pre>
+      </div>
+    </section>
+  );
+};
+
+const Row: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="flex justify-between gap-3">
+    <dt className="text-neutral-400">{label}</dt>
+    <dd className="text-right">{children}</dd>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Recent fires
+// ---------------------------------------------------------------------------
+
+interface RecentFiresProps {
+  fires: NotificationItem[] | undefined;
+  loading: boolean;
+  onFireTap: (notification: NotificationItem) => void;
+}
+
+const RecentFiresPane: React.FC<RecentFiresProps> = ({
+  fires,
+  loading,
+  onFireTap,
+}) => {
+  if (loading || fires === undefined) {
+    return (
+      <section
+        className="mt-6 px-4 text-sm text-neutral-400"
+        data-testid="rule-fires-loading"
+      >
+        <h2 className="text-base font-medium">Recent fires</h2>
+        <p className="mt-1">Loading…</p>
+      </section>
+    );
+  }
+  if (fires.length === 0) {
+    return (
+      <section
+        className="mt-6 px-4 text-sm text-neutral-400"
+        data-testid="rule-fires-empty"
+      >
+        <h2 className="text-base font-medium">Recent fires</h2>
+        <p className="mt-1">This rule has not fired yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="mt-6" data-testid="rule-fires-list">
+      <h2 className="px-4 text-base font-medium">Recent fires</h2>
+      <IonList>
+        {fires.map((fire) => (
+          <IonItem
+            key={fire.id}
+            button
+            onClick={() => onFireTap(fire)}
+            data-testid={`rule-fire-${fire.id}`}
+          >
+            <IonLabel className="ion-text-wrap">
+              <h3>{formatAbsolute(fire.scheduled_at)}</h3>
+              <p>
+                <IonText color="medium">
+                  <small>{fire.status}</small>
+                </IonText>
+              </p>
+              <p>{fire.message}</p>
+            </IonLabel>
+            <IonNote slot="end" className="text-xs">
+              {formatTime(fire.scheduled_at)}
+            </IonNote>
+          </IonItem>
+        ))}
+      </IonList>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Not-found card
+// ---------------------------------------------------------------------------
+
+const NotFoundCard: React.FC<{ onBack: () => void }> = ({ onBack }) => (
+  <div
+    className="flex h-full w-full flex-col items-center justify-center px-4 text-center text-neutral-300"
+    data-testid="rule-not-found"
+  >
+    <p>Rule not found.</p>
+    <IonButton fill="outline" className="mt-3" onClick={onBack}>
+      Back to rules
+    </IonButton>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'notFound' in error &&
+      (error as { notFound: unknown }).notFound === true,
+  );
+}
+
+export default RuleDetailPage;

--- a/src/pages/RulesPage.test.tsx
+++ b/src/pages/RulesPage.test.tsx
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: vi.fn(),
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { RULES_CACHE_KEY, type RuleRead } from '../lib/rules';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import RulesPage from './RulesPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeRule(overrides: Partial<RuleRead> = {}): RuleRead {
+  return {
+    id: overrides.id ?? 'r-1',
+    name: overrides.name ?? 'Habit nudge — 3 skips',
+    entity_type: overrides.entity_type ?? 'habit',
+    entity_id: overrides.entity_id ?? null,
+    metric: overrides.metric ?? 'consecutive_skips',
+    operator: overrides.operator ?? '>=',
+    threshold: overrides.threshold ?? 3,
+    action: overrides.action ?? 'create_notification',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message_template:
+      overrides.message_template ??
+      "{entity_name} hasn't been touched in {metric_value} days",
+    enabled: overrides.enabled ?? true,
+    cooldown_hours: overrides.cooldown_hours ?? 24,
+    is_default: overrides.is_default ?? false,
+    last_triggered_at: overrides.last_triggered_at ?? null,
+    created_at: overrides.created_at ?? '2026-05-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-01T00:00:00Z',
+  };
+}
+
+function seedCache(items: RuleRead[]): void {
+  prefsStore.set(
+    RULES_CACHE_KEY,
+    JSON.stringify({ fetched_at: '2026-05-09T00:00:00Z', items }),
+  );
+}
+
+interface RulesFetchOptions {
+  response?: { status: number; items?: RuleRead[]; raw?: unknown };
+  rejection?: Error;
+}
+
+function stubFetch(opts: RulesFetchOptions = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/rules/')) {
+        if (opts.rejection) throw opts.rejection;
+        const r = opts.response ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          const body =
+            r.raw !== undefined
+              ? JSON.stringify(r.raw)
+              : JSON.stringify({ items: r.items ?? [], count: (r.items ?? []).length });
+          return new Response(body, { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/rules']}>
+        <RulesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('RulesPage — bootstrap', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RulesPage — list render', () => {
+  it('renders rows with name, condition, notification type, and pill', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [
+          makeRule({
+            id: 'r-1',
+            name: 'Habit nudge — 3 skips',
+            entity_type: 'habit',
+            metric: 'consecutive_skips',
+            operator: '>=',
+            threshold: 3,
+            notification_type: 'habit_nudge',
+            enabled: true,
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Habit nudge — 3 skips')).toBeInTheDocument();
+    expect(
+      screen.getByText('habit — consecutive_skips >= 3'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('→ habit_nudge')).toBeInTheDocument();
+    expect(screen.getByTestId('rule-enabled-pill-enabled')).toHaveTextContent(
+      'Enabled',
+    );
+  });
+
+  it('renders disabled rules with a Disabled pill', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [makeRule({ id: 'r-2', enabled: false })],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('rule-enabled-pill-disabled'),
+    ).toHaveTextContent('Disabled');
+  });
+
+  it('sorts most-recently-triggered first, never-fired below', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [
+          makeRule({
+            id: 'r-old',
+            name: 'Old rule',
+            last_triggered_at: '2026-05-01T00:00:00Z',
+          }),
+          makeRule({
+            id: 'r-recent',
+            name: 'Recent rule',
+            last_triggered_at: '2026-05-09T00:00:00Z',
+          }),
+          makeRule({
+            id: 'r-never',
+            name: 'Unfired rule',
+            last_triggered_at: null,
+          }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    await screen.findByText('Recent rule');
+    const rows = screen.getAllByText(/rule$/);
+    expect(rows.map((el) => el.textContent)).toEqual([
+      'Recent rule',
+      'Old rule',
+      'Unfired rule',
+    ]);
+  });
+});
+
+describe('RulesPage — empty state', () => {
+  it('shows the "No rules yet" empty-state message', async () => {
+    pair();
+    stubFetch({ response: { status: 200, items: [] } });
+    renderPage();
+    expect(
+      await screen.findByText(
+        /no rules yet\. create rules via brain3 cli or api\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RulesPage — navigation', () => {
+  it('pushes /rules/:id when a row is tapped', async () => {
+    pair();
+    stubFetch({
+      response: {
+        status: 200,
+        items: [makeRule({ id: 'r-9', name: 'Tap me' })],
+      },
+    });
+
+    renderPage();
+
+    const title = await screen.findByText('Tap me');
+    await userEvent.click(title);
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith('/rules/r-9');
+    });
+  });
+});
+
+describe('RulesPage — offline cache', () => {
+  it('renders cached items + cache hint when the network fetch fails', async () => {
+    pair();
+    seedCache([
+      makeRule({ id: 'r-cached', name: 'Cached rule', enabled: true }),
+    ]);
+    stubFetch({ rejection: new Error('offline') });
+
+    renderPage();
+
+    expect(await screen.findByText('Cached rule')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/showing cached data/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RulesPage — fetch URL', () => {
+  it('issues GET against /api/rules/ with bearer token', async () => {
+    pair();
+    const fetchSpy = stubFetch({ response: { status: 200, items: [] } });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const rulesCall = fetchSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' && call[0].includes('/api/rules/'),
+    );
+    expect(rulesCall).toBeDefined();
+    const url = rulesCall![0] as string;
+    expect(url.startsWith(`${PAIRED_URL}/api/rules/`)).toBe(true);
+    const init = rulesCall![1] as RequestInit;
+    expect(init.headers).toEqual({ Authorization: `Bearer ${PAIRED_TOKEN}` });
+  });
+});

--- a/src/pages/RulesPage.tsx
+++ b/src/pages/RulesPage.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import { useQuery } from '@tanstack/react-query';
+import { useHistory } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import RuleEnabledPill from '../components/RuleEnabledPill';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  RULES_QUERY_KEY,
+  fetchRules,
+  formatRelativeFiredAt,
+  readCachedRules,
+  sortRulesForList,
+  writeCachedRules,
+  type RuleRead,
+} from '../lib/rules';
+
+const RULES_STALE_MS = 5 * 60 * 1000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedItems: RuleRead[] | null;
+      cachedFetchedAtMs: number | null;
+    };
+
+const RulesPage: React.FC = () => {
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cached] = await Promise.all([
+        loadPairing(),
+        readCachedRules(),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const cachedFetchedAtMs = cached?.fetched_at
+        ? Date.parse(cached.fetched_at)
+        : null;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedItems: cached?.items ?? null,
+        cachedFetchedAtMs: Number.isFinite(cachedFetchedAtMs)
+          ? cachedFetchedAtMs
+          : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Rules</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see rules.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <RulesBody
+            pairing={bootstrap.pairing}
+            initialCachedItems={bootstrap.cachedItems}
+            initialCachedFetchedAtMs={bootstrap.cachedFetchedAtMs}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  initialCachedItems: RuleRead[] | null;
+  initialCachedFetchedAtMs: number | null;
+}
+
+const RulesBody: React.FC<BodyProps> = ({
+  pairing,
+  initialCachedItems,
+  initialCachedFetchedAtMs,
+}) => {
+  const history = useHistory();
+
+  const rulesQuery = useQuery<RuleRead[]>({
+    queryKey: RULES_QUERY_KEY,
+    queryFn: async () => {
+      const result = await fetchRules(pairing);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedRules(result.items);
+      return result.items;
+    },
+    initialData: initialCachedItems ?? undefined,
+    initialDataUpdatedAt:
+      initialCachedItems !== null && initialCachedFetchedAtMs !== null
+        ? initialCachedFetchedAtMs
+        : undefined,
+    staleTime: RULES_STALE_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  const items = rulesQuery.data;
+  const showCacheHint =
+    rulesQuery.isError && items !== undefined && items.length >= 0;
+
+  const sorted = useMemo(
+    () => (items ? sortRulesForList(items) : null),
+    [items],
+  );
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await rulesQuery.refetch();
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [rulesQuery],
+  );
+
+  const onRowClick = useCallback(
+    (rule: RuleRead): void => {
+      history.push(`/rules/${rule.id}`);
+    },
+    [history],
+  );
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      {showCacheHint ? (
+        <div
+          className="px-4 pt-3 text-sm text-neutral-300"
+          role="status"
+          aria-live="polite"
+        >
+          Showing cached data
+        </div>
+      ) : null}
+
+      {sorted !== null && sorted.length === 0 ? (
+        <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+          <p>No rules yet. Create rules via brain3 CLI or API.</p>
+        </div>
+      ) : null}
+
+      {sorted !== null && sorted.length > 0 ? (
+        <IonList>
+          {sorted.map((rule) => (
+            <RuleRow key={rule.id} rule={rule} onRowClick={onRowClick} />
+          ))}
+        </IonList>
+      ) : null}
+    </>
+  );
+};
+
+interface RowProps {
+  rule: RuleRead;
+  onRowClick: (rule: RuleRead) => void;
+}
+
+const RuleRow: React.FC<RowProps> = ({ rule, onRowClick }) => {
+  const conditionLine = `${rule.entity_type} — ${rule.metric} ${rule.operator} ${rule.threshold}`;
+  const notificationLine = `→ ${rule.notification_type}`;
+  return (
+    <IonItem
+      button
+      onClick={() => onRowClick(rule)}
+      data-testid={`rule-row-${rule.id}`}
+    >
+      <IonLabel className="ion-text-wrap">
+        <h2>{rule.name}</h2>
+        <p>
+          <IonText color="medium">
+            <small>{conditionLine}</small>
+          </IonText>
+        </p>
+        <p>
+          <IonText color="medium">
+            <small>{notificationLine}</small>
+          </IonText>
+        </p>
+      </IonLabel>
+      <div slot="end" className="flex flex-col items-end gap-1">
+        <RuleEnabledPill enabled={rule.enabled} />
+        <IonNote className="text-xs">
+          {formatRelativeFiredAt(rule.last_triggered_at)}
+        </IonNote>
+      </div>
+    </IonItem>
+  );
+};
+
+export default RulesPage;


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors, no warnings)
- `npm run test.unit` — ✅ Pass (283 passed across 24 test files; 31 new tests added by this PR)
- `npx tsc --noEmit` — ✅ Pass (clean)
- `npm run build` — ✅ Pass (built in 8.56s; only pre-existing chunk-size warnings)
- `npm run android:sync` — ⏭️  Not applicable (no Capacitor plugin add/remove/upgrade in this PR)

Ran locally against develop HEAD at a8bd295 immediately before opening this PR.

## Summary

Adds the read-only `/rules` and `/rules/:ruleId` surfaces. The list shows each rule with its condition (`{entity_type} — {metric} {operator} {threshold}`), notification type, an Enabled/Disabled pill, and a relative "fired Nh ago" trailing note, sorted most-recently-triggered first with never-fired rules pushed below. The detail view renders the full rule definition (including a monospace, preformatted `message_template`), a "Recent fires" section showing up to 20 notifications produced by the rule, and an explicit "Editing rules will arrive in Phase 3" footer. Pull-to-refresh and offline-cached fallback with a "Showing cached data" hint mirror the [2C-20] check-ins surface.

No write actions on this surface — rule mutation lands in Phase 3 per spec Out of Scope.

## Changes

- **`src/lib/rules.ts` (new)** — Data layer: `RuleRead` types mirroring `brain3/app/schemas/rule.py:155`, envelope-aware `fetchRules` / `fetchRuleFires` parsers (handles the `{items, count}` shapes that `RuleListResponse` and `NotificationListResponse` return), `fetchRule` for detail, Capacitor Preferences cache (`brain.cache.rules`), `sortRulesForList` (last_triggered_at desc, nulls below by created_at desc), and `formatRelativeFiredAt` ("fired 2h ago" / "never fired"). Exports the shared `RULES_QUERY_KEY = ['rules']` so [2C-18] can read the same TanStack cache for client-side rule-name resolution per its issue body's reuse pattern.
- **`src/lib/rules.test.ts` (new)** — Covers fetchers (envelope unwrap, status mapping), cache round-trip, sort ordering with mixed null/non-null `last_triggered_at`, and relative-time formatting. 12 tests.
- **`src/components/RuleEnabledPill.tsx` (new)** — Read-only `Enabled`/`Disabled` pill (emerald/neutral tones). See Deviations §4 for why this lives next to `StatusPill` rather than reusing it.
- **`src/components/RuleEnabledPill.test.tsx` (new)** — Two tests covering both states.
- **`src/pages/RulesPage.tsx` (new)** — List screen mirroring the [2C-20] `CheckinsPage` bootstrap shape (loading / no-pairing / paired) with a TanStack `useQuery` keyed by `RULES_QUERY_KEY`, cache-first paint, pull-to-refresh, empty state ("No rules yet. Create rules via brain3 CLI or API."), and tap-through to `/rules/:ruleId`.
- **`src/pages/RulesPage.test.tsx` (new)** — Bootstrap, list render with all per-row fields, sort ordering, Disabled pill, empty state, navigation, offline-cache fallback, fetch-URL/auth shape. 8 tests.
- **`src/pages/RuleDetailPage.tsx` (new)** — Detail screen with definition pane (full rule fields including UUID `entity_id` with a Copy button per spec, "Default rule (matches all {entity_type}s)" labelling when `entity_id` is null, monospace preformatted `message_template`), Recent fires pane with tap-through to `/notifications/:id`, not-found card on 404, Phase 3 footer.
- **`src/pages/RuleDetailPage.test.tsx` (new)** — Bootstrap, full definition render, copy-to-clipboard, default-rule labelling, last-triggered-never, recent fires render/empty/tap, not-found, fetch URLs/auth. 9 tests.
- **`src/App.tsx`** — Adds `/rules` and `/rules/:ruleId` `<Route>`s.

## How to Verify

1. `cd brain3-companion && git checkout feat/2C-16-rules-list-detail`
2. `npm install` (no new deps)
3. `npm run test.unit` — all 283 tests pass.
4. `npm run lint && npx tsc --noEmit && npm run build` — clean.
5. With a paired pairing in Preferences and a brain3-dev server seeded with rules:
   - Visit `/rules`. Confirm list rendering, status pills, sort order, pull-to-refresh, and offline cache hint after a network drop.
   - Tap a rule — confirm `/rules/{id}` renders the full definition, including monospace template and Phase 3 footer.
   - Tap "Copy" next to a non-default rule's `entity_id` — confirm the toast appears.
   - Tap a row in Recent fires — confirm `/notifications/{id}` is pushed (the route does not exist on develop yet; [2C-18] adds it. See Deviations §2).

## Deviations

1. **Test path co-located, not under `tests/unit/`.** Spec ACs name `tests/unit/rules.spec.ts`; repo CLAUDE.md v3 §Test Conventions explicitly forbids new files under `tests/unit/` and requires colocation (`src/lib/foo.ts` → `src/lib/foo.test.ts`). Per the inheritance order in org CLAUDE.md v6 and the canonical-source rule in directive `ba044399`, repo CLAUDE.md wins. Tests are split across `src/lib/rules.test.ts`, `src/components/RuleEnabledPill.test.tsx`, `src/pages/RulesPage.test.tsx`, and `src/pages/RuleDetailPage.test.tsx`. This is Shape A spec drift per directive `5cb98368` — flagging so the spec template can be adjusted for future tickets.

2. **`history.push('/notifications/:id')` is a forward-looking hook.** Spec says taps on Recent fires "navigate to the Chunk 2 notification detail view (hydrated via `[2C-18]`)". `/notifications/:id` does not exist on develop — [2C-18] (next ticket in Group 4 dispatch order, brain3-companion#13) creates it. The navigation is wired per spec intent and will land live the moment [2C-18] merges. First-consumer-instantiates per org CLAUDE.md v6 — flagging here for the codification call.

3. **`RULES_QUERY_KEY` exported from `lib/rules.ts` for [2C-18] cache reuse.** [2C-18]'s issue body explicitly specifies reusing this key for client-side rule-name resolution. Introducing the constant in this PR rather than the consuming PR is the first-consumer-instantiates pattern (org CLAUDE.md v6) — naming it now so reviewers/spec authors confirm intent.

4. **`StatusPill` reuse anticipation did not naturally hold.** The existing `components/StatusPill.tsx` (introduced by [2C-21]) names "(eventually) [2C-16] rules list" as a planned consumer in its docstring, but its API is typed against the 3-way `ScaffoldingStatus` enum (tracking/accountable/graduated). The rule's binary `enabled` state doesn't fit that shape, and generalizing the component would have meant a refactor of `HabitsPage` and `HabitDetailPage` callers — beyond the scope of this ticket per `17cc8ad0`. Added a sibling `RuleEnabledPill` instead. The `StatusPill.tsx` comment now slightly mis-anticipates — flagging for cleanup if/when the abstraction is revisited.

5. **Brief watch-item — StatusPill ordering.** Group 4 brief §5 asks me to flag-and-stand-by per `70e5e875` if the implementation produces multiple status pills on a rule. The spec specifies a single pill (`Enabled` / `Disabled`); no ordering question arises from this surface. Watch-item did not fire.

## Concerns / findings (out of scope — log it, don't fix it)

- **Pre-existing bug in `src/lib/notifications.ts:70-72`.** The fetch parses the response as a bare array (`Array.isArray(body)`), but `brain3/app/routers/notification.py:98` returns `NotificationListResponse {items, count}` since brain3 PR #176 (merged 2026-04-18, after [2C-09] was authored). On current develop, the [2C-09] recent notifications view silently returns an empty list. I noticed this while writing `fetchRuleFires` (which hits the same envelope). Per directive `968470eb`, not fixing inline — will file a separate `[2C-Bug-XX]` issue with the diagnosis and a one-line fix proposal.

## Test Results

```
$ npm run test.unit
Test Files  24 passed (24)
     Tests  283 passed (283)
```

(31 new tests added by this PR across `src/lib/rules.test.ts`, `src/components/RuleEnabledPill.test.tsx`, `src/pages/RulesPage.test.tsx`, `src/pages/RuleDetailPage.test.tsx`.)

## Acceptance Checklist

- [x] `/rules` loads, shows all enabled + disabled rules (disabled visually distinct via gray pill).
- [x] Empty rule set → renders empty state ("No rules yet. Create rules via brain3 CLI or API.").
- [x] Tap a rule → navigates to `/rules/{id}` with full definition visible.
- [x] Recent fires section shows up to 20 most-recent notifications from that rule.
- [x] Pull-to-refresh reloads both list and detail.
- [x] Offline launch (cached): shows last-known list with "Showing cached data" hint.
- [x] Test coverage covers list render, empty state, detail render, rule-fires fetch (deviated path — co-located per CLAUDE.md v3, see Deviations §1).

Closes #11
