### PR TITLE
[2C-Bug-07]: notifications list parser drift — bare-array vs NotificationListResponse envelope

### DIFF
--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -63,7 +63,9 @@ describe('fetchNotifications — server contract', () => {
   it('GETs /api/notifications/ with bearer auth and a scheduled_after window', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response('[]', { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+      );
 
     const now = new Date(2026, 3, 28, 14, 0); // 2026-04-28 14:00 local
     const result = await fetchNotifications(PAIRING, now);
@@ -82,7 +84,9 @@ describe('fetchNotifications — server contract', () => {
   it('strips a trailing slash from pairing.url', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response('[]', { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], count: 0 }), { status: 200 }),
+      );
 
     await fetchNotifications(
       { url: 'https://brain.local:8000/', token: 'tok' },
@@ -94,10 +98,10 @@ describe('fetchNotifications — server contract', () => {
     expect((url as string).startsWith('https://brain.local:8000//api/notifications/')).toBe(false);
   });
 
-  it('returns the parsed array on 200', async () => {
+  it('unwraps {items, count} envelope from /api/notifications/ on 200', async () => {
     const items = [makeItem({ id: 'a' }), makeItem({ id: 'b' })];
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify(items), { status: 200 }),
+      new Response(JSON.stringify({ items, count: 2 }), { status: 200 }),
     );
 
     const result = await fetchNotifications(PAIRING);
@@ -108,9 +112,9 @@ describe('fetchNotifications — server contract', () => {
     }
   });
 
-  it('falls back to an empty array if the body is not an array', async () => {
+  it('returns empty list when the server returns a non-envelope shape', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ items: [] }), { status: 200 }),
+      new Response('null', { status: 200 }),
     );
 
     const result = await fetchNotifications(PAIRING);

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -42,6 +42,11 @@ export interface NotificationItem {
   response: string | null;
 }
 
+interface NotificationListResponseBody {
+  items: NotificationItem[];
+  count: number;
+}
+
 export type FetchResult =
   | { ok: true; items: NotificationItem[] }
   | {
@@ -68,7 +73,13 @@ export async function fetchNotifications(
     });
     if (response.status === 200) {
       const body = (await response.json()) as unknown;
-      const items = Array.isArray(body) ? (body as NotificationItem[]) : [];
+      const items =
+        body &&
+        typeof body === 'object' &&
+        'items' in body &&
+        Array.isArray((body as NotificationListResponseBody).items)
+          ? (body as NotificationListResponseBody).items
+          : [];
       return { ok: true, items };
     }
     if (response.status === 401) {


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no findings)
- `npx tsc --noEmit` — ✅ Pass (no errors)
- `npm run test.unit` — ✅ Pass (24 files, 283 tests passed)
- `npm run build` — ✅ Pass (built in 7.01s; pre-existing chunk-size warning unchanged)

Ran locally against develop HEAD at 9e60ecd immediately before opening this PR.

## Summary

`fetchNotifications` now unwraps the `NotificationListResponse {items, count}` envelope returned by `GET /api/notifications/` instead of treating the body as a bare JSON array. The bare-array parse path silently resolved to `[]` on every 200 response since brain3 PR #192 (envelope normalization, merged 2026-04-19), causing the [2C-09] recent notifications view to render the empty state regardless of payload. Test mocks migrate to the envelope shape so the regression cannot recur invisibly.

## Changes

- `src/lib/notifications.ts` — Added a private `NotificationListResponseBody { items, count }` interface alongside `NotificationItem`, and replaced the `Array.isArray(body)` parse at lines 70–72 with the envelope-aware unwrap pattern verbatim from `lib/rules.ts:108–117` / `lib/rules.ts:185–194`. Defensive: still returns `[]` when the body is not envelope-shaped. Public `FetchResult` shape and call signature unchanged — the [2C-09] page consumer needs no change.
- `src/lib/notifications.test.ts` — Migrated four bare-array fetch mocks (the bearer-auth/window test, the trailing-slash test, and the previously named "returns the parsed array on 200" test) to the `{ items, count }` envelope shape. Renamed the parsed-200 case to "unwraps {items, count} envelope from /api/notifications/ on 200" to match the rules-side test naming. Replaced the previous "falls back to an empty array if the body is not an array" case (which mocked `{items: []}` — an envelope, not a non-envelope shape) with a true negative-shape test mirroring `rules.test.ts:111`: mocks `'null'` and asserts `{ ok: true, items: [] }`. Test count unchanged (16).

## How to Verify

1. From `D:\_DEVELOPMENT\brain3-companion`, run the four gates: `npm run lint`, `npx tsc --noEmit`, `npm run test.unit`, `npm run build`. All four should pass clean.
2. The new negative-shape case lives in `src/lib/notifications.test.ts` under `describe('fetchNotifications — server contract')`. Confirm vitest reports it green.
3. The Manual verification section below is the runtime-environment gate L runs against a live brain3 develop server.

## Deviations

None from the issue body spec. The fix shape, type-name, sibling-endpoint sweep, and test migration all follow the canonical contract verbatim.

Process note (not a spec deviation): the activation prompt suggested a conventional-commits PR title (`fix: notifications list parser envelope-unwrap (#66)`), which conflicts with org CLAUDE.md v6 ("PR title must match the GitHub issue title exactly... Do not add conventional commit prefixes to PR titles"). Per directive `70e5e875` (flag-and-stand-by on canonical-source conflict), halted pre-branch and surfaced. L confirmed the canonical CLAUDE.md convention wins; PR title is the issue title verbatim. Conventional-commit format applied to the commit message instead, as intended.

## Test Results

```
Test Files  24 passed (24)
     Tests  283 passed (283)
  Duration  9.54s
```

`notifications.test.ts` accounts for 16 of those tests; all green against the new envelope-aware parser. Pre-existing `RoutineDetailPage.test.tsx` stderr noise (`Cannot read properties of null (reading 'offsetHeight')` from `@ionic/core` under jsdom) is unchanged by this PR — those tests still pass.

## Acceptance Checklist

- [x] `fetchNotifications` returns the parsed `items` array when the server responds with `{items, count}`.
- [x] Returns `[]` when the response is not envelope-shaped (defensive parse, mirrors `lib/rules.ts` pattern).
- [x] `src/lib/notifications.test.ts` `fetchNotifications` cases mock the envelope shape (`Response(JSON.stringify({ items, count }))`) — not bare arrays.
- [x] Added a negative-shape test mirroring `src/lib/rules.test.ts:111` ("returns empty list when the server returns a non-envelope shape").
- [x] `npm run test.unit`, `npm run lint`, `npx tsc --noEmit`, `npm run build` all pass.

#### Manual verification

This drift class is invisible to unit-test mocking — the existing `notifications.test.ts` mocks bare-array shapes and passes, even though the runtime path returns empty against the real server. P-8b sub-shape per repo CLAUDE.md v3 §Pre-PR Verification Gates. Manual on-device confirmation is required:

1. Start brain3 server on `develop` (envelope shape live since PR #192, merged 2026-04-19).
2. Pair the companion to it; seed at least three notifications via the brain3 API across two `scheduled_date` buckets (today + earlier).
3. Open the recent notifications view.
4. Confirm: items render in Today and Earlier sections (not the empty state).
5. Drop the network and re-open the view from cache; confirm cached items render with the "Showing cached data" hint.

Closes #66