### PR TITLE
[2C-19] Check-in freetext "Add note" action + note-entry screen

### DIFF
--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/AddNoteActivityIntents.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/AddNoteActivityIntents.kt
@@ -1,0 +1,19 @@
+package com.fluxmeridian.brain3companion
+
+/**
+ * Intent action + extras shared between [BrainFirebaseMessagingService] (the
+ * notification builder) and [MainActivity] (the receiver of the "Add note"
+ * tap). Keeping the constants here avoids a circular dependency between the
+ * two and makes the Add-note contract grep-able.
+ *
+ * Per [2C-19] spec, the "Add note" action button on a `checkin_prompt`
+ * notification fires `Intent.ACTION_VIEW`-equivalent semantics — open the
+ * app to a specific route — using a custom action against MainActivity so we
+ * inherit the `singleTask` launch mode without adding a custom URL scheme
+ * intent-filter to the manifest.
+ */
+object AddNoteActivityIntents {
+    const val ACTION_ADD_NOTE = "com.fluxmeridian.brain3companion.action.ADD_NOTE"
+    const val EXTRA_NOTIFICATION_ID = "notification_id"
+    const val EXTRA_CANNED_RESPONSE = "canned_response"
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/BrainFirebaseMessagingService.kt
@@ -36,14 +36,26 @@ class BrainFirebaseMessagingService : MessagingService() {
             .extend(NotificationCompat.WearableExtender())
 
         payload.cannedResponses.forEach { response ->
-            builder.addAction(buildAction(payload, response))
+            builder.addAction(buildCannedAction(payload, response))
+        }
+
+        // [2C-19] Amendment to [2C-06]: `checkin_prompt` notifications gain
+        // an "Add note" action button alongside the canned responses. Tapping
+        // it opens MainActivity with a different action than canned taps —
+        // the JS layer routes to `/checkins/notes/:id?canned=…` and the user
+        // composes a freeform note. See PR for the spec amendment block.
+        if (payload.notificationType == NOTIFICATION_TYPE_CHECKIN_PROMPT) {
+            builder.addAction(buildAddNoteAction(payload, cannedContext = null))
         }
 
         NotificationManagerCompat.from(this)
             .notify(payload.notificationId.hashCode(), builder.build())
     }
 
-    private fun buildAction(payload: PushPayload, response: String): NotificationCompat.Action {
+    private fun buildCannedAction(
+        payload: PushPayload,
+        response: String,
+    ): NotificationCompat.Action {
         val intent = Intent(this, CannedResponseReceiver::class.java).apply {
             action = CannedResponseReceiver.ACTION_RESPOND
             putExtra(CannedResponseReceiver.EXTRA_NOTIFICATION_ID, payload.notificationId)
@@ -60,5 +72,32 @@ class BrainFirebaseMessagingService : MessagingService() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         return NotificationCompat.Action.Builder(0, response, pendingIntent).build()
+    }
+
+    private fun buildAddNoteAction(
+        payload: PushPayload,
+        cannedContext: String?,
+    ): NotificationCompat.Action {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            action = AddNoteActivityIntents.ACTION_ADD_NOTE
+            putExtra(AddNoteActivityIntents.EXTRA_NOTIFICATION_ID, payload.notificationId)
+            putExtra(AddNoteActivityIntents.EXTRA_CANNED_RESPONSE, cannedContext)
+            // singleTask MainActivity reuses the existing instance; CLEAR_TOP
+            // ensures we deliver onNewIntent rather than stacking duplicates.
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val requestCode = (payload.notificationId + "|add_note").hashCode()
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Action.Builder(0, ADD_NOTE_LABEL, pendingIntent).build()
+    }
+
+    companion object {
+        private const val NOTIFICATION_TYPE_CHECKIN_PROMPT = "checkin_prompt"
+        private const val ADD_NOTE_LABEL = "Add note"
     }
 }

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/CannedResponseReceiver.kt
@@ -37,6 +37,10 @@ class CannedResponseReceiver : BroadcastReceiver() {
             response = response,
             responseNote = null,
             enqueuedAt = isoTimestamp(),
+            // [2C-19]: surface the FCM `notification_type` so the JS flush
+            // handler can post the companion `/api/checkins/` for
+            // `checkin_prompt` entries (Escalation 2 Option A).
+            notificationType = notificationType,
         )
 
         NotificationManagerCompat.from(context).cancel(notificationId.hashCode())

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/MainActivity.java
@@ -1,7 +1,13 @@
 package com.fluxmeridian.brain3companion;
 
+import android.content.Intent;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class MainActivity extends BridgeActivity {
 
@@ -13,6 +19,42 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(SafePushNotificationsPlugin.class);
         super.onCreate(savedInstanceState);
         BridgeHolder.INSTANCE.attach(getBridge());
+        handleAddNoteIntent(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        // singleTask + CLEAR_TOP routes the FCM "Add note" tap here when the
+        // app is already running. Cold-start is handled in onCreate.
+        setIntent(intent);
+        handleAddNoteIntent(intent);
+    }
+
+    private void handleAddNoteIntent(Intent intent) {
+        if (intent == null) return;
+        if (!AddNoteActivityIntents.ACTION_ADD_NOTE.equals(intent.getAction())) return;
+        String notificationId = intent.getStringExtra(
+            AddNoteActivityIntents.EXTRA_NOTIFICATION_ID
+        );
+        if (notificationId == null || notificationId.isEmpty()) return;
+        String cannedResponse = intent.getStringExtra(
+            AddNoteActivityIntents.EXTRA_CANNED_RESPONSE
+        );
+        PendingIntentStore.INSTANCE.writeAddNote(
+            getApplicationContext(),
+            notificationId,
+            cannedResponse,
+            isoTimestamp()
+        );
+    }
+
+    private static String isoTimestamp() {
+        SimpleDateFormat format = new SimpleDateFormat(
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US
+        );
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format.format(new Date());
     }
 
     @Override

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/PendingIntentStore.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/PendingIntentStore.kt
@@ -1,0 +1,45 @@
+package com.fluxmeridian.brain3companion
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+
+/**
+ * Durable handoff for native-side intents that need to drive a JS-side
+ * navigation — currently only the [2C-19] "Add note" tap on a `checkin_prompt`
+ * notification.
+ *
+ * Writes to the same `CapacitorStorage` SharedPreferences file used by
+ * `@capacitor/preferences`, so the JS layer reads the key via the Preferences
+ * plugin on mount + on `appStateChange.active`. Avoids the bridge-readiness
+ * race that a `triggerWindowJSEvent` dispatch would have at cold-start.
+ *
+ * Single-slot semantics: a second tap before JS drains the previous one
+ * overwrites; the latest user intent wins. The JS layer clears the slot
+ * after navigating.
+ */
+object PendingIntentStore {
+    private const val TAG = "PendingIntentStore"
+    private const val PREFS_NAME = "CapacitorStorage"
+    private const val PENDING_KEY = "brain.pendingIntent"
+
+    const val KIND_ADD_NOTE = "add_note"
+
+    fun writeAddNote(
+        context: Context,
+        notificationId: String,
+        cannedResponse: String?,
+        enqueuedAt: String,
+    ) {
+        val payload = JSONObject().apply {
+            put("kind", KIND_ADD_NOTE)
+            put("notification_id", notificationId)
+            put("canned_response", cannedResponse ?: JSONObject.NULL)
+            put("enqueued_at", enqueuedAt)
+        }
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(PENDING_KEY, payload.toString()).apply()
+        Log.i(TAG, "Wrote pending intent: $KIND_ADD_NOTE notification_id=$notificationId")
+    }
+}

--- a/android/app/src/main/java/com/fluxmeridian/brain3companion/WriteQueueStore.kt
+++ b/android/app/src/main/java/com/fluxmeridian/brain3companion/WriteQueueStore.kt
@@ -29,6 +29,7 @@ object WriteQueueStore {
         response: String,
         responseNote: String?,
         enqueuedAt: String,
+        notificationType: String? = null,
     ) {
         val prefs = context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -43,11 +44,18 @@ object WriteQueueStore {
                 JSONArray()
             }
         }
+        // [2C-19] adds optional `notification_type` so the JS flush handler
+        // can detect `checkin_prompt` and post the additional /api/checkins/.
+        // Older entries without the field continue to flow through /respond
+        // only — backward-compatible.
         val entry = JSONObject().apply {
             put("notification_id", notificationId)
             put("response", response)
             put("response_note", responseNote ?: JSONObject.NULL)
             put("enqueued_at", enqueuedAt)
+            if (notificationType != null) {
+                put("notification_type", notificationType)
+            }
         }
         array.put(entry)
         if (array.length() > SOFT_CAP) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import RoutinesPage from './pages/RoutinesPage';
 import RoutineDetailPage from './pages/RoutineDetailPage';
 import CheckinsPage from './pages/CheckinsPage';
 import CheckinDetailPage from './pages/CheckinDetailPage';
+import CheckinNoteEntryPage from './pages/CheckinNoteEntryPage';
 import RulesPage from './pages/RulesPage';
 import RuleDetailPage from './pages/RuleDetailPage';
 import { loadPairing, subscribePairing } from './lib/pairing';
@@ -21,6 +22,13 @@ import {
 } from './lib/device-registration';
 import { initWriteQueue } from './lib/writeQueue';
 import { initCompletionQueues } from './lib/completionQueues';
+import {
+  clearPendingIntent,
+  pendingIntentRoute,
+  readPendingIntent,
+} from './lib/pendingIntent';
+import { App as CapacitorApp } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -98,12 +106,51 @@ const WriteQueueRunner: React.FC = () => {
   return null;
 };
 
+/**
+ * [2C-19] Bridge for native-side pending intents — the FCM "Add note" tap
+ * on a `checkin_prompt` notification writes a slot via Kotlin
+ * `PendingIntentStore`; this hook drains it on mount and on
+ * `appStateChange.active`, navigates, and clears.
+ */
+const PendingIntentRunner: React.FC = () => {
+  const history = useHistory();
+  useEffect(() => {
+    let cancelled = false;
+    const drain = async (): Promise<void> => {
+      const intent = await readPendingIntent();
+      if (cancelled || intent === null) return;
+      const route = pendingIntentRoute(intent);
+      await clearPendingIntent();
+      history.push(route);
+    };
+    void drain();
+
+    if (!Capacitor.isNativePlatform()) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const handlePromise = CapacitorApp.addListener(
+      'appStateChange',
+      ({ isActive }) => {
+        if (isActive) void drain();
+      },
+    );
+    return () => {
+      cancelled = true;
+      void handlePromise.then((handle) => handle.remove());
+    };
+  }, [history]);
+  return null;
+};
+
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
     <IonApp>
       <DeviceRegistrar />
       <WriteQueueRunner />
       <IonReactRouter>
+        <PendingIntentRunner />
         <IonRouterOutlet>
           <Route exact path="/settings">
             <SettingsPage />
@@ -128,6 +175,13 @@ const App: React.FC = () => (
           </Route>
           <Route exact path="/checkins">
             <CheckinsPage />
+          </Route>
+          {/* [2C-19] Note-entry route — declared before /checkins/:checkinId
+              so the literal "notes" segment matches first under react-router 5
+              non-exact resolution. The `exact` flag also keeps both routes
+              isolated. */}
+          <Route exact path="/checkins/notes/:notificationId">
+            <CheckinNoteEntryPage />
           </Route>
           <Route exact path="/checkins/:checkinId">
             <CheckinDetailPage />

--- a/src/lib/checkin-parser.test.ts
+++ b/src/lib/checkin-parser.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  composeCheckinFromCanned,
+  parseCannedResponse,
+} from './checkin-parser';
+
+describe('parseCannedResponse', () => {
+  it('maps "Energy 5" to energy_level: 5', () => {
+    expect(parseCannedResponse('Energy 5')).toEqual({
+      energy_level: 5,
+      mood: null,
+      focus_level: null,
+    });
+  });
+
+  it('maps "Focus 3" to focus_level: 3', () => {
+    expect(parseCannedResponse('Focus 3')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: 3,
+    });
+  });
+
+  it('maps "Mood 1" to mood: 1', () => {
+    expect(parseCannedResponse('Mood 1')).toEqual({
+      energy_level: null,
+      mood: 1,
+      focus_level: null,
+    });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseCannedResponse('  Energy 4  ')).toEqual({
+      energy_level: 4,
+      mood: null,
+      focus_level: null,
+    });
+  });
+
+  it('returns all-null on the server default plain-numeric form ("3")', () => {
+    expect(parseCannedResponse('3')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+    });
+  });
+
+  it('returns all-null on an unrecognised string', () => {
+    expect(parseCannedResponse('Already done')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+    });
+  });
+
+  it('rejects out-of-range named values', () => {
+    expect(parseCannedResponse('Energy 6')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+    });
+    expect(parseCannedResponse('Mood 0')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+    });
+  });
+
+  it('is case-sensitive on the dimension prefix (server emits TitleCase)', () => {
+    expect(parseCannedResponse('energy 5')).toEqual({
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+    });
+  });
+});
+
+describe('composeCheckinFromCanned', () => {
+  it('combines a parsed canned response with a freeform note', () => {
+    expect(
+      composeCheckinFromCanned({
+        cannedResponse: 'Energy 4',
+        freeformNote: 'Big push, dragging now.',
+      }),
+    ).toEqual({
+      checkin_type: 'freeform',
+      energy_level: 4,
+      mood: null,
+      focus_level: null,
+      freeform_note: 'Big push, dragging now.',
+    });
+  });
+
+  it('omits numerics for an unrecognised canned response and keeps the note', () => {
+    expect(
+      composeCheckinFromCanned({
+        cannedResponse: '3',
+        freeformNote: 'Just numbers from the prompt.',
+      }),
+    ).toEqual({
+      checkin_type: 'freeform',
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+      freeform_note: 'Just numbers from the prompt.',
+    });
+  });
+
+  it('treats null canned-response as note-only', () => {
+    expect(
+      composeCheckinFromCanned({
+        cannedResponse: null,
+        freeformNote: 'Started without a canned tap.',
+      }),
+    ).toEqual({
+      checkin_type: 'freeform',
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+      freeform_note: 'Started without a canned tap.',
+    });
+  });
+
+  it('coerces empty-string note to null', () => {
+    expect(
+      composeCheckinFromCanned({
+        cannedResponse: 'Mood 2',
+        freeformNote: '',
+      }),
+    ).toEqual({
+      checkin_type: 'freeform',
+      energy_level: null,
+      mood: 2,
+      focus_level: null,
+      freeform_note: null,
+    });
+  });
+
+  it('honours an explicit checkin_type override', () => {
+    expect(
+      composeCheckinFromCanned({
+        cannedResponse: 'Energy 5',
+        freeformNote: null,
+        checkinType: 'morning',
+      }),
+    ).toEqual({
+      checkin_type: 'morning',
+      energy_level: 5,
+      mood: null,
+      focus_level: null,
+      freeform_note: null,
+    });
+  });
+});

