### PR TITLE
[2C-17] Pattern observation filter on recent notifications view

### DIFF
--- a/src/lib/notification-filter.test.ts
+++ b/src/lib/notification-filter.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  NOTIFICATION_FILTER_KEY,
+  PATTERN_OBSERVATION_TYPE,
+  applyNotificationFilter,
+  readNotificationFilter,
+  writeNotificationFilter,
+  type NotificationFilter,
+} from './notification-filter';
+import type { NotificationItem } from './notifications';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeItem(overrides: Partial<NotificationItem>): NotificationItem {
+  return {
+    id: overrides.id ?? 'n-1',
+    notification_type: overrides.notification_type ?? 'habit_reminder',
+    message: overrides.message ?? 'Take your meds',
+    scheduled_at: overrides.scheduled_at ?? '2026-04-28T13:00:00Z',
+    scheduled_date: overrides.scheduled_date ?? '2026-04-28',
+    status: overrides.status ?? 'pending',
+    expires_at: overrides.expires_at ?? '2026-04-28T15:00:00Z',
+    response: overrides.response ?? null,
+  };
+}
+
+describe('notification filter persistence', () => {
+  it('defaults to "all" when no value is stored', async () => {
+    const result = await readNotificationFilter();
+    expect(result).toBe('all');
+  });
+
+  it('roundtrips a written filter through Preferences', async () => {
+    await writeNotificationFilter('patterns');
+    const result = await readNotificationFilter();
+    expect(result).toBe('patterns');
+    expect(prefsStore.get(NOTIFICATION_FILTER_KEY)).toBe('patterns');
+  });
+
+  it('falls back to "all" when the stored value is not a valid filter', async () => {
+    prefsStore.set(NOTIFICATION_FILTER_KEY, 'something-else');
+    const result = await readNotificationFilter();
+    expect(result).toBe('all');
+  });
+
+  it('persists across read calls', async () => {
+    await writeNotificationFilter('patterns');
+    expect(await readNotificationFilter()).toBe('patterns');
+    expect(await readNotificationFilter()).toBe('patterns');
+
+    await writeNotificationFilter('all');
+    expect(await readNotificationFilter()).toBe('all');
+  });
+});
+
+describe('applyNotificationFilter', () => {
+  const items: NotificationItem[] = [
+    makeItem({ id: 'habit-1', notification_type: 'habit_reminder' }),
+    makeItem({ id: 'pattern-1', notification_type: PATTERN_OBSERVATION_TYPE }),
+    makeItem({ id: 'routine-1', notification_type: 'routine_due' }),
+    makeItem({ id: 'pattern-2', notification_type: PATTERN_OBSERVATION_TYPE }),
+  ];
+
+  it('returns the input unchanged when filter is "all"', () => {
+    const result = applyNotificationFilter(items, 'all');
+    expect(result).toEqual(items);
+  });
+
+  it('keeps only pattern_observation items when filter is "patterns"', () => {
+    const result = applyNotificationFilter(items, 'patterns');
+    expect(result.map((i) => i.id)).toEqual(['pattern-1', 'pattern-2']);
+  });
+
+  it('returns an empty list when no items match the active filter', () => {
+    const noPatterns = items.filter(
+      (i) => i.notification_type !== PATTERN_OBSERVATION_TYPE,
+    );
+    const result = applyNotificationFilter(noPatterns, 'patterns');
+    expect(result).toEqual([]);
+  });
+
+  it('preserves input order under the patterns filter', () => {
+    const ordered: NotificationItem[] = [
+      makeItem({ id: 'p-late', notification_type: PATTERN_OBSERVATION_TYPE, scheduled_at: '2026-04-28T18:00:00Z' }),
+      makeItem({ id: 'p-early', notification_type: PATTERN_OBSERVATION_TYPE, scheduled_at: '2026-04-28T08:00:00Z' }),
+    ];
+    const result = applyNotificationFilter(ordered, 'patterns');
+    expect(result.map((i) => i.id)).toEqual(['p-late', 'p-early']);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = items.map((i) => i.id);
+    applyNotificationFilter(items, 'patterns');
+    expect(items.map((i) => i.id)).toEqual(before);
+  });
+});
+
+describe('NotificationFilter type', () => {
+  it('exports a string-literal union usable in narrowing', () => {
+    const value: NotificationFilter = 'all';
+    expect(value === 'all' || value === 'patterns').toBe(true);
+  });
+});

