### PR TITLE
[2C-18] Rule-name resolution on notification detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { IonReactRouter } from '@ionic/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
+import NotificationDetailPage from './pages/NotificationDetailPage';
 import HabitsPage from './pages/HabitsPage';
 import HabitDetailPage from './pages/HabitDetailPage';
 import RoutinesPage from './pages/RoutinesPage';
@@ -109,6 +110,9 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/notifications">
             <NotificationsPage />
+          </Route>
+          <Route exact path="/notifications/:notificationId">
+            <NotificationDetailPage />
           </Route>
           <Route exact path="/habits">
             <HabitsPage />

--- a/src/lib/notification-filter.test.ts
+++ b/src/lib/notification-filter.test.ts
@@ -45,12 +45,26 @@ function makeItem(overrides: Partial<NotificationItem>): NotificationItem {
   return {
     id: overrides.id ?? 'n-1',
     notification_type: overrides.notification_type ?? 'habit_reminder',
+    delivery_type: overrides.delivery_type ?? 'notification',
     message: overrides.message ?? 'Take your meds',
     scheduled_at: overrides.scheduled_at ?? '2026-04-28T13:00:00Z',
     scheduled_date: overrides.scheduled_date ?? '2026-04-28',
     status: overrides.status ?? 'pending',
-    expires_at: overrides.expires_at ?? '2026-04-28T15:00:00Z',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : '2026-04-28T15:00:00Z',
     response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-04-28T12:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-04-28T12:00:00Z',
   };
 }
 

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -50,12 +50,26 @@ function makeItem(overrides: Partial<NotificationItem>): NotificationItem {
   return {
     id: overrides.id ?? 'n-1',
     notification_type: overrides.notification_type ?? 'habit_reminder',
+    delivery_type: overrides.delivery_type ?? 'notification',
     message: overrides.message ?? 'Take your meds',
     scheduled_at: overrides.scheduled_at ?? '2026-04-28T13:00:00Z',
     scheduled_date: overrides.scheduled_date ?? '2026-04-28',
     status: overrides.status ?? 'pending',
-    expires_at: overrides.expires_at ?? '2026-04-28T15:00:00Z',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : '2026-04-28T15:00:00Z',
     response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-04-28T12:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-04-28T12:00:00Z',
   };
 }
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -31,15 +31,25 @@ export type NotificationStatus =
 export interface NotificationItem {
   id: string;
   notification_type: string;
+  delivery_type: string;
   message: string;
   /** ISO timestamp of when the nudge was scheduled to fire. */
   scheduled_at: string;
   /** Device-local calendar date the nudge belongs to (`YYYY-MM-DD`). */
   scheduled_date: string;
   status: NotificationStatus;
-  expires_at: string;
+  expires_at: string | null;
   /** The chosen canned response, or `null` if not responded. */
   response: string | null;
+  response_note: string | null;
+  responded_at: string | null;
+  canned_responses: string[] | null;
+  target_entity_type: string;
+  target_entity_id: string;
+  scheduled_by: string;
+  rule_id: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 interface NotificationListResponseBody {
@@ -52,6 +62,14 @@ export type FetchResult =
   | {
       ok: false;
       reason: 'unauthorized' | 'network' | 'server' | 'timeout';
+      statusCode?: number;
+    };
+
+export type FetchNotificationResult =
+  | { ok: true; notification: NotificationItem }
+  | {
+      ok: false;
+      reason: 'unauthorized' | 'network' | 'server' | 'timeout' | 'not_found';
       statusCode?: number;
     };
 
@@ -84,6 +102,42 @@ export async function fetchNotifications(
     }
     if (response.status === 401) {
       return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    return { ok: false, reason: 'server', statusCode: response.status };
+  } catch {
+    if (controller.signal.aborted) {
+      return { ok: false, reason: 'timeout' };
+    }
+    return { ok: false, reason: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchNotification(
+  pairing: Pairing,
+  notificationId: string,
+): Promise<FetchNotificationResult> {
+  const base = pairing.url.replace(/\/$/, '');
+  const url = `${base}${NOTIFICATIONS_PATH}${notificationId}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${pairing.token}` },
+      signal: controller.signal,
+    });
+    if (response.status === 200) {
+      const body = (await response.json()) as NotificationItem;
+      return { ok: true, notification: body };
+    }
+    if (response.status === 401) {
+      return { ok: false, reason: 'unauthorized', statusCode: 401 };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: 'not_found', statusCode: 404 };
     }
     return { ok: false, reason: 'server', statusCode: response.status };
   } catch {

--- a/src/lib/rules.test.ts
+++ b/src/lib/rules.test.ts
@@ -73,12 +73,26 @@ function makeNotification(
   return {
     id: overrides.id ?? 'n-1',
     notification_type: overrides.notification_type ?? 'habit_nudge',
+    delivery_type: overrides.delivery_type ?? 'notification',
     message: overrides.message ?? 'Test message',
     scheduled_at: overrides.scheduled_at ?? '2026-05-09T08:00:00Z',
     scheduled_date: overrides.scheduled_date ?? '2026-05-09',
     status: overrides.status ?? 'delivered',
-    expires_at: overrides.expires_at ?? '2026-05-09T20:00:00Z',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : '2026-05-09T20:00:00Z',
     response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-05-09T07:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-09T07:00:00Z',
   };
 }
 

--- a/src/pages/NotificationDetailPage.test.tsx
+++ b/src/pages/NotificationDetailPage.test.tsx
@@ -1,0 +1,368 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy, replaceSpy } = vi.hoisted(() => ({
+  pushSpy: vi.fn(),
+  replaceSpy: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: replaceSpy,
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import {
+  RULES_CACHE_KEY,
+  type RuleRead,
+} from '../lib/rules';
+import type { NotificationItem } from '../lib/notifications';
+import NotificationDetailPage from './NotificationDetailPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function seedRulesCache(rules: RuleRead[]): void {
+  prefsStore.set(
+    RULES_CACHE_KEY,
+    JSON.stringify({ fetched_at: '2026-05-09T13:00:00Z', items: rules }),
+  );
+}
+
+function makeRule(overrides: Partial<RuleRead> = {}): RuleRead {
+  return {
+    id: overrides.id ?? 'r-1',
+    name: overrides.name ?? 'Habit nudge — 3 skips',
+    entity_type: overrides.entity_type ?? 'habit',
+    entity_id: overrides.entity_id ?? null,
+    metric: overrides.metric ?? 'consecutive_skips',
+    operator: overrides.operator ?? '>=',
+    threshold: overrides.threshold ?? 3,
+    action: overrides.action ?? 'create_notification',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    message_template:
+      overrides.message_template ??
+      "{entity_name} hasn't been touched in {metric_value} days",
+    enabled: overrides.enabled ?? true,
+    cooldown_hours: overrides.cooldown_hours ?? 24,
+    is_default: overrides.is_default ?? false,
+    last_triggered_at: overrides.last_triggered_at ?? null,
+    created_at: overrides.created_at ?? '2026-05-01T00:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-01T00:00:00Z',
+  };
+}
+
+function makeNotification(
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  return {
+    id: overrides.id ?? 'n-1',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    delivery_type: overrides.delivery_type ?? 'notification',
+    message: overrides.message ?? 'Time to take meds',
+    scheduled_at: overrides.scheduled_at ?? '2026-05-09T13:00:00Z',
+    scheduled_date: overrides.scheduled_date ?? '2026-05-09',
+    status: overrides.status ?? 'delivered',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : '2026-05-09T15:00:00Z',
+    response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-05-09T12:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-09T12:00:00Z',
+  };
+}
+
+interface FetchStub {
+  notification?: { status: number; body?: NotificationItem };
+  rulesList?: { status: number; items?: RuleRead[] };
+  ruleDetail?: { status: number; rule?: RuleRead };
+}
+
+function stubFetch(stub: FetchStub = {}) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      // /api/rules/{id} (single) — must check before list because both
+      // share the same /api/rules/ prefix.
+      const ruleDetailMatch = url.match(/\/api\/rules\/([^/?]+)$/);
+      if (ruleDetailMatch) {
+        const r = stub.ruleDetail ?? { status: 200, rule: makeRule() };
+        if (r.status === 200 && r.rule) {
+          return new Response(JSON.stringify(r.rule), { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      if (url.includes('/api/rules')) {
+        const r = stub.rulesList ?? { status: 200, items: [] };
+        if (r.status === 200) {
+          return new Response(
+            JSON.stringify({
+              items: r.items ?? [],
+              count: (r.items ?? []).length,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response('', { status: r.status });
+      }
+      if (url.includes('/api/notifications/')) {
+        const r = stub.notification ?? {
+          status: 200,
+          body: makeNotification(),
+        };
+        if (r.status === 200 && r.body) {
+          return new Response(JSON.stringify(r.body), { status: 200 });
+        }
+        return new Response('', { status: r.status });
+      }
+      return new Response('', { status: 404 });
+    });
+}
+
+function renderPage(notificationId: string = 'n-1') {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/notifications/${notificationId}`]}>
+        <Route path="/notifications/:notificationId">
+          <NotificationDetailPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('NotificationDetailPage — bootstrap', () => {
+  it('shows the no-pairing message when the app is unpaired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the notification body when fetched successfully', async () => {
+    pair();
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({
+          id: 'n-1',
+          message: 'Hello world',
+          status: 'delivered',
+          target_entity_type: 'habit',
+          target_entity_id: '22222222-2222-2222-2222-222222222222',
+        }),
+      },
+    });
+
+    renderPage('n-1');
+
+    expect(
+      await screen.findByTestId('notification-detail-message'),
+    ).toHaveTextContent('Hello world');
+    expect(screen.getByText('Habit nudge')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('notification-status-pill-delivered'),
+    ).toHaveTextContent('Delivered');
+    expect(screen.getByTestId('notification-detail-target-id')).toHaveTextContent(
+      '22222222-2222-2222-2222-222222222222',
+    );
+  });
+
+  it('shows a not-found card on 404', async () => {
+    pair();
+    stubFetch({ notification: { status: 404 } });
+
+    renderPage('missing');
+
+    expect(await screen.findByTestId('notification-not-found')).toHaveTextContent(
+      /not found/i,
+    );
+  });
+
+  it('copies the target entity id when the copy button is tapped', async () => {
+    pair();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({
+          target_entity_id: '33333333-3333-3333-3333-333333333333',
+        }),
+      },
+    });
+
+    renderPage();
+
+    await screen.findByTestId('notification-detail-message');
+    await userEvent.click(screen.getByTestId('notification-detail-target-copy'));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        '33333333-3333-3333-3333-333333333333',
+      );
+    });
+  });
+});
+
+describe('NotificationDetailPage — rule_id resolution', () => {
+  it('renders "Triggered manually" when rule_id is null', async () => {
+    pair();
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({ rule_id: null }),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('notification-rule-manual'),
+    ).toHaveTextContent(/triggered manually/i);
+  });
+
+  it('resolves rule name from the cached ["rules"] list and navigates on tap', async () => {
+    pair();
+    seedRulesCache([
+      makeRule({ id: 'rule-aaa', name: 'Daily standup nudge' }),
+      makeRule({ id: 'rule-bbb', name: 'Other rule' }),
+    ]);
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({ rule_id: 'rule-aaa' }),
+      },
+      // Stale-time on the rules query plus initialData from the cached
+      // payload should mean no /api/rules/ refetch fires; if the page
+      // does refetch, fall back to the cached rule list shape.
+      rulesList: {
+        status: 200,
+        items: [
+          makeRule({ id: 'rule-aaa', name: 'Daily standup nudge' }),
+          makeRule({ id: 'rule-bbb', name: 'Other rule' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const chip = await screen.findByTestId('notification-rule-chip-rule-aaa');
+    expect(chip).toHaveTextContent(/triggered by rule: daily standup nudge/i);
+
+    await userEvent.click(chip);
+    expect(pushSpy).toHaveBeenCalledWith('/rules/rule-aaa');
+  });
+
+  it('resolves rule name via warm fetch when on-disk cache is empty', async () => {
+    pair();
+    // No cached rules on disk — rules query will fetch /api/rules/ from
+    // network and resolve from the response.
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({ rule_id: 'rule-ccc' }),
+      },
+      rulesList: {
+        status: 200,
+        items: [makeRule({ id: 'rule-ccc', name: 'Cold-start rule' })],
+      },
+    });
+
+    renderPage();
+
+    const chip = await screen.findByTestId('notification-rule-chip-rule-ccc');
+    expect(chip).toHaveTextContent(/triggered by rule: cold-start rule/i);
+  });
+
+  it('shows "Triggered by deleted rule" when rule_id is set but the single-rule fetch returns 404', async () => {
+    pair();
+    // Cached rules list does NOT contain rule-ddd. On-demand single-rule
+    // fetch returns 404 (rule was deleted between firing and viewing).
+    seedRulesCache([makeRule({ id: 'rule-other', name: 'Some other rule' })]);
+    stubFetch({
+      notification: {
+        status: 200,
+        body: makeNotification({ rule_id: 'rule-ddd' }),
+      },
+      rulesList: {
+        status: 200,
+        items: [makeRule({ id: 'rule-other', name: 'Some other rule' })],
+      },
+      ruleDetail: { status: 404 },
+    });
+
+    renderPage();
+
+    const deleted = await screen.findByTestId('notification-rule-deleted');
+    expect(deleted).toHaveTextContent(
+      /triggered by deleted rule \(id: rule-ddd\)/i,
+    );
+  });
+});

--- a/src/pages/NotificationDetailPage.tsx
+++ b/src/pages/NotificationDetailPage.tsx
@@ -1,0 +1,589 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonChip,
+  IonContent,
+  IonHeader,
+  IonLabel,
+  IonPage,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+  type RefresherEventDetail,
+} from '@ionic/react';
+import {
+  useQuery,
+  type QueryKey,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { useHistory, useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchNotification,
+  type NotificationItem,
+  type NotificationStatus,
+} from '../lib/notifications';
+import {
+  RULES_QUERY_KEY,
+  fetchRule,
+  fetchRules,
+  readCachedRules,
+  writeCachedRules,
+  type RuleRead,
+} from '../lib/rules';
+
+const NOTIFICATION_QUERY_KEY = (id: string): QueryKey => ['notification', id];
+const RULE_QUERY_KEY = (id: string): QueryKey => ['rule', id];
+const STALE_MS = 5 * 60 * 1000;
+
+const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
+  habit_nudge: 'Habit nudge',
+  routine_checklist: 'Routine checklist',
+  checkin_prompt: 'Check-in prompt',
+  time_block_reminder: 'Time block reminder',
+  deadline_event_alert: 'Deadline / event alert',
+  pattern_observation: 'Pattern observation',
+  stale_work_nudge: 'Stale work nudge',
+};
+
+function friendlyNotificationType(notificationType: string): string {
+  return NOTIFICATION_TYPE_LABELS[notificationType] ?? notificationType;
+}
+
+function statusLabel(status: NotificationStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'Pending';
+    case 'delivered':
+      return 'Delivered';
+    case 'responded':
+      return 'Responded';
+    case 'expired':
+      return 'Expired';
+  }
+}
+
+function statusPillClasses(status: NotificationStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'bg-neutral-100 text-neutral-700 ring-neutral-300';
+    case 'delivered':
+      return 'bg-blue-100 text-blue-800 ring-blue-200';
+    case 'responded':
+      return 'bg-emerald-100 text-emerald-800 ring-emerald-200';
+    case 'expired':
+      return 'bg-amber-100 text-amber-800 ring-amber-200';
+  }
+}
+
+function formatAbsolute(iso: string): string {
+  try {
+    return format(parseISO(iso), "EEE, MMM d 'at' h:mm a");
+  } catch {
+    return iso;
+  }
+}
+
+function formatScheduledDate(yyyyMmDd: string): string {
+  try {
+    return format(parseISO(yyyyMmDd), 'EEE, MMM d');
+  } catch {
+    return yyyyMmDd;
+  }
+}
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | {
+      kind: 'paired';
+      pairing: Pairing;
+      cachedRules: RuleRead[] | null;
+      cachedRulesFetchedAtMs: number | null;
+    };
+
+const NotificationDetailPage: React.FC = () => {
+  const { notificationId } = useParams<{ notificationId: string }>();
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pairing, cachedRules] = await Promise.all([
+        loadPairing(),
+        readCachedRules(),
+      ]);
+      if (cancelled) return;
+      if (!pairing) {
+        setBootstrap({ kind: 'no-pairing' });
+        return;
+      }
+      const cachedRulesFetchedAtMs = cachedRules?.fetched_at
+        ? Date.parse(cachedRules.fetched_at)
+        : null;
+      setBootstrap({
+        kind: 'paired',
+        pairing,
+        cachedRules: cachedRules?.items ?? null,
+        cachedRulesFetchedAtMs: Number.isFinite(cachedRulesFetchedAtMs)
+          ? cachedRulesFetchedAtMs
+          : null,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/notifications" />
+          </IonButtons>
+          <IonTitle>Notification</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to see this notification.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <DetailBody
+            notificationId={notificationId}
+            pairing={bootstrap.pairing}
+            initialCachedRules={bootstrap.cachedRules}
+            initialCachedRulesFetchedAtMs={bootstrap.cachedRulesFetchedAtMs}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  notificationId: string;
+  pairing: Pairing;
+  initialCachedRules: RuleRead[] | null;
+  initialCachedRulesFetchedAtMs: number | null;
+}
+
+const DetailBody: React.FC<BodyProps> = ({
+  notificationId,
+  pairing,
+  initialCachedRules,
+  initialCachedRulesFetchedAtMs,
+}) => {
+  const history = useHistory();
+  const [toastOpen, setToastOpen] = useState(false);
+
+  const notificationQuery = useQuery<NotificationItem>({
+    queryKey: NOTIFICATION_QUERY_KEY(notificationId),
+    queryFn: async () => {
+      const result = await fetchNotification(pairing, notificationId);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      return result.notification;
+    },
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  // Reuse [2C-16]'s ['rules'] cache for the common rule-name resolution path.
+  // Cold-start hydrates from the on-disk Capacitor Preferences cache so deep
+  // links into a notification don't trigger a new /api/rules/ fetch when
+  // there's a recent local copy.
+  const rulesQuery = useQuery<RuleRead[]>({
+    queryKey: RULES_QUERY_KEY,
+    queryFn: async () => {
+      const result = await fetchRules(pairing);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      await writeCachedRules(result.items);
+      return result.items;
+    },
+    initialData: initialCachedRules ?? undefined,
+    initialDataUpdatedAt:
+      initialCachedRules !== null && initialCachedRulesFetchedAtMs !== null
+        ? initialCachedRulesFetchedAtMs
+        : undefined,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  const notification = notificationQuery.data;
+  const ruleId = notification?.rule_id ?? null;
+
+  const cachedRule = useMemo<RuleRead | null>(() => {
+    if (ruleId === null) return null;
+    const rules = rulesQuery.data;
+    if (!rules) return null;
+    return rules.find((r) => r.id === ruleId) ?? null;
+  }, [ruleId, rulesQuery.data]);
+
+  // Spec: if rule_id is set but the rule isn't in the (already-resolved)
+  // rules cache, re-fetch /api/rules/{id} on demand. 404 → deleted-rule
+  // label. The single-rule fetch is gated on the rules query having
+  // resolved (success or error) so we don't double-request the rule
+  // before the list has had its turn.
+  const shouldFetchSingleRule =
+    ruleId !== null &&
+    cachedRule === null &&
+    !rulesQuery.isPending &&
+    !rulesQuery.isFetching;
+
+  const singleRuleQuery = useQuery<RuleRead>({
+    queryKey: RULE_QUERY_KEY(ruleId ?? '_'),
+    queryFn: async () => {
+      const result = await fetchRule(pairing, ruleId!);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      return result.rule;
+    },
+    enabled: shouldFetchSingleRule,
+    staleTime: STALE_MS,
+    retry: false,
+  });
+
+  const handleRefresh = useCallback(
+    async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
+      try {
+        await Promise.all([
+          notificationQuery.refetch(),
+          rulesQuery.refetch(),
+        ]);
+      } finally {
+        event.detail.complete();
+      }
+    },
+    [notificationQuery, rulesQuery],
+  );
+
+  const onCopyTargetEntityId = useCallback(
+    async (entityId: string): Promise<void> => {
+      try {
+        await navigator.clipboard.writeText(entityId);
+        setToastOpen(true);
+      } catch {
+        // Clipboard unavailable — surface nothing rather than a hard error.
+      }
+    },
+    [],
+  );
+
+  const onRuleChipTap = useCallback(
+    (id: string): void => {
+      history.push(`/rules/${id}`);
+    },
+    [history],
+  );
+
+  if (
+    isNotFoundError(notificationQuery.error) &&
+    notificationQuery.data === undefined
+  ) {
+    return (
+      <NotFoundCard onBack={() => history.replace('/notifications')} />
+    );
+  }
+
+  if (notificationQuery.isPending) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-neutral-300">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  if (notificationQuery.isError || notification === undefined) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-200"
+        role="alert"
+      >
+        <p>Couldn&apos;t load notification.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
+      <section className="px-4 pt-4" data-testid="notification-detail-pane">
+        <div className="flex items-center gap-2">
+          <span
+            data-testid={`notification-status-pill-${notification.status}`}
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusPillClasses(notification.status)}`}
+          >
+            {statusLabel(notification.status)}
+          </span>
+          <h1 className="text-xl font-semibold">
+            {friendlyNotificationType(notification.notification_type)}
+          </h1>
+        </div>
+
+        <p
+          className="mt-3 whitespace-pre-wrap text-base text-neutral-100"
+          data-testid="notification-detail-message"
+        >
+          {notification.message}
+        </p>
+
+        <RuleSection
+          ruleId={ruleId}
+          cachedRule={cachedRule}
+          singleRuleQuery={singleRuleQuery}
+          shouldFetchSingleRule={shouldFetchSingleRule}
+          onTap={onRuleChipTap}
+        />
+
+        <dl className="mt-6 grid grid-cols-1 gap-2 text-sm">
+          <Row label="Scheduled">
+            {formatAbsolute(notification.scheduled_at)}
+          </Row>
+          <Row label="Scheduled date">
+            {formatScheduledDate(notification.scheduled_date)}
+          </Row>
+          {notification.expires_at !== null ? (
+            <Row label="Expires">{formatAbsolute(notification.expires_at)}</Row>
+          ) : null}
+          <Row label="Target">
+            <span
+              className="flex items-center gap-2"
+              data-testid="notification-detail-target"
+            >
+              <span>{notification.target_entity_type} —</span>
+              <code
+                className="font-mono text-xs"
+                data-testid="notification-detail-target-id"
+              >
+                {notification.target_entity_id}
+              </code>
+              <IonButton
+                size="small"
+                fill="clear"
+                onClick={() =>
+                  onCopyTargetEntityId(notification.target_entity_id)
+                }
+                data-testid="notification-detail-target-copy"
+              >
+                Copy
+              </IonButton>
+            </span>
+          </Row>
+        </dl>
+
+        {notification.canned_responses !== null &&
+        notification.canned_responses.length > 0 ? (
+          <div className="mt-4">
+            <h2 className="text-sm font-medium text-neutral-300">
+              Canned responses
+            </h2>
+            <div
+              className="mt-1 flex flex-wrap gap-1"
+              data-testid="notification-detail-canned-responses"
+            >
+              {notification.canned_responses.map((response) => (
+                <IonChip key={response} disabled>
+                  {response}
+                </IonChip>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {notification.response !== null ? (
+          <div className="mt-4">
+            <h2 className="text-sm font-medium text-neutral-300">Response</h2>
+            <p
+              className="mt-1 text-neutral-100"
+              data-testid="notification-detail-response"
+            >
+              {notification.response}
+            </p>
+            {notification.responded_at !== null ? (
+              <p className="mt-1">
+                <IonText color="medium">
+                  <small>{formatAbsolute(notification.responded_at)}</small>
+                </IonText>
+              </p>
+            ) : null}
+            {notification.response_note !== null ? (
+              <p
+                className="mt-2 whitespace-pre-wrap text-neutral-100"
+                data-testid="notification-detail-response-note"
+              >
+                {notification.response_note}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      <IonToast
+        isOpen={toastOpen}
+        message="Copied to clipboard"
+        duration={1500}
+        onDidDismiss={() => setToastOpen(false)}
+      />
+    </>
+  );
+};
+
+interface RuleSectionProps {
+  ruleId: string | null;
+  cachedRule: RuleRead | null;
+  singleRuleQuery: UseQueryResult<RuleRead, Error>;
+  shouldFetchSingleRule: boolean;
+  onTap: (ruleId: string) => void;
+}
+
+const RuleSection: React.FC<RuleSectionProps> = ({
+  ruleId,
+  cachedRule,
+  singleRuleQuery,
+  shouldFetchSingleRule,
+  onTap,
+}) => {
+  if (ruleId === null) {
+    return (
+      <p
+        className="mt-4 text-sm"
+        data-testid="notification-rule-manual"
+      >
+        <IonText color="medium">Triggered manually</IonText>
+      </p>
+    );
+  }
+
+  if (cachedRule !== null) {
+    return (
+      <div className="mt-4" data-testid="notification-rule-resolved">
+        <IonChip
+          color="primary"
+          onClick={() => onTap(cachedRule.id)}
+          data-testid={`notification-rule-chip-${cachedRule.id}`}
+        >
+          <IonLabel>Triggered by rule: {cachedRule.name}</IonLabel>
+        </IonChip>
+      </div>
+    );
+  }
+
+  if (shouldFetchSingleRule && singleRuleQuery.isPending) {
+    return (
+      <p
+        className="mt-4 text-sm"
+        data-testid="notification-rule-resolving"
+      >
+        <IonText color="medium">Resolving rule…</IonText>
+      </p>
+    );
+  }
+
+  if (isNotFoundError(singleRuleQuery.error)) {
+    return (
+      <p
+        className="mt-4 text-sm"
+        data-testid="notification-rule-deleted"
+      >
+        <IonText color="medium">
+          Triggered by deleted rule (id: {ruleId})
+        </IonText>
+      </p>
+    );
+  }
+
+  if (singleRuleQuery.data) {
+    return (
+      <div className="mt-4" data-testid="notification-rule-resolved">
+        <IonChip
+          color="primary"
+          onClick={() => onTap(singleRuleQuery.data!.id)}
+          data-testid={`notification-rule-chip-${singleRuleQuery.data.id}`}
+        >
+          <IonLabel>
+            Triggered by rule: {singleRuleQuery.data.name}
+          </IonLabel>
+        </IonChip>
+      </div>
+    );
+  }
+
+  // Rule lookup failed for a non-404 reason (network/server/timeout, or the
+  // rules-list query itself failed and we never got a single-rule fetch
+  // off the ground). Fall back to the rule_id so the audit trail isn't
+  // silently lost.
+  return (
+    <p
+      className="mt-4 text-sm"
+      data-testid="notification-rule-unresolved"
+    >
+      <IonText color="medium">Triggered by rule (id: {ruleId})</IonText>
+    </p>
+  );
+};
+
+const Row: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="flex justify-between gap-3">
+    <dt className="text-neutral-400">{label}</dt>
+    <dd className="text-right">{children}</dd>
+  </div>
+);
+
+const NotFoundCard: React.FC<{ onBack: () => void }> = ({ onBack }) => (
+  <div
+    className="flex h-full w-full flex-col items-center justify-center px-4 text-center text-neutral-300"
+    data-testid="notification-not-found"
+  >
+    <p>Notification not found.</p>
+    <IonButton fill="outline" className="mt-3" onClick={onBack}>
+      Back to notifications
+    </IonButton>
+  </div>
+);
+
+function isNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'notFound' in error &&
+      (error as { notFound: unknown }).notFound === true,
+  );
+}
+
+export default NotificationDetailPage;

--- a/src/pages/NotificationsPage.test.tsx
+++ b/src/pages/NotificationsPage.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: pushSpy,
+      replace: vi.fn(),
+      goBack: vi.fn(),
+    }),
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import type { NotificationItem } from '../lib/notifications';
+import NotificationsPage from './NotificationsPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  pushSpy.mockReset();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeNotification(
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  const todayLocal = new Date();
+  const yyyyMmDd = `${todayLocal.getFullYear()}-${String(
+    todayLocal.getMonth() + 1,
+  ).padStart(2, '0')}-${String(todayLocal.getDate()).padStart(2, '0')}`;
+  return {
+    id: overrides.id ?? 'n-1',
+    notification_type: overrides.notification_type ?? 'habit_nudge',
+    delivery_type: overrides.delivery_type ?? 'notification',
+    message: overrides.message ?? 'Test message',
+    scheduled_at:
+      overrides.scheduled_at ?? new Date(Date.now() - 60_000).toISOString(),
+    scheduled_date: overrides.scheduled_date ?? yyyyMmDd,
+    status: overrides.status ?? 'delivered',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : new Date(Date.now() + 3_600_000).toISOString(),
+    response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-05-09T12:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-09T12:00:00Z',
+  };
+}
+
+function stubNotifications(items: NotificationItem[]) {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(
+      new Response(JSON.stringify({ items, count: items.length }), {
+        status: 200,
+      }),
+    );
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/notifications']}>
+        <Route path="/notifications">
+          <NotificationsPage />
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('NotificationsPage — tap-through to detail', () => {
+  it('pushes /notifications/{id} when a row is tapped', async () => {
+    pair();
+    stubNotifications([
+      makeNotification({ id: 'n-tap', message: 'Tappable item' }),
+    ]);
+
+    renderPage();
+
+    const row = await screen.findByTestId('notification-row-n-tap');
+    await userEvent.click(row);
+    expect(pushSpy).toHaveBeenCalledWith('/notifications/n-tap');
+  });
+});

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -19,6 +19,7 @@ import {
   type SegmentChangeEventDetail,
 } from '@ionic/react';
 import { format, parseISO } from 'date-fns';
+import { useHistory } from 'react-router-dom';
 import ConnectionIndicator from '../components/ConnectionIndicator';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
@@ -101,8 +102,16 @@ function fetchErrorMessage(result: Extract<FetchResult, { ok: false }>): string 
 }
 
 const NotificationsPage: React.FC = () => {
+  const history = useHistory();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [filter, setFilter] = useState<NotificationFilter>('all');
+
+  const onRowTap = useCallback(
+    (item: NotificationItem): void => {
+      history.push(`/notifications/${item.id}`);
+    },
+    [history],
+  );
 
   const refresh = useCallback(
     async (pairing: Pairing): Promise<void> => {
@@ -257,7 +266,7 @@ const NotificationsPage: React.FC = () => {
                 </IonItem>
               ) : (
                 partition.today.map((item) => (
-                  <NotificationRow key={item.id} item={item} />
+                  <NotificationRow key={item.id} item={item} onTap={onRowTap} />
                 ))
               )}
             </IonList>
@@ -283,7 +292,11 @@ const NotificationsPage: React.FC = () => {
                 </IonItem>
               ) : (
                 partition.earlier.map((group) => (
-                  <EarlierDayGroup key={group.date} group={group} />
+                  <EarlierDayGroup
+                    key={group.date}
+                    group={group}
+                    onRowTap={onRowTap}
+                  />
                 ))
               )}
             </IonList>
@@ -294,7 +307,15 @@ const NotificationsPage: React.FC = () => {
   );
 };
 
-const EarlierDayGroup: React.FC<{ group: EarlierGroup }> = ({ group }) => (
+interface EarlierDayGroupProps {
+  group: EarlierGroup;
+  onRowTap: (item: NotificationItem) => void;
+}
+
+const EarlierDayGroup: React.FC<EarlierDayGroupProps> = ({
+  group,
+  onRowTap,
+}) => (
   <>
     <IonItem lines="none" className="ion-margin-top">
       <IonLabel>
@@ -304,13 +325,22 @@ const EarlierDayGroup: React.FC<{ group: EarlierGroup }> = ({ group }) => (
       </IonLabel>
     </IonItem>
     {group.items.map((item) => (
-      <NotificationRow key={item.id} item={item} />
+      <NotificationRow key={item.id} item={item} onTap={onRowTap} />
     ))}
   </>
 );
 
-const NotificationRow: React.FC<{ item: NotificationItem }> = ({ item }) => (
-  <IonItem>
+interface NotificationRowProps {
+  item: NotificationItem;
+  onTap: (item: NotificationItem) => void;
+}
+
+const NotificationRow: React.FC<NotificationRowProps> = ({ item, onTap }) => (
+  <IonItem
+    button
+    onClick={() => onTap(item)}
+    data-testid={`notification-row-${item.id}`}
+  >
     <IonLabel className="ion-text-wrap">
       <h2>{item.notification_type}</h2>
       <p>{item.message}</p>

--- a/src/pages/RuleDetailPage.test.tsx
+++ b/src/pages/RuleDetailPage.test.tsx
@@ -93,12 +93,26 @@ function makeFire(overrides: Partial<NotificationItem> = {}): NotificationItem {
   return {
     id: overrides.id ?? 'n-1',
     notification_type: overrides.notification_type ?? 'habit_nudge',
+    delivery_type: overrides.delivery_type ?? 'notification',
     message: overrides.message ?? 'Test message',
     scheduled_at: overrides.scheduled_at ?? '2026-05-09T08:00:00Z',
     scheduled_date: overrides.scheduled_date ?? '2026-05-09',
     status: overrides.status ?? 'delivered',
-    expires_at: overrides.expires_at ?? '2026-05-09T20:00:00Z',
+    expires_at:
+      overrides.expires_at !== undefined
+        ? overrides.expires_at
+        : '2026-05-09T20:00:00Z',
     response: overrides.response ?? null,
+    response_note: overrides.response_note ?? null,
+    responded_at: overrides.responded_at ?? null,
+    canned_responses: overrides.canned_responses ?? null,
+    target_entity_type: overrides.target_entity_type ?? 'habit',
+    target_entity_id:
+      overrides.target_entity_id ?? '11111111-1111-1111-1111-111111111111',
+    scheduled_by: overrides.scheduled_by ?? 'system',
+    rule_id: overrides.rule_id ?? null,
+    created_at: overrides.created_at ?? '2026-05-09T07:00:00Z',
+    updated_at: overrides.updated_at ?? '2026-05-09T07:00:00Z',
   };
 }
 


### PR DESCRIPTION
## Verification

- `npm run lint` — Pass (no errors)
- `npx tsc --noEmit` — Pass (no errors)
- `npx vitest run` — Pass (302 passed, 0 failed)

Ran locally against develop HEAD at `94d8beda1635` immediately before opening this PR.

## Summary

Adds a new notification detail surface at `/notifications/:notificationId`. Tapping a row in the existing `[2C-09]` recent view now navigates into a detail page that renders the full `NotificationResponse` shape (status pill, friendly type label, message, scheduled / scheduled-date / expires timestamps, copyable target entity id, read-only canned response chips, and any response + response note that's been recorded).

The C4-specific surface is the rule-resolution chip:
- `rule_id` resolved from the `[2C-16]` `['rules']` TanStack cache → "Triggered by rule: {name}" tappable chip → `/rules/{ruleId}`.
- `rule_id` null → "Triggered manually".
- `rule_id` set but missing from the cache → on-demand `GET /api/rules/{rule_id}`. 404 → "Triggered by deleted rule (id: …)" per spec; 200 (stale list) → resolves the chip from the fresh fetch; other failures → "Triggered by rule (id: …)" so the audit trail isn't lost.

## Changes

- `src/lib/notifications.ts` — extended `NotificationItem` to mirror the full `NotificationResponse` schema (added `delivery_type`, `responded_at`, `response_note`, `canned_responses`, `target_entity_type`, `target_entity_id`, `scheduled_by`, `rule_id`, `created_at`, `updated_at`; relaxed `expires_at` to nullable to match the server's `datetime | None`). Added `fetchNotification(pairing, id)` returning a tagged result with a `not_found` reason for the 404 path.
- `src/pages/NotificationsPage.tsx` — `NotificationRow` is now a `button`/`onClick` `IonItem` that pushes `/notifications/{id}`; row gets a `data-testid` for the new tap-through test.
- `src/pages/NotificationDetailPage.tsx` — new page. Bootstraps pairing + reads the on-disk `RULES_CACHE_KEY` so deep-link arrivals don't trigger a fresh `/api/rules/` fetch when there's a recent local copy. Two TanStack queries (`['notification', id]` and the shared `RULES_QUERY_KEY`) plus a gated `['rule', id]` fallback for the deleted-rule path. Status pill is a small inline Tailwind span — kept local to avoid premature abstraction (the existing `StatusPill` component encodes scaffolding status, not notification status).
- `src/App.tsx` — wires `/notifications/:notificationId` route.
- `src/pages/NotificationDetailPage.test.tsx` — 8 tests covering bootstrap, body render, 404 not-found card, target-id copy, and the four rule-resolution paths (manual / cache hit / cold-start fetch / deleted-rule 404).
- `src/pages/NotificationsPage.test.tsx` — new co-located test asserting the list-side tap pushes `/notifications/{id}` (covers AC #1).
- `src/lib/{notifications,notification-filter,rules}.test.ts`, `src/pages/RuleDetailPage.test.tsx` — backfilled the in-test `makeItem` / `makeFire` factories with the new required `NotificationItem` fields so existing tests still type-check.

## How to Verify

1. `npm install` (no new deps).
2. `npm run lint` — clean.
3. `npx tsc --noEmit` — clean.
4. `npx vitest run` — 302 tests pass.
5. App-side: pair the app, sideload, tap a notification on `/notifications`, confirm:
   - Detail view renders the message, status pill, target with copy button, scheduled times.
   - A notification with `rule_id` set surfaces "Triggered by rule: {name}" as a tappable chip → `/rules/{id}`.
   - A notification with `rule_id` null surfaces "Triggered manually".
   - A notification whose rule has been deleted surfaces "Triggered by deleted rule (id: …)".

## Deviations

- **Test file location.** Spec AC says `tests/unit/notification-detail.spec.ts`. Repo CLAUDE.md v3 (Test Conventions) says *"Do NOT introduce new files in `tests/unit/` — that directory is being phased out."* Honored the spec's intent (the file exists and covers all three rule_id paths) and placed it co-located at `src/pages/NotificationDetailPage.test.tsx` per the convention. Same call applied to the new `NotificationsPage.test.tsx` covering AC #1 (list tap-through).
- **`expires_at` nullability.** Server `NotificationResponse.expires_at` is `datetime | None`; the existing `NotificationItem` typed it as a non-null `string`. Relaxed to `string | null` to match the server contract — the field was always nullable in the API.
- **Rule-resolution fallback (200 path).** Spec only enumerates the on-demand 404 path. When the on-demand `/api/rules/{id}` returns 200 (the rule exists but wasn't in the cached list — list was stale), the chip resolves from the fresh fetch. Treated as "honor spec intent" (resolve when we can) rather than a deviation worth a separate flag.
- **Non-404 single-rule failure.** Network/server/timeout on the on-demand fetch falls back to "Triggered by rule (id: …)" so the audit trail isn't silently lost. Spec is silent on this branch.

## First Consumer Instantiates

- **`NotificationItem` extended to mirror the full `NotificationResponse` schema.** This is the first consumer to need the detail-only fields (`response_note`, `responded_at`, `canned_responses`, `target_entity_type`, `target_entity_id`, `scheduled_by`, `delivery_type`, `created_at`, `updated_at`). Right place to add it: list and detail share the API shape, and Phase-3 follow-ups (re-response from history, deletion-from-detail, entity name resolution) will all consume from the same shape.
- **`fetchNotification(pairing, id)`.** First single-notification fetcher in the client; mirrors `fetchRule` so its result-type and timeout-handling stay symmetric across detail screens.

## Test Results

```
Test Files  27 passed (27)
     Tests  302 passed (302)
  Duration  10.97s
```

(was 26 / 293 before this PR — +1 file / +9 tests from `NotificationDetailPage.test.tsx` and `NotificationsPage.test.tsx`.)

## Acceptance Checklist

- [x] Tapping a notification in `/notifications` navigates to `/notifications/{id}`.
- [x] Detail view renders all notification fields.
- [x] Notifications with `rule_id` set show "Triggered by rule: {name}" with tap-through to `/rules/{ruleId}`.
- [x] Notifications with `rule_id` null show "Triggered manually".
- [x] Deleted-rule edge case: if `rule_id` is set but rule doesn't exist, shows "Triggered by deleted rule (id: …)".
- [x] Test file covers all three rule_id paths (note: located at `src/pages/NotificationDetailPage.test.tsx` per repo convention; see Deviations).

Closes #13