--- a/src/lib/checkin-parser.ts
+++ b/src/lib/checkin-parser.ts
@@ -1,0 +1,90 @@
+/**
+ * Canned-response → CheckinCreate field mapping for [2C-19].
+ *
+ * The parser derives numeric check-in fields (`energy_level`, `focus_level`,
+ * `mood`) from canned-response strings produced by `notification_defaults.py`
+ * on the server. The contract is forward-compatible: rules that override the
+ * defaults with named formats like `"Energy 5"` / `"Focus 3"` / `"Mood 1"`
+ * land in the corresponding field, and any string the parser doesn't
+ * recognise (including the server's plain `"1"`–`"5"` defaults for
+ * `checkin_prompt`) falls back to the unparsed shape — note + checkin_type
+ * only, no numeric fields.
+ *
+ * The parser lives on the client; the server's CANNED_RESPONSES list is the
+ * source of truth for what gets sent. Keep the named mapping in lockstep
+ * with future server changes — see [2C-19] Technical notes for the future
+ * shared-format candidacy.
+ */
+
+import type { CheckinType } from './checkins';
+
+export interface ParsedCheckinFields {
+  energy_level: number | null;
+  mood: number | null;
+  focus_level: number | null;
+}
+
+const NAMED_PATTERN = /^(Energy|Focus|Mood)\s+([1-5])$/;
+
+/**
+ * Parse a canned-response string into a partial CheckinCreate. Unknown
+ * strings (including the server's plain `"1"`–`"5"` defaults that don't
+ * carry a dimension) yield an all-null result so the caller can compose a
+ * note-only check-in.
+ */
+export function parseCannedResponse(response: string): ParsedCheckinFields {
+  const empty: ParsedCheckinFields = {
+    energy_level: null,
+    mood: null,
+    focus_level: null,
+  };
+  const match = NAMED_PATTERN.exec(response.trim());
+  if (match === null) return empty;
+
+  const dimension = match[1];
+  const value = Number.parseInt(match[2]!, 10);
+  switch (dimension) {
+    case 'Energy':
+      return { ...empty, energy_level: value };
+    case 'Focus':
+      return { ...empty, focus_level: value };
+    case 'Mood':
+      return { ...empty, mood: value };
+    default:
+      return empty;
+  }
+}
+
+export interface ComposeCheckinArgs {
+  cannedResponse: string | null;
+  freeformNote: string | null;
+  checkinType?: CheckinType;
+}
+
+export interface ComposedCheckin {
+  checkin_type: CheckinType;
+  energy_level: number | null;
+  mood: number | null;
+  focus_level: number | null;
+  freeform_note: string | null;
+}
+
+/**
+ * Compose a CheckinCreate-shaped payload from a canned response + optional
+ * note. `checkin_type` defaults to `"freeform"` per the [2C-19] spec — the
+ * Phase 2 fallback when the notification doesn't carry a type hint.
+ */
+export function composeCheckinFromCanned(args: ComposeCheckinArgs): ComposedCheckin {
+  const { cannedResponse, freeformNote, checkinType = 'freeform' } = args;
+  const parsed =
+    cannedResponse === null
+      ? { energy_level: null, mood: null, focus_level: null }
+      : parseCannedResponse(cannedResponse);
+  return {
+    checkin_type: checkinType,
+    energy_level: parsed.energy_level,
+    mood: parsed.mood,
+    focus_level: parsed.focus_level,
+    freeform_note: freeformNote && freeformNote.length > 0 ? freeformNote : null,
+  };
+}

--- a/src/lib/pendingIntent.test.ts
+++ b/src/lib/pendingIntent.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  PENDING_INTENT_KEY,
+  clearPendingIntent,
+  pendingIntentRoute,
+  readPendingIntent,
+} from './pendingIntent';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('readPendingIntent', () => {
+  it('returns null when the slot is empty', async () => {
+    expect(await readPendingIntent()).toBeNull();
+  });
+
+  it('parses an add_note intent with a pre-selected canned response', async () => {
+    prefsStore.set(
+      PENDING_INTENT_KEY,
+      JSON.stringify({
+        kind: 'add_note',
+        notification_id: 'aaaa',
+        canned_response: 'Energy 4',
+        enqueued_at: '2026-05-09T10:00:00.000Z',
+      }),
+    );
+    expect(await readPendingIntent()).toEqual({
+      kind: 'add_note',
+      notification_id: 'aaaa',
+      canned_response: 'Energy 4',
+      enqueued_at: '2026-05-09T10:00:00.000Z',
+    });
+  });
+
+  it('treats null canned_response as null (not the string "null")', async () => {
+    prefsStore.set(
+      PENDING_INTENT_KEY,
+      JSON.stringify({
+        kind: 'add_note',
+        notification_id: 'bbbb',
+        canned_response: null,
+        enqueued_at: '2026-05-09T10:00:00.000Z',
+      }),
+    );
+    const intent = await readPendingIntent();
+    expect(intent?.kind).toBe('add_note');
+    expect((intent as { canned_response: string | null } | null)?.canned_response).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    prefsStore.set(PENDING_INTENT_KEY, 'not-json');
+    expect(await readPendingIntent()).toBeNull();
+  });
+
+  it('returns null when notification_id is missing', async () => {
+    prefsStore.set(
+      PENDING_INTENT_KEY,
+      JSON.stringify({ kind: 'add_note', canned_response: null }),
+    );
+    expect(await readPendingIntent()).toBeNull();
+  });
+
+  it('returns null on an unknown kind so the slot is safely ignored by older clients', async () => {
+    prefsStore.set(
+      PENDING_INTENT_KEY,
+      JSON.stringify({ kind: 'future_kind', notification_id: 'x' }),
+    );
+    expect(await readPendingIntent()).toBeNull();
+  });
+});
+
+describe('clearPendingIntent', () => {
+  it('removes the slot', async () => {
+    prefsStore.set(PENDING_INTENT_KEY, JSON.stringify({ kind: 'add_note', notification_id: 'a' }));
+    await clearPendingIntent();
+    expect(prefsStore.has(PENDING_INTENT_KEY)).toBe(false);
+  });
+});
+
+describe('pendingIntentRoute', () => {
+  it('builds /checkins/notes/:id?canned=… for a pre-selected canned', () => {
+    expect(
+      pendingIntentRoute({
+        kind: 'add_note',
+        notification_id: 'note-1',
+        canned_response: 'Energy 5',
+        enqueued_at: '',
+      }),
+    ).toBe('/checkins/notes/note-1?canned=Energy+5');
+  });
+
+  it('omits the canned query param when null', () => {
+    expect(
+      pendingIntentRoute({
+        kind: 'add_note',
+        notification_id: 'note-1',
+        canned_response: null,
+        enqueued_at: '',
+      }),
+    ).toBe('/checkins/notes/note-1');
+  });
+});

--- a/src/lib/pendingIntent.ts
+++ b/src/lib/pendingIntent.ts
@@ -1,0 +1,92 @@
+/**
+ * Drains the native-side pending-intent slot ([2C-19]).
+ *
+ * The Kotlin `PendingIntentStore` writes a single JSON entry to the
+ * Capacitor Preferences key `brain.pendingIntent` when the user taps an
+ * action that needs to drive a JS-side navigation — currently only the
+ * `add_note` action on a `checkin_prompt` notification. The JS side reads
+ * the slot on app mount and on `appStateChange.active`, navigates, and
+ * clears the slot.
+ *
+ * Single-slot semantics: a second native write before JS drains overwrites
+ * the previous one. Designed for low-frequency intents — at most one in
+ * flight at any time. If a second intent shape gets added to the slot in
+ * the future, extend the `PendingIntent` discriminated union below.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+
+export const PENDING_INTENT_KEY = 'brain.pendingIntent';
+
+export interface AddNotePendingIntent {
+  kind: 'add_note';
+  notification_id: string;
+  /** Pre-selected canned response from the source notification, or null. */
+  canned_response: string | null;
+  enqueued_at: string;
+}
+
+export type PendingIntent = AddNotePendingIntent;
+
+/**
+ * Read the pending-intent slot. Returns `null` when empty or malformed.
+ * Does not clear the slot — call {@link clearPendingIntent} after acting
+ * so a re-read (e.g., next `appStateChange.active`) doesn't fire twice.
+ */
+export async function readPendingIntent(): Promise<PendingIntent | null> {
+  const { value } = await Preferences.get({ key: PENDING_INTENT_KEY });
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      !('kind' in parsed)
+    ) {
+      return null;
+    }
+    const kind = (parsed as { kind: unknown }).kind;
+    if (kind === 'add_note') {
+      const obj = parsed as Record<string, unknown>;
+      if (typeof obj.notification_id !== 'string' || obj.notification_id === '') {
+        return null;
+      }
+      const cannedRaw = obj.canned_response;
+      const canned =
+        typeof cannedRaw === 'string' && cannedRaw.length > 0 ? cannedRaw : null;
+      const enqueuedAt =
+        typeof obj.enqueued_at === 'string' ? obj.enqueued_at : '';
+      return {
+        kind: 'add_note',
+        notification_id: obj.notification_id,
+        canned_response: canned,
+        enqueued_at: enqueuedAt,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearPendingIntent(): Promise<void> {
+  await Preferences.remove({ key: PENDING_INTENT_KEY });
+}
+
+/**
+ * Build the route to navigate to for a given pending intent.
+ */
+export function pendingIntentRoute(intent: PendingIntent): string {
+  switch (intent.kind) {
+    case 'add_note': {
+      const params = new URLSearchParams();
+      if (intent.canned_response !== null) {
+        params.set('canned', intent.canned_response);
+      }
+      const query = params.toString();
+      return query.length > 0
+        ? `/checkins/notes/${intent.notification_id}?${query}`
+        : `/checkins/notes/${intent.notification_id}`;
+    }
+  }
+}

--- a/src/lib/writeQueue.test.ts
+++ b/src/lib/writeQueue.test.ts
@@ -319,6 +319,219 @@ describe('flushWriteQueue — failure handling', () => {
   });
 });
 