--- a/src/lib/notification-filter.ts
+++ b/src/lib/notification-filter.ts
@@ -1,0 +1,47 @@
+/**
+ * Notification filter state for [2C-17] pattern observation filter.
+ *
+ * Pattern observations share `/api/notifications/` with other notification
+ * types — `notification_type="pattern_observation"` is the discriminator. Per
+ * the [2C-17] spec, the surface for showing them is a client-side filter on
+ * the existing [2C-09] view rather than a dedicated screen. This module owns
+ * the filter type, its persistence under `@capacitor/preferences`, and the
+ * filter application against an item list.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { NotificationItem } from './notifications';
+
+export const NOTIFICATION_FILTER_KEY = 'brain.ui.notifFilter';
+
+export const PATTERN_OBSERVATION_TYPE = 'pattern_observation';
+
+export type NotificationFilter = 'all' | 'patterns';
+
+const VALID_FILTERS: ReadonlySet<NotificationFilter> = new Set([
+  'all',
+  'patterns',
+]);
+
+function isNotificationFilter(value: unknown): value is NotificationFilter {
+  return typeof value === 'string' && VALID_FILTERS.has(value as NotificationFilter);
+}
+
+export async function readNotificationFilter(): Promise<NotificationFilter> {
+  const { value } = await Preferences.get({ key: NOTIFICATION_FILTER_KEY });
+  return isNotificationFilter(value) ? value : 'all';
+}
+
+export async function writeNotificationFilter(
+  filter: NotificationFilter,
+): Promise<void> {
+  await Preferences.set({ key: NOTIFICATION_FILTER_KEY, value: filter });
+}
+
+export function applyNotificationFilter(
+  items: NotificationItem[],
+  filter: NotificationFilter,
+): NotificationItem[] {
+  if (filter === 'all') return items;
+  return items.filter((item) => item.notification_type === PATTERN_OBSERVATION_TYPE);
+}

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -10,10 +10,13 @@ import {
   IonPage,
   IonRefresher,
   IonRefresherContent,
+  IonSegment,
+  IonSegmentButton,
   IonText,
   IonTitle,
   IonToolbar,
   type RefresherEventDetail,
+  type SegmentChangeEventDetail,
 } from '@ionic/react';
 import { format, parseISO } from 'date-fns';
 import ConnectionIndicator from '../components/ConnectionIndicator';
@@ -28,6 +31,12 @@ import {
   type NotificationItem,
   type NotificationStatus,
 } from '../lib/notifications';
+import {
+  applyNotificationFilter,
+  readNotificationFilter,
+  writeNotificationFilter,
+  type NotificationFilter,
+} from '../lib/notification-filter';
 
 type LoadState =
   | { kind: 'loading' }
@@ -93,6 +102,7 @@ function fetchErrorMessage(result: Extract<FetchResult, { ok: false }>): string 
 
 const NotificationsPage: React.FC = () => {
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [filter, setFilter] = useState<NotificationFilter>('all');
 
   const refresh = useCallback(
     async (pairing: Pairing): Promise<void> => {
@@ -116,8 +126,12 @@ const NotificationsPage: React.FC = () => {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const pairing = await loadPairing();
+      const [pairing, persistedFilter] = await Promise.all([
+        loadPairing(),
+        readNotificationFilter(),
+      ]);
       if (cancelled) return;
+      setFilter(persistedFilter);
       if (!pairing) {
         setState({ kind: 'empty-no-pairing' });
         return;
@@ -145,10 +159,22 @@ const NotificationsPage: React.FC = () => {
     [refresh],
   );
 
+  const handleFilterChange = useCallback(
+    (event: CustomEvent<SegmentChangeEventDetail>): void => {
+      const next = event.detail.value;
+      if (next !== 'all' && next !== 'patterns') return;
+      setFilter(next);
+      void writeNotificationFilter(next);
+    },
+    [],
+  );
+
   const partition = useMemo(() => {
     if (state.kind !== 'ready') return null;
-    return partitionNotifications(state.items);
-  }, [state]);
+    return partitionNotifications(applyNotificationFilter(state.items, filter));
+  }, [state, filter]);
+
+  const filterAnnotation = filter === 'patterns' ? '(filtered: patterns)' : null;
 
   return (
     <IonPage>
@@ -156,6 +182,20 @@ const NotificationsPage: React.FC = () => {
         <IonToolbar>
           <IonTitle>Notifications</IonTitle>
           <ConnectionIndicator slot="end" />
+        </IonToolbar>
+        <IonToolbar>
+          <IonSegment
+            value={filter}
+            onIonChange={handleFilterChange}
+            aria-label="Notification type filter"
+          >
+            <IonSegmentButton value="all">
+              <IonLabel>All</IonLabel>
+            </IonSegmentButton>
+            <IonSegmentButton value="patterns">
+              <IonLabel>Patterns</IonLabel>
+            </IonSegmentButton>
+          </IonSegment>
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen>
@@ -198,7 +238,14 @@ const NotificationsPage: React.FC = () => {
 
             <IonList>
               <IonListHeader>
-                <IonLabel>Today</IonLabel>
+                <IonLabel>
+                  Today
+                  {filterAnnotation ? (
+                    <IonText color="medium">
+                      <small className="ml-2">{filterAnnotation}</small>
+                    </IonText>
+                  ) : null}
+                </IonLabel>
               </IonListHeader>
               {partition.today.length === 0 ? (
                 <IonItem lines="none">
@@ -217,7 +264,14 @@ const NotificationsPage: React.FC = () => {
 
             <IonList>
               <IonListHeader>
-                <IonLabel>Earlier</IonLabel>
+                <IonLabel>
+                  Earlier
+                  {filterAnnotation ? (
+                    <IonText color="medium">
+                      <small className="ml-2">{filterAnnotation}</small>
+                    </IonText>
+                  ) : null}
+                </IonLabel>
               </IonListHeader>
               {partition.earlier.length === 0 ? (
                 <IonItem lines="none">


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npx tsc --noEmit` — ✅ Pass (no errors)
- `npx vitest run` — ✅ Pass (293 passed, 0 failed across 25 files; includes 10 new tests in `src/lib/notification-filter.test.ts`)
- `npm run android:sync` — n/a (no Capacitor plugin changes; no native shim changes)

Ran locally against develop HEAD at `6ed3c44` immediately before opening this PR.

## Summary

Adds a two-segment `IonSegment` filter (All / Patterns) to `/notifications` that lets the user narrow the recent-notifications view to `notification_type="pattern_observation"` rows. Per the [2C-17] recommendation and Pass 3 E5, the pattern observation surface IS this filter — there is no dedicated screen. Filter state is persisted under `@capacitor/preferences` key `brain.ui.notifFilter` so the user's last-chosen filter survives app restarts. No new fetches: filtering is applied client-side over the existing 8-day window that [2C-09] already pulls.

## Changes

**New module — `src/lib/notification-filter.ts`** owns the filter type, persistence, and application:
- `NotificationFilter = 'all' | 'patterns'` — extendable union for the future segments the spec calls out as "added lazily by other chunks as needed."
- `NOTIFICATION_FILTER_KEY = 'brain.ui.notifFilter'` — the Preferences key from the spec, exported so tests pin against the literal.
- `readNotificationFilter()` / `writeNotificationFilter()` — Preferences-backed persistence; reads default to `'all'` on missing or invalid stored values (forward-compat against future filter values that this build doesn't recognise).
- `applyNotificationFilter(items, filter)` — pure, non-mutating; returns the input unchanged for `'all'`, else keeps only `notification_type === 'pattern_observation'`.

**New tests — `src/lib/notification-filter.test.ts`** mirror the existing `notifications.test.ts` mocking shape (Preferences in-memory map). 10 tests cover: default-when-empty, write/read roundtrip, fallback on invalid stored value, multi-call persistence, no-op for `'all'`, filter to pattern rows, empty-result on no matches, order preservation, and input-non-mutation.

**Page wiring — `src/pages/NotificationsPage.tsx`:**
- Added a second `IonToolbar` in the header containing the `IonSegment` with All / Patterns buttons. Placed in the toolbar rather than inline content so it stays pinned at the top of the page on scroll, consistent with the rest of the app's segmented-control patterns.
- Filter state hydrates on mount alongside `loadPairing()` via `Promise.all`, then drives a `useMemo` that filters items pre-partition. Segment changes update local state and persist via `writeNotificationFilter` — no refetch.
- `Today` and `Earlier` `IonListHeader` labels render a `(filtered: patterns)` annotation in `IonText color="medium"` when the filter is non-default. Annotation is hidden when the filter is `'all'`.

## How to Verify

1. Pair the app and let `/notifications` populate (or seed cached notifications via offline launch path).
2. Confirm the segment control appears at the top of the page with **All** selected by default.
3. Tap **Patterns** — list narrows to `pattern_observation` rows only; both `Today` and `Earlier` headers show `(filtered: patterns)`.
4. Tap **All** — full list returns; annotations disappear.
5. Open Chrome/Android dev tools and confirm no `/api/notifications/` request fires on segment toggle.
6. Force-quit and relaunch the app — the last-selected filter is restored.

## Deviations

None. Spec implemented as written.

Watch-items per Group 4 brief:
- **First-Consumer-Instantiates** does not apply — the filter module is purpose-built for [2C-17], not a forward-looking scaffold for unrelated consumers. The `'all' | 'patterns'` union is extendable per the spec's "future segment options" note, but the introduction is the deliverable, not preemptive scaffolding.
- **Spec-vs-ledger conflict (`70e5e875`)** — no conflict to flag. Issue body and Group 4 brief agree (Pass 3 E5: "the pattern observation surface IS the filter on `[2C-09]`").
- **StatusPill ordering** — does not surface here; that watch-item lands on `[2C-16]`.
- **Manual verification** — issue body has no `#### Manual verification` section, so no MV obligations apply per repo CLAUDE.md.

## Test Results

See **Verification** section above. Full vitest run: 25 test files, 293 tests, 0 failures, ~9.1s. New `src/lib/notification-filter.test.ts` adds 10 tests, all passing.

The `RoutineDetailPage.test.tsx` stderr noise (`TypeError: Cannot read properties of null (reading 'offsetHeight')` from Ionic animation frames inside jsdom) is pre-existing and present on develop `6ed3c44` independent of this branch — not caused or affected by this change.

## Acceptance Checklist

- [x] Segment control visible at top of `/notifications`
- [x] Selecting **Patterns** filters the list to only `notification_type="pattern_observation"` rows
- [x] Filter persists across app launches (Preferences key `brain.ui.notifFilter`)
- [x] Selecting **All** restores the full list
- [x] Filter state appears in section headers when non-default (`(filtered: patterns)`)
- [x] No additional network fetches triggered by segment change (client-side filter only)

Closes #12