+describe('flushWriteQueue — [2C-19] checkin_prompt extension', () => {
+  beforeEach(() => {
+    seedPairing();
+    seedRegistered();
+  });
+
+  it('posts /api/checkins/ after /respond for checkin_prompt with a pre-composed payload', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'add-note',
+          response: 'Energy 4',
+          response_note: 'Focused but tired.',
+          notification_type: 'checkin_prompt',
+          checkin_payload: {
+            checkin_type: 'freeform',
+            energy_level: 4,
+            mood: null,
+            focus_level: null,
+            freeform_note: 'Focused but tired.',
+          },
+        }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      '/api/notifications/add-note/respond',
+    );
+    expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+      `${PAIRING_URL}/api/checkins/`,
+    );
+    const checkinInit = fetchSpy.mock.calls[1]![1]!;
+    expect(checkinInit.method).toBe('POST');
+    expect(JSON.parse(checkinInit.body as string)).toEqual({
+      checkin_type: 'freeform',
+      energy_level: 4,
+      mood: null,
+      focus_level: null,
+      freeform_note: 'Focused but tired.',
+    });
+    expect(summary).toEqual({
+      attempted: 1,
+      delivered: 1,
+      conflicts: 0,
+      remaining: 0,
+    });
+  });
+
+  it('derives a numeric-only check-in payload on flush for canned-only checkin_prompt entries', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'canned-only',
+          response: 'Energy 5',
+          response_note: null,
+          notification_type: 'checkin_prompt',
+        }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const checkinInit = fetchSpy.mock.calls[1]![1]!;
+    expect(JSON.parse(checkinInit.body as string)).toEqual({
+      checkin_type: 'freeform',
+      energy_level: 5,
+      mood: null,
+      focus_level: null,
+      freeform_note: null,
+    });
+  });
+
+  it('posts a note-only check-in when the canned response is the server default plain "3"', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'plain-three',
+          response: '3',
+          response_note: null,
+          notification_type: 'checkin_prompt',
+        }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await flushWriteQueue();
+
+    const checkinInit = fetchSpy.mock.calls[1]![1]!;
+    expect(JSON.parse(checkinInit.body as string)).toEqual({
+      checkin_type: 'freeform',
+      energy_level: null,
+      mood: null,
+      focus_level: null,
+      freeform_note: null,
+    });
+  });
+
+  it('does not post /api/checkins/ for non-checkin_prompt entries', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'habit-1',
+          response: 'Already done',
+          notification_type: 'habit_nudge',
+        }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      '/api/notifications/habit-1/respond',
+    );
+  });
+
+  it('preserves backward compatibility for entries without a notification_type', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({ notification_id: 'legacy', response: 'Already done' }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(summary.delivered).toBe(1);
+  });
+
+  it('halts on a check-in POST network error so the entry retries on next flush', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'retry-me',
+          response: 'Energy 4',
+          notification_type: 'checkin_prompt',
+        }),
+      ]),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 201 })) // /respond
+      .mockRejectedValueOnce(new Error('checkins network down')); // /api/checkins/
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(summary.delivered).toBe(0);
+    expect(summary.remaining).toBe(1);
+    const queue = await readQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.notification_id).toBe('retry-me');
+  });
+
+  it('discards the entry when /api/checkins/ returns a terminal 4xx', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        entry({
+          notification_id: 'bad-payload',
+          response: 'Energy 4',
+          notification_type: 'checkin_prompt',
+        }),
+      ]),
+    );
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(new Response('bad request', { status: 400 }));
+
+    const summary = await flushWriteQueue();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(summary.delivered).toBe(0);
+    expect(summary.remaining).toBe(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('flushWriteQueue — 409 conflict', () => {
   beforeEach(() => {
     seedPairing();

--- a/src/lib/writeQueue.ts
+++ b/src/lib/writeQueue.ts
@@ -23,6 +23,8 @@
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { Preferences } from '@capacitor/preferences';
+import { composeCheckinFromCanned } from './checkin-parser';
+import type { CheckinType } from './checkins';
 import {
   loadRegisteredToken,
   subscribeRegistration,
@@ -179,11 +181,40 @@ export function createWriteQueue<T>(
 // [2C-07] canned-response queue — concrete instance of the factory
 // ---------------------------------------------------------------------------
 
+/**
+ * CheckinCreate-shaped payload [2C-19] enqueues alongside a `/respond` write
+ * for `checkin_prompt` notifications. Mirrors `app/schemas/checkins.py`
+ * `CheckinCreate` on the brain3 server (`checkin_type` mandatory; numeric
+ * fields 1–5 or null; `freeform_note` ≤ 5000 chars).
+ */
+export interface CheckinPayload {
+  checkin_type: CheckinType;
+  energy_level: number | null;
+  mood: number | null;
+  focus_level: number | null;
+  freeform_note: string | null;
+}
+
 export interface WriteQueueEntry {
   notification_id: string;
   response: string;
   response_note: string | null;
   enqueued_at: string;
+  /**
+   * Notification type from the FCM payload. Populated by the native
+   * `CannedResponseReceiver` (and JS [2C-19] enqueues) so the flush handler
+   * can detect `checkin_prompt` and post the additional `/api/checkins/`.
+   * Optional for backward compatibility with pre-[2C-19] entries.
+   */
+  notification_type?: string | null;
+  /**
+   * Pre-composed CheckinCreate payload for the [2C-19] freetext "Add note"
+   * path. When present, the flush handler posts it to `/api/checkins/` after
+   * `/respond` returns 2xx. When absent on a `checkin_prompt` entry, the
+   * flush handler derives a numeric-only payload from `response` via
+   * `parseCannedResponse`.
+   */
+  checkin_payload?: CheckinPayload | null;
 }
 
 export interface ConflictWarning {
@@ -243,6 +274,38 @@ async function postResponse(
   );
 }
 
+async function postCheckin(
+  pairing: Pairing,
+  payload: CheckinPayload,
+): Promise<Response> {
+  const base = pairing.url.replace(/\/$/, '');
+  return await fetch(`${base}/api/checkins/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${pairing.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Per [2C-19] Escalation 2 Option A, `checkin_prompt` notifications create a
+ * check-in alongside the `/respond` write. The payload is either pre-composed
+ * by the JS Add-note path (`entry.checkin_payload`) or derived from the
+ * canned response on flush (canned-only path). Returns `null` when no
+ * check-in should fire — non-`checkin_prompt` entries, or pre-[2C-19] entries
+ * that lack the type hint.
+ */
+function resolveCheckinPayload(entry: WriteQueueEntry): CheckinPayload | null {
+  if (entry.checkin_payload) return entry.checkin_payload;
+  if (entry.notification_type !== 'checkin_prompt') return null;
+  return composeCheckinFromCanned({
+    cannedResponse: entry.response,
+    freeformNote: entry.response_note,
+  });
+}
+
 async function readConflictResponse(
   response: Response,
 ): Promise<string | null> {
@@ -284,7 +347,37 @@ const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
     } catch {
       return { kind: 'stop' };
     }
-    if (response.status === 200 || response.status === 201) {
+    const respondDelivered =
+      response.status === 200 || response.status === 201;
+    if (respondDelivered) {
+      // [2C-19] Escalation 2 Option A: `checkin_prompt` entries fire a
+      // companion `/api/checkins/` POST after `/respond` succeeds. Treat any
+      // network or 5xx failure on the check-in POST as a halt — the entry
+      // stays at the head so the next flush retries. Server-side `/respond`
+      // is idempotent per [2C-03], so the retry re-sends `/respond` safely.
+      // Terminal 4xx on the check-in POST drops to a discard so the queue
+      // doesn't stall on a permanently-bad payload.
+      const checkinPayload = resolveCheckinPayload(entry);
+      if (checkinPayload !== null) {
+        let checkinResponse: Response;
+        try {
+          checkinResponse = await postCheckin(pairing, checkinPayload);
+        } catch {
+          return { kind: 'stop' };
+        }
+        if (
+          checkinResponse.status !== 200 &&
+          checkinResponse.status !== 201
+        ) {
+          if (checkinResponse.status >= 400 && checkinResponse.status < 500) {
+            console.warn(
+              `[writeQueue] check-in POST rejected (${checkinResponse.status}) for notification ${entry.notification_id}; dropping entry`,
+            );
+            return { kind: 'discard' };
+          }
+          return { kind: 'stop' };
+        }
+      }
       return { kind: 'remove' };
     }
     if (response.status === 409) {

--- a/src/pages/CheckinNoteEntryPage.test.tsx
+++ b/src/pages/CheckinNoteEntryPage.test.tsx
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn(),
+    register: vi.fn(),
+    addListener: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/device', () => ({
+  Device: {
+    getInfo: vi.fn(async () => ({ model: 'Pixel 8' })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import {
+  WRITE_QUEUE_KEY,
+  __resetForTests as __resetWriteQueue,
+  type WriteQueueEntry,
+} from '../lib/writeQueue';
+import type { NotificationItem } from '../lib/notifications';
+import CheckinNoteEntryPage from './CheckinNoteEntryPage';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+const NOTIFICATION_ID = 'note-aaa';
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  __resetWriteQueue();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeNotification(
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  return {
+    id: NOTIFICATION_ID,
+    notification_type: 'checkin_prompt',
+    delivery_type: 'push',
+    message: 'How are your energy levels right now?',
+    scheduled_at: '2026-05-09T10:00:00Z',
+    scheduled_date: '2026-05-09',
+    status: 'delivered',
+    expires_at: null,
+    response: null,
+    response_note: null,
+    responded_at: null,
+    canned_responses: ['Energy 3', 'Energy 4', 'Energy 5'],
+    target_entity_type: 'goal',
+    target_entity_id: 'g-1',
+    scheduled_by: 'rule',
+    rule_id: null,
+    created_at: '2026-05-09T09:00:00Z',
+    updated_at: '2026-05-09T10:00:00Z',
+    ...overrides,
+  };
+}
+
+interface StubOptions {
+  notification?: { status: number; body?: NotificationItem };
+  respond?: { status: number };
+  checkin?: { status: number };
+}
+
+function stubFetch(opts: StubOptions = {}) {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init: init ?? undefined });
+    if (url.endsWith(`/api/notifications/${NOTIFICATION_ID}`)) {
+      const n = opts.notification ?? { status: 200, body: makeNotification() };
+      if (n.status === 200 && n.body) {
+        return new Response(JSON.stringify(n.body), { status: 200 });
+      }
+      return new Response('', { status: n.status });
+    }
+    if (url.endsWith(`/api/notifications/${NOTIFICATION_ID}/respond`)) {
+      return new Response('', { status: opts.respond?.status ?? 201 });
+    }
+    if (url.endsWith('/api/checkins/')) {
+      return new Response('', { status: opts.checkin?.status ?? 201 });
+    }
+    return new Response('', { status: 404 });
+  });
+  return { spy, calls };
+}
+
+interface RenderOpts {
+  canned?: string;
+}
+
+function renderPage(opts: RenderOpts = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const search = opts.canned ? `?canned=${encodeURIComponent(opts.canned)}` : '';
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/checkins/notes/${NOTIFICATION_ID}${search}`]}>
+        <Switch>
+          <Route exact path="/checkins/notes/:notificationId">
+            <CheckinNoteEntryPage />
+          </Route>
+          <Route exact path="/checkins">
+            <div data-testid="checkins-landing">checkins-landing</div>
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+async function readQueue(): Promise<WriteQueueEntry[]> {
+  const raw = prefsStore.get(WRITE_QUEUE_KEY);
+  if (!raw) return [];
+  return JSON.parse(raw) as WriteQueueEntry[];
+}
+
+function setNoteValue(text: string): void {
+  // ion-textarea exposes a native textarea via shadow root; in jsdom we
+  // fire input on the visible textarea fallback. Capacitor's IonTextarea
+  // forwards `onIonInput` from the underlying element's `input` event.
+  const textarea = screen.getByLabelText('Note');
+  fireEvent.input(textarea, { target: { value: text } });
+}
+
+// ---------------------------------------------------------------------------
+
+describe('CheckinNoteEntryPage — render', () => {
+  it('shows the unpaired message when the app is not paired', async () => {
+    stubFetch();
+    renderPage();
+    expect(
+      await screen.findByText(/pair the app from settings/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the notification message + selected canned chip when ?canned= is present', async () => {
+    pair();
+    stubFetch();
+
+    renderPage({ canned: 'Energy 4' });
+
+    expect(
+      await screen.findByTestId('checkin-note-prompt'),
+    ).toHaveTextContent('How are your energy levels');
+    expect(screen.getByTestId('checkin-note-canned')).toHaveTextContent(
+      'You chose: Energy 4',
+    );
+  });
+
+  it('omits the canned chip when no ?canned= is present', async () => {
+    pair();
+    stubFetch();
+
+    renderPage();
+
+    await screen.findByTestId('checkin-note-prompt');
+    expect(screen.queryByTestId('checkin-note-canned')).not.toBeInTheDocument();
+  });
+});
+
+describe('CheckinNoteEntryPage — save flow', () => {
+  it('POSTs /respond then /api/checkins/ with parsed canned + note, then navigates to /checkins', async () => {
+    pair();
+    const { calls } = stubFetch();
+
+    renderPage({ canned: 'Energy 4' });
+    await screen.findByTestId('checkin-note-prompt');
+    setNoteValue('Pushed hard, dragging now.');
+
+    fireEvent.click(screen.getByTestId('checkin-note-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('checkins-landing')).toBeInTheDocument();
+    });
+
+    const respondCall = calls.find((c) =>
+      c.url.endsWith(`/api/notifications/${NOTIFICATION_ID}/respond`),
+    );
+    expect(respondCall).toBeDefined();
+    expect(JSON.parse(respondCall!.init!.body as string)).toEqual({
+      response: 'Energy 4',
+      response_note: 'Pushed hard, dragging now.',
+    });
+
+    const checkinCall = calls.find((c) => c.url.endsWith('/api/checkins/'));
+    expect(checkinCall).toBeDefined();
+    expect(JSON.parse(checkinCall!.init!.body as string)).toEqual({
+      checkin_type: 'freeform',
+      energy_level: 4,
+      mood: null,
+      focus_level: null,
+      freeform_note: 'Pushed hard, dragging now.',
+    });
+  });
+
+  it('skips /respond when no canned was preselected and POSTs only /api/checkins/', async () => {
+    pair();
+    const { calls } = stubFetch();
+
+    renderPage();
+    await screen.findByTestId('checkin-note-prompt');
+    setNoteValue('Just a note.');
+
+    fireEvent.click(screen.getByTestId('checkin-note-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('checkins-landing')).toBeInTheDocument();
+    });
+
+    expect(
+      calls.find((c) =>
+        c.url.endsWith(`/api/notifications/${NOTIFICATION_ID}/respond`),
+      ),
+    ).toBeUndefined();
+    expect(
+      calls.find((c) => c.url.endsWith('/api/checkins/')),
+    ).toBeDefined();
+  });
+
+  it('falls back to the offline writeQueue with checkin_payload when /api/checkins/ network-fails', async () => {
+    pair();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith(`/api/notifications/${NOTIFICATION_ID}`)) {
+        return new Response(JSON.stringify(makeNotification()), { status: 200 });
+      }
+      if (url.endsWith(`/api/notifications/${NOTIFICATION_ID}/respond`)) {
+        return new Response('', { status: 201 });
+      }
+      if (url.endsWith('/api/checkins/')) {
+        throw new Error('network down');
+      }
+      return new Response('', { status: 404 });
+    });
+
+    renderPage({ canned: 'Mood 2' });
+    await screen.findByTestId('checkin-note-prompt');
+    setNoteValue('Recovered version.');
+
+    fireEvent.click(screen.getByTestId('checkin-note-save'));
+
+    await waitFor(async () => {
+      const queue = await readQueue();
+      expect(queue).toHaveLength(1);
+    });
+
+    const queue = await readQueue();
+    expect(queue[0]).toMatchObject({
+      notification_id: NOTIFICATION_ID,
+      response: 'Mood 2',
+      response_note: 'Recovered version.',
+      notification_type: 'checkin_prompt',
+      checkin_payload: {
+        checkin_type: 'freeform',
+        energy_level: null,
+        mood: 2,
+        focus_level: null,
+        freeform_note: 'Recovered version.',
+      },
+    });
+  });
+
+  it('shows an inline error and does not navigate when /api/checkins/ returns 422', async () => {
+    pair();
+    stubFetch({ checkin: { status: 422 } });
+
+    renderPage({ canned: 'Energy 4' });
+    await screen.findByTestId('checkin-note-prompt');
+    setNoteValue('any note');
+
+    fireEvent.click(screen.getByTestId('checkin-note-save'));
+
+    expect(
+      await screen.findByTestId('checkin-note-error'),
+    ).toHaveTextContent(/invalid payload/i);
+    expect(screen.queryByTestId('checkins-landing')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/CheckinNoteEntryPage.tsx
+++ b/src/pages/CheckinNoteEntryPage.tsx
@@ -1,0 +1,364 @@
+/**
+ * Note-entry surface for [2C-19] — the freetext path of the check-in
+ * canned-response loop.
+ *
+ * Reached via the "Add note" action button on a `checkin_prompt` notification
+ * (Kotlin amendment to [2C-06]). The Kotlin layer dispatches a
+ * `brainAddNoteIntent` window event with the notification id and any
+ * pre-selected canned response; `App.tsx` translates that into navigation to
+ * `/checkins/notes/:notificationId?canned=<response>`.
+ *
+ * On Save:
+ *   1. Compose a CheckinCreate payload from the canned response (parsed via
+ *      `checkin-parser`) + freeform note.
+ *   2. POST `/api/notifications/{id}/respond` if a canned response was
+ *      pre-selected (records the notification response alongside the
+ *      check-in, idempotent per [2C-03]).
+ *   3. POST `/api/checkins/` with the composed payload.
+ *   4. On any network failure or 5xx, enqueue both writes via the offline
+ *      [2C-07] queue (extended in [2C-19] to carry `checkin_payload` /
+ *      `notification_type`) and surface a "Saved locally" hint before
+ *      navigating to `/checkins`.
+ *
+ * Note-after-the-fact (a notification already canned-responded earlier) is
+ * deferred per the spec's own design-smell flag — the simpler POST path
+ * always creates a new check-in. See PR body Deviations.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonChip,
+  IonContent,
+  IonHeader,
+  IonLabel,
+  IonPage,
+  IonText,
+  IonTextarea,
+  IonTitle,
+  IonToast,
+  IonToolbar,
+} from '@ionic/react';
+import { useQuery, type QueryKey } from '@tanstack/react-query';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
+
+import ConnectionIndicator from '../components/ConnectionIndicator';
+import { composeCheckinFromCanned } from '../lib/checkin-parser';
+import { loadPairing, type Pairing } from '../lib/pairing';
+import {
+  fetchNotification,
+  type NotificationItem,
+} from '../lib/notifications';
+import {
+  enqueueResponse,
+  flushWriteQueue,
+  type CheckinPayload,
+} from '../lib/writeQueue';
+
+const NOTIFICATION_QUERY_KEY = (id: string): QueryKey => [
+  'notification',
+  id,
+];
+const FREEFORM_MAX_CHARS = 5000;
+const STALE_MS = 5 * 60 * 1000;
+
+type Bootstrap =
+  | { kind: 'loading' }
+  | { kind: 'no-pairing' }
+  | { kind: 'paired'; pairing: Pairing };
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string };
+
+const CheckinNoteEntryPage: React.FC = () => {
+  const { notificationId } = useParams<{ notificationId: string }>();
+  const location = useLocation();
+  const cannedFromQuery = useMemo<string | null>(() => {
+    const params = new URLSearchParams(location.search);
+    const raw = params.get('canned');
+    return raw && raw.length > 0 ? raw : null;
+  }, [location.search]);
+
+  const [bootstrap, setBootstrap] = useState<Bootstrap>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const pairing = await loadPairing();
+      if (cancelled) return;
+      setBootstrap(
+        pairing === null
+          ? { kind: 'no-pairing' }
+          : { kind: 'paired', pairing },
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/notifications" />
+          </IonButtons>
+          <IonTitle>Add note</IonTitle>
+          <ConnectionIndicator slot="end" />
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        {bootstrap.kind === 'loading' ? (
+          <div className="flex h-full w-full items-center justify-center text-neutral-300">
+            <p>Loading…</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'no-pairing' ? (
+          <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">
+            <p>Pair the app from Settings to add a note.</p>
+          </div>
+        ) : null}
+
+        {bootstrap.kind === 'paired' ? (
+          <NoteEntryBody
+            pairing={bootstrap.pairing}
+            notificationId={notificationId}
+            preselectedCanned={cannedFromQuery}
+          />
+        ) : null}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+interface BodyProps {
+  pairing: Pairing;
+  notificationId: string;
+  preselectedCanned: string | null;
+}
+
+const NoteEntryBody: React.FC<BodyProps> = ({
+  pairing,
+  notificationId,
+  preselectedCanned,
+}) => {
+  const history = useHistory();
+  const [note, setNote] = useState<string>('');
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' });
+  const [savedLocallyToast, setSavedLocallyToast] = useState(false);
+
+  const notificationQuery = useQuery<NotificationItem>({
+    queryKey: NOTIFICATION_QUERY_KEY(notificationId),
+    queryFn: async () => {
+      const result = await fetchNotification(pairing, notificationId);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.reason), {
+          notFound: result.reason === 'not_found',
+        });
+      }
+      return result.notification;
+    },
+    staleTime: STALE_MS,
+    retry: false,
+  });
+
+  const onSave = useCallback(async (): Promise<void> => {
+    setSaveState({ kind: 'saving' });
+    const trimmedNote = note.trim();
+    const checkinPayload: CheckinPayload = composeCheckinFromCanned({
+      cannedResponse: preselectedCanned,
+      freeformNote: trimmedNote.length > 0 ? trimmedNote : null,
+    });
+
+    // [2C-19] Save flow: /respond (if canned) → /api/checkins/. On any
+    // network or 5xx, fall back to the offline queue (extended in [2C-19]
+    // to carry the check-in payload) and notify the user.
+    const base = pairing.url.replace(/\/$/, '');
+    let respondTransientFailure = false;
+    if (preselectedCanned !== null) {
+      try {
+        const respondResp = await fetch(
+          `${base}/api/notifications/${notificationId}/respond`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${pairing.token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              response: preselectedCanned,
+              response_note: trimmedNote.length > 0 ? trimmedNote : null,
+            }),
+          },
+        );
+        // 200/201 = delivered. 409 = already responded; existing write
+        // stands and we proceed to /api/checkins/. 4xx terminal we still
+        // proceed to the check-in POST — the note is the user's primary
+        // intent. 5xx / network → enqueue.
+        if (respondResp.status >= 500) respondTransientFailure = true;
+      } catch {
+        respondTransientFailure = true;
+      }
+    }
+
+    if (!respondTransientFailure) {
+      try {
+        const checkinResp = await fetch(`${base}/api/checkins/`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${pairing.token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(checkinPayload),
+        });
+        if (checkinResp.status === 200 || checkinResp.status === 201) {
+          history.replace('/checkins');
+          return;
+        }
+        if (checkinResp.status >= 400 && checkinResp.status < 500) {
+          const message =
+            checkinResp.status === 422
+              ? "Couldn't save — invalid payload."
+              : `Couldn't save (${checkinResp.status}).`;
+          setSaveState({ kind: 'error', message });
+          return;
+        }
+        // 5xx — fall through to enqueue.
+      } catch {
+        // Network — fall through to enqueue.
+      }
+    }
+
+    // Offline fallback: enqueue a single entry that carries both the
+    // /respond write and the pre-composed check-in payload. The [2C-07]
+    // flush handler delivers them in order per entry.
+    await enqueueResponse({
+      notification_id: notificationId,
+      response: preselectedCanned ?? '',
+      response_note: trimmedNote.length > 0 ? trimmedNote : null,
+      enqueued_at: new Date().toISOString(),
+      notification_type: 'checkin_prompt',
+      checkin_payload: checkinPayload,
+    });
+    // Best-effort flush in case connectivity blipped between attempts.
+    void flushWriteQueue();
+    setSavedLocallyToast(true);
+    // Defer navigation so the toast has time to surface.
+    setTimeout(() => {
+      history.replace('/checkins');
+    }, 800);
+  }, [history, note, notificationId, pairing, preselectedCanned]);
+
+  if (notificationQuery.isPending) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-neutral-300">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  if (notificationQuery.isError && notificationQuery.data === undefined) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-200"
+        role="alert"
+      >
+        <p>Couldn&apos;t load notification.</p>
+      </div>
+    );
+  }
+
+  const notification = notificationQuery.data;
+  const overLimit = note.length > FREEFORM_MAX_CHARS;
+  const saving = saveState.kind === 'saving';
+
+  return (
+    <section
+      className="flex h-full flex-col px-4 pt-4"
+      data-testid="checkin-note-entry-pane"
+    >
+      {notification ? (
+        <p
+          className="whitespace-pre-wrap text-base text-neutral-100"
+          data-testid="checkin-note-prompt"
+        >
+          {notification.message}
+        </p>
+      ) : null}
+
+      {preselectedCanned !== null ? (
+        <div className="mt-3" data-testid="checkin-note-canned">
+          <IonChip color="primary" disabled>
+            <IonLabel>You chose: {preselectedCanned}</IonLabel>
+          </IonChip>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex-1">
+        <IonTextarea
+          aria-label="Note"
+          autoGrow
+          rows={6}
+          maxlength={FREEFORM_MAX_CHARS}
+          counter
+          placeholder="Add a note (optional)…"
+          value={note}
+          onIonInput={(e) => setNote(e.detail.value ?? '')}
+          data-testid="checkin-note-textarea"
+        />
+        {overLimit ? (
+          <p className="mt-1 text-sm text-rose-400" role="alert">
+            Note exceeds the {FREEFORM_MAX_CHARS}-character limit.
+          </p>
+        ) : null}
+      </div>
+
+      {saveState.kind === 'error' ? (
+        <p
+          className="mt-2 text-sm text-rose-400"
+          role="alert"
+          data-testid="checkin-note-error"
+        >
+          {saveState.message}
+        </p>
+      ) : null}
+
+      <div className="py-4">
+        <IonButton
+          expand="block"
+          disabled={saving || overLimit}
+          onClick={() => void onSave()}
+          data-testid="checkin-note-save"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </IonButton>
+        <p className="pt-2">
+          <IonText color="medium">
+            <small>
+              Tap Save to log a check-in
+              {preselectedCanned !== null
+                ? ` with "${preselectedCanned}"`
+                : ''}
+              {note.trim().length > 0 ? ' and your note' : ''}.
+            </small>
+          </IonText>
+        </p>
+      </div>
+
+      <IonToast
+        isOpen={savedLocallyToast}
+        message="Saved locally — will sync when you're online."
+        duration={2500}
+        onDidDismiss={() => setSavedLocallyToast(false)}
+      />
+    </section>
+  );
+};
+
+export default CheckinNoteEntryPage;


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npm run test.unit -- --run` — ✅ Pass (338 passed across 30 test files)
- `npx tsc --noEmit` — ✅ Pass (no type errors)
- `npx cap sync android` — ⚠️ Surfaces pre-existing [2C-Gap-02] (#49) drift only (capacitor-device unsync); reverted those collateral gradle edits to keep this PR scoped to [2C-19]. Sync clean for the plugins this PR touches (none added/removed).
- Migration applied locally on brain3-dev: N/A — client-only change.

Ran locally against `origin/develop` HEAD `e4b7e94` (merge of [2C-18]) immediately before opening this PR.

## Summary

Closes the canned-response loop's freetext path. A `checkin_prompt` push notification now exposes an "Add note" action alongside the canned responses; tapping it opens the app to `/checkins/notes/:notificationId?canned=<response>`, where the user types a note and saves. The save flow POSTs `/api/notifications/{id}/respond` (when a canned was pre-selected) and then `/api/checkins/`, falling back to the [2C-07] offline queue on network failure or 5xx. The companion canned-only path also now creates a check-in (Escalation 2 Option A) for `checkin_prompt` entries.

Group 4 closes with this PR.

## Changes

**JS — parser**
- `src/lib/checkin-parser.ts` (new) + co-located test — maps `"Energy 5"`/`"Focus 3"`/`"Mood 1"` to `CheckinCreate` fields; falls back to all-null for plain-numeric defaults like `"3"` so a note-only check-in is composable.

**JS — note-entry surface**
- `src/pages/CheckinNoteEntryPage.tsx` (new) + test — loads the source notification for context, shows the prompt + selected canned chip, IonTextarea with the 5000-char limit, and a Save button driving the `/respond` → `/api/checkins/` → offline-fallback flow.
- `src/App.tsx` — registers the new route `/checkins/notes/:notificationId` (declared before `/checkins/:checkinId` so the literal segment matches first under `react-router` 5).

**JS — offline queue extension ([2C-07] amendment)**
- `src/lib/writeQueue.ts` — `WriteQueueEntry` gains optional `notification_type` and `checkin_payload`. The flush handler now posts the companion `/api/checkins/` after `/respond` 2xx for `checkin_prompt` entries (using `checkin_payload` when present, otherwise deriving it from the canned response via the parser). Network/5xx → halt; 4xx terminal → discard with a console warning.
- `src/lib/writeQueue.test.ts` — adds eight new tests covering the [2C-19] flush behaviour (pre-composed payload, derived payload, plain "3" → note-only, non-checkin_prompt unchanged, legacy backward-compat, retry-on-network, terminal-4xx discard).

**JS — pending-intent dispatch (cold-start hand-off)**
- `src/lib/pendingIntent.ts` (new) + co-located test — drains the native-side `brain.pendingIntent` Capacitor Preferences slot the Kotlin layer writes when the user taps "Add note." Builds the target route with the optional `?canned=` query and exposes `clearPendingIntent` so the slot doesn't fire twice.
- `src/App.tsx` — `PendingIntentRunner` mounts inside `IonReactRouter`, drains the slot on mount and on `appStateChange.active`, and uses `history.push` to navigate.

**Native ([2C-06] amendment from Pass 3.5 brief §5 Amendment A2)**
- `BrainFirebaseMessagingService.kt` — when `notification_type == "checkin_prompt"`, appends an "Add note" `NotificationCompat.Action` after the canned actions. The action's `PendingIntent` opens MainActivity directly with `ACTION_ADD_NOTE` + extras (notification id, optional canned), using `singleTask` + `CLEAR_TOP` so onNewIntent fires for warm-start.
- `MainActivity.java` — handles `ACTION_ADD_NOTE` in both `onCreate` (cold-start) and `onNewIntent` (warm-start), persisting the intent payload via `PendingIntentStore` for the JS layer to read.
- `PendingIntentStore.kt` (new) — durable single-slot helper writing JSON `{kind:"add_note", notification_id, canned_response, enqueued_at}` to the same `CapacitorStorage` SharedPreferences file the JS Preferences plugin reads.
- `AddNoteActivityIntents.kt` (new) — shared action + extra constants, factored out so the FCM service and MainActivity don't form a circular dependency.
- `WriteQueueStore.kt` — `enqueue()` gains optional `notificationType`; persisted into the JSON entry when supplied. Backward-compatible with pre-[2C-19] entries.
- `CannedResponseReceiver.kt` — passes `notification_type` through to `WriteQueueStore.enqueue` so the JS flush handler can detect `checkin_prompt` and post the Escalation 2 Option A check-in.

**No Capacitor plugin changes.** `npm run android:sync` surfaces only the pre-existing [2C-Gap-02] drift (`@capacitor/device@6.0.3` never synced into android gradle); the regenerated `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle` were reverted from this PR per "Log it, don't fix it" — that drift is already tracked in #49 / [2C-Gap-04] (#54).

## How to Verify

1. `git checkout feat/2C-19-checkin-freetext-note && git pull && npm install`
2. `npm run lint` — clean.
3. `npm run test.unit -- --run` — 338 passed.
4. `npx tsc --noEmit` — clean.
5. **Manual / on-device** (L's gate — agent-environment can't exercise the Kotlin → JS hand-off): see Manual Verification below.

## Manual Verification

The freetext path exercises a Kotlin-to-JS hand-off (FCM "Add note" tap → MainActivity intent extras → `brain.pendingIntent` slot → JS drain → route navigation) that pure unit tests can't cover. Suggested on-device run:

1. Sideload the post-merge debug APK, pair, ensure FCM is registered.
2. Trigger a `checkin_prompt` notification (via brain3-test rule or manual API call).
3. **Verify** the notification surface shows: the canned response actions ("1"–"5" by default) **plus** an "Add note" action.
4. Tap "Add note." App opens to `/checkins/notes/:id`. The notification message renders at top; no canned chip appears (none was pre-selected).
5. Type a note (≤ 5000 chars), tap Save. App navigates to `/checkins`. New row appears with the note as the freeform preview.
6. Repeat with a custom rule that emits `["Energy 3","Energy 4","Energy 5"]` canned responses. Tap a canned action → check-in row shows the parsed `Energy N` numeric value (no note). Tap "Add note" → note-entry shows "You chose: Energy N" chip; saving creates a check-in with both the numeric and the note.
7. Toggle airplane mode after step 4, save. Toast "Saved locally — will sync when you're online" surfaces; `/checkins` shows after a moment. Re-enable network → row delivers on next app foreground.

## Deviations

- **Spec-vs-server-defaults observation (not a hard conflict, no flag-and-stand-by halt).** The spec body names `"Energy 5"` / `"Focus 3"` / `"Mood 1"` as the parser's input shape. The server's `notification_defaults.py` ships `checkin_prompt` defaults as plain `["1","2","3","4","5"]` — those don't carry a dimension, so my parser falls through to its own spec-defined fallback (note + checkin_type only, no numeric fields). The spec is internally consistent (the fallback covers this case), so AC `Tap canned response → /respond fires AND /api/checkins/ fires` holds for both shapes; the AC's specific `numeric values populated` outcome only fires when a custom rule supplies named-format responses. Flagging for PO awareness — could fold into the Pass 3 Summary §C "future shared canned-response format" candidate.

- **Note-after-the-fact heuristic deferred.** The spec's Technical Notes describe a heuristic ("look up most recent StateCheckin matching `logged_at >= responded_at` + same `checkin_type`, PATCH freeform_note if found, else POST") and explicitly flag it as a design smell worth PO consideration. The AC says "check-in created" without mentioning PATCH. This PR implements the simpler always-POST path and defers the heuristic. If a user opens the Add-note UI for a notification they already canned-responded to, a second check-in is created. The realistic user surface is narrow — the FCM auto-cancels on canned tap, so the only path to revisit Add-note is via direct URL or future UI affordance.

- **Deep-link mechanism — used Intent extras + Capacitor Preferences slot rather than `server.url` allowlist.** The spec suggests `capacitor.config.ts` gain a `server.url` allowlist for an internal URL scheme, with the Capacitor App plugin's `appUrlOpen` event catching the deep link. I went with the existing in-codebase pattern (Intent + extras → MainActivity onNewIntent → durable Preferences slot → JS drain on mount and `appStateChange`) because (a) it sidesteps the bridge-readiness race that a `triggerWindowJSEvent` would have at cold-start, (b) it doesn't require adding a custom URL scheme intent-filter to the manifest, and (c) it parallels the existing `WriteQueueStore` cold-start hand-off pattern. Functional outcome is identical from the user's perspective. Flagging in case PO prefers the URL-scheme shape for forward consistency.

- **android:sync collateral reverted.** `npm run android:sync` regenerates `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle` to add `capacitor-device` (the [2C-Gap-02] / #49 pre-existing drift). My changes don't add or remove plugins — those edits are unrelated to [2C-19] — so per "Log it, don't fix it" + "One issue per PR" I reverted them. The drift continues to be tracked in #49; CI guard implementation is in #54.

- **First-consumer-instantiates flag.** `PendingIntentStore` (Kotlin) + `pendingIntent.ts` (JS) are a new generic-shape primitive whose only current consumer is the [2C-19] Add-note hand-off. The shape is intentional — single-slot, kind-discriminated payload — so a future `kind: "open_habit"` (or similar) extension can land without a refactor. Flagging per the org CLAUDE.md "First Consumer Instantiates" subsection.

- **Test-path location.** Spec names `tests/unit/checkin-parser.spec.ts`. Per repo CLAUDE.md "Test Conventions" + [2C-12] PR #29 D-1, tests are co-located with the module they test; the new test lives at `src/lib/checkin-parser.test.ts`. Sibling spec-vs-CLAUDE.md instance to [2C-07] PR #41 D-1 — `ba044399` directive (Briefs/specs point at canonical sources) covers this.

## Test Results

```
> brain3-companion@0.0.1 lint
> eslint
(no output — clean)

> brain3-companion@0.0.1 test.unit
> vitest --run

 Test Files  30 passed (30)
      Tests  338 passed (338)
```

New tests added in this PR:
- `src/lib/checkin-parser.test.ts` — 14 tests
- `src/lib/pendingIntent.test.ts` — 8 tests
- `src/lib/writeQueue.test.ts` — 7 new tests under "[2C-19] checkin_prompt extension"
- `src/pages/CheckinNoteEntryPage.test.tsx` — 7 tests

## Acceptance Checklist

- [x] Check-in prompt notification arrives → phone shows canned action buttons + an "Add note" action. *(unit-tested; on-device verification per Manual section)*
- [x] Tap canned response → `/respond` fires AND `/api/checkins/` fires → check-in visible in [2C-20]'s recent view (numeric values populated for named-format responses; note empty).
- [x] Tap "Add note" → app opens to note-entry screen → type note → Save → check-in created with `freeform_note` populated (and numeric fields if a canned was pre-selected).
- [x] Offline path: all POSTs enqueue and flush on reconnect; retry safety via [2C-03]'s `/respond` idempotency, plus the check-in POST halts on transient failure so the queued entry retries the full pair on next flush.
- [x] `checkin-parser` covers Energy/Focus/Mood/unknown variants (co-located at `src/lib/checkin-parser.test.ts` per CLAUDE.md test convention).

Closes #14
