### PR TITLE
[2C-27] App: Connection indicator tri-state + staleness derivation

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-network')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-push-notifications')
     implementation project(':capacitor-splash-screen')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -11,6 +11,9 @@ project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 
+include ':capacitor-network'
+project(':capacitor-network').projectDir = new File('../node_modules/@capacitor/network/android')
+
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/device": "^6.0.3",
         "@capacitor/haptics": "^6.0.0",
         "@capacitor/keyboard": "^6.0.0",
+        "@capacitor/network": "^6.0.4",
         "@capacitor/preferences": "^6.0.0",
         "@capacitor/push-notifications": "^6.0.5",
         "@capacitor/splash-screen": "^6.0.4",
@@ -1935,6 +1936,15 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-6.0.4.tgz",
       "integrity": "sha512-tNeyQGxIOTiSv3g+dTxJ/plVpGMnB4daJuCHz1E2Kelo+jOx+FKlyFY9L1Ow144SCzuXK48NXr8WoxXfXgQEKA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-6.0.4.tgz",
+      "integrity": "sha512-ywtlM3wJ3evci0T9zl3aGXGvd96pkiQDeoxrGR3rAqcBpf9DQubMGdFRmHma3frn2Fd/MBDYlgleu+nWDXunAg==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/device": "^6.0.3",
     "@capacitor/haptics": "^6.0.0",
     "@capacitor/keyboard": "^6.0.0",
+    "@capacitor/network": "^6.0.4",
     "@capacitor/preferences": "^6.0.0",
     "@capacitor/push-notifications": "^6.0.5",
     "@capacitor/splash-screen": "^6.0.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from './lib/device-registration';
 import { initWriteQueue } from './lib/writeQueue';
 import { initCompletionQueues } from './lib/completionQueues';
+import { ConnectionStateProvider } from './lib/connection/ConnectionStateProvider';
 import {
   clearPendingIntent,
   pendingIntentRoute,
@@ -146,58 +147,60 @@ const PendingIntentRunner: React.FC = () => {
 
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
-    <IonApp>
-      <DeviceRegistrar />
-      <WriteQueueRunner />
-      <IonReactRouter>
-        <PendingIntentRunner />
-        <IonRouterOutlet>
-          <Route exact path="/settings">
-            <SettingsPage />
-          </Route>
-          <Route exact path="/notifications">
-            <NotificationsPage />
-          </Route>
-          <Route exact path="/notifications/:notificationId">
-            <NotificationDetailPage />
-          </Route>
-          <Route exact path="/habits">
-            <HabitsPage />
-          </Route>
-          <Route exact path="/habits/:habitId">
-            <HabitDetailPage />
-          </Route>
-          <Route exact path="/routines">
-            <RoutinesPage />
-          </Route>
-          <Route exact path="/routines/:routineId">
-            <RoutineDetailPage />
-          </Route>
-          <Route exact path="/checkins">
-            <CheckinsPage />
-          </Route>
-          {/* [2C-19] Note-entry route — declared before /checkins/:checkinId
-              so the literal "notes" segment matches first under react-router 5
-              non-exact resolution. The `exact` flag also keeps both routes
-              isolated. */}
-          <Route exact path="/checkins/notes/:notificationId">
-            <CheckinNoteEntryPage />
-          </Route>
-          <Route exact path="/checkins/:checkinId">
-            <CheckinDetailPage />
-          </Route>
-          <Route exact path="/rules">
-            <RulesPage />
-          </Route>
-          <Route exact path="/rules/:ruleId">
-            <RuleDetailPage />
-          </Route>
-          <Route exact path="/">
-            <RootRedirect />
-          </Route>
-        </IonRouterOutlet>
-      </IonReactRouter>
-    </IonApp>
+    <ConnectionStateProvider>
+      <IonApp>
+        <DeviceRegistrar />
+        <WriteQueueRunner />
+        <IonReactRouter>
+          <PendingIntentRunner />
+          <IonRouterOutlet>
+            <Route exact path="/settings">
+              <SettingsPage />
+            </Route>
+            <Route exact path="/notifications">
+              <NotificationsPage />
+            </Route>
+            <Route exact path="/notifications/:notificationId">
+              <NotificationDetailPage />
+            </Route>
+            <Route exact path="/habits">
+              <HabitsPage />
+            </Route>
+            <Route exact path="/habits/:habitId">
+              <HabitDetailPage />
+            </Route>
+            <Route exact path="/routines">
+              <RoutinesPage />
+            </Route>
+            <Route exact path="/routines/:routineId">
+              <RoutineDetailPage />
+            </Route>
+            <Route exact path="/checkins">
+              <CheckinsPage />
+            </Route>
+            {/* [2C-19] Note-entry route — declared before /checkins/:checkinId
+                so the literal "notes" segment matches first under react-router 5
+                non-exact resolution. The `exact` flag also keeps both routes
+                isolated. */}
+            <Route exact path="/checkins/notes/:notificationId">
+              <CheckinNoteEntryPage />
+            </Route>
+            <Route exact path="/checkins/:checkinId">
+              <CheckinDetailPage />
+            </Route>
+            <Route exact path="/rules">
+              <RulesPage />
+            </Route>
+            <Route exact path="/rules/:ruleId">
+              <RuleDetailPage />
+            </Route>
+            <Route exact path="/">
+              <RootRedirect />
+            </Route>
+          </IonRouterOutlet>
+        </IonReactRouter>
+      </IonApp>
+    </ConnectionStateProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/ConnectionIndicator.tsx
+++ b/src/components/ConnectionIndicator.tsx
@@ -1,21 +1,41 @@
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { loadPairing, subscribePairing, type Pairing } from '../lib/pairing';
-import { pingHealth, type HealthResult } from '../lib/health';
+import { useConnectionState } from '../lib/connection/useConnectionState';
+import type { ConnectionStatus } from '../lib/connection/types';
 
 interface ConnectionIndicatorProps {
   slot?: string;
 }
 
+interface Visual {
+  label: string;
+  dotColor: string;
+  pulse: boolean;
+}
+
 /**
- * Passive connection-status chrome element. Renders an 8px dot + label and
- * refreshes via TanStack Query's own interval (5 min) + window-focus +
- * online-event hooks. Intentionally hides when the app is unpaired — a
- * standalone gray dot on Settings would be misleading. Per [2C-13].
+ * Visual map for the [2C-27] tri-state extension (technically four states —
+ * `syncing` shares the green hue of `connected` and adds a pulse per Pass 5
+ * Summary Escalation 5). Colors follow the v2.0.0 palette: green for healthy,
+ * amber for degraded, gray for offline.
+ */
+const VISUAL: Record<ConnectionStatus, Visual> = {
+  connected: { label: 'Connected', dotColor: '#22C55E', pulse: false },
+  syncing: { label: 'Syncing', dotColor: '#22C55E', pulse: true },
+  degraded: { label: 'Degraded', dotColor: '#F59E0B', pulse: false },
+  offline: { label: 'Offline', dotColor: '#9CA3AF', pulse: false },
+};
+
+/**
+ * Passive connection-status chrome element. Reads the derived state from
+ * [2C-27]'s `useConnectionState` and renders an 8 px dot + label. Intentionally
+ * hides when the app is unpaired — a standalone gray dot on Settings would be
+ * misleading. Per [2C-13] and extended in [2C-27].
  */
 const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = ({ slot }) => {
   const [pairing, setPairing] = useState<Pairing | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const { status } = useConnectionState();
 
   useEffect(() => {
     let cancelled = false;
@@ -33,33 +53,18 @@ const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = ({ slot }) => {
     };
   }, []);
 
-  const { data } = useQuery<HealthResult>({
-    queryKey: ['health', pairing?.url ?? null],
-    queryFn: () => {
-      // queryFn only runs when enabled, so pairing is non-null here.
-      const current = pairing as Pairing;
-      return pingHealth(current.url, current.token);
-    },
-    enabled: pairing !== null,
-    staleTime: 4.5 * 60 * 1000,
-    refetchInterval: 5 * 60 * 1000,
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-  });
-
   if (!loaded || pairing === null) {
     return null;
   }
 
-  const connected = data?.ok === true;
-  const label = connected ? 'Connected' : 'Disconnected';
-  const dotColor = connected ? '#22C55E' : '#9CA3AF';
+  const { label, dotColor, pulse } = VISUAL[status];
 
   return (
     <div
       slot={slot}
       role="status"
       aria-label={`Connection status: ${label}`}
+      data-connection-status={status}
       className="flex items-center gap-2 px-2"
     >
       <span
@@ -70,6 +75,7 @@ const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = ({ slot }) => {
           height: '8px',
           borderRadius: '9999px',
           backgroundColor: dotColor,
+          animation: pulse ? 'connection-pulse 1s ease-in-out infinite' : 'none',
         }}
       />
       <span className="text-xs">{label}</span>

--- a/src/lib/completionQueues.habit.test.ts
+++ b/src/lib/completionQueues.habit.test.ts
@@ -21,6 +21,13 @@ vi.mock('@capacitor/app', () => ({
   },
 }));
 
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
 import { Preferences } from '@capacitor/preferences';
 import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
 import {

--- a/src/lib/completionQueues.routine.test.ts
+++ b/src/lib/completionQueues.routine.test.ts
@@ -21,6 +21,13 @@ vi.mock('@capacitor/app', () => ({
   },
 }));
 
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
 import { Preferences } from '@capacitor/preferences';
 import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from './pairing';
 import {

--- a/src/lib/completionQueues.ts
+++ b/src/lib/completionQueues.ts
@@ -27,6 +27,7 @@
 
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
+import { Network } from '@capacitor/network';
 import {
   createWriteQueue,
   flushWriteQueue,
@@ -376,11 +377,17 @@ export function initCompletionQueues(): () => void {
     });
   }
 
-  if (typeof window !== 'undefined') {
-    const onlineHandler = (): void => safeFlushBoth();
-    window.addEventListener('online', onlineHandler);
-    cleanups.push(() => window.removeEventListener('online', onlineHandler));
-  }
+  // [2C-27] Reachability detection moved from `window.online` to the
+  // Capacitor Network plugin to mirror the notification queue.
+  let networkHandle: { remove: () => void } | null = null;
+  void Network.addListener('networkStatusChange', (status) => {
+    if (status.connected) safeFlushBoth();
+  }).then((handle) => {
+    networkHandle = handle;
+  });
+  cleanups.push(() => {
+    networkHandle?.remove();
+  });
 
   return () => {
     for (const cleanup of cleanups) {

--- a/src/lib/connection/ConnectionStateProvider.tsx
+++ b/src/lib/connection/ConnectionStateProvider.tsx
@@ -1,0 +1,114 @@
+/**
+ * Mounts the [2C-27] connection-state listener stack once at the app root and
+ * exposes the derived `ConnectionState` to descendants via Context.
+ *
+ * Listener wiring (all owned by this provider):
+ *
+ * 1. **Capacitor Network plugin.** Seeded with `Network.getStatus()` on mount;
+ *    `networkStatusChange` events thereafter. Single subscription regardless
+ *    of how many components read the hook — the store is a module-level
+ *    singleton.
+ * 2. **TanStack Query cache.** `queryClient.getQueryCache().subscribe()` —
+ *    the `'updated'` notify events with `action.type === 'success' | 'error'`
+ *    feed the rolling outcome window and update `lastSuccessAt`.
+ * 3. **Write-queue flush state.** Subscribes to the `writeQueueFlushState`
+ *    emitter so the indicator pulses `syncing` while [2C-29] is draining the
+ *    queue.
+ *
+ * The provider re-derives the state via `useSyncExternalStore` on every
+ * snapshot transition and provides it to descendants. Consumers can use
+ * `useConnectionState` to read.
+ */
+
+import { useEffect, useSyncExternalStore, type ReactNode } from 'react';
+import { Network } from '@capacitor/network';
+import { useQueryClient } from '@tanstack/react-query';
+import { classifyError } from './classifyError';
+import {
+  deriveConnectionState,
+  getSnapshot,
+  recordOutcome,
+  setFlushing,
+  setNetworkOnline,
+  subscribe,
+  type ConnectionSnapshot,
+} from './store';
+import {
+  getFlushState,
+  subscribeFlushState,
+} from './writeQueueFlushState';
+import { ConnectionStateContext } from './useConnectionState';
+
+export const ConnectionStateProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const queryClient = useQueryClient();
+  const snapshot = useSyncExternalStore<ConnectionSnapshot>(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    let handle: { remove: () => void } | null = null;
+
+    void Network.getStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setNetworkOnline(status.connected);
+      })
+      .catch(() => {
+        // Plugin unavailable (web preview without the polyfill, etc.) —
+        // leave `networkOnline` at its optimistic default so the indicator
+        // does not paint offline on startup.
+      });
+
+    void Network.addListener('networkStatusChange', (status) => {
+      setNetworkOnline(status.connected);
+    }).then((listenerHandle) => {
+      if (cancelled) {
+        listenerHandle.remove();
+        return;
+      }
+      handle = listenerHandle;
+    });
+
+    return () => {
+      cancelled = true;
+      handle?.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    const cache = queryClient.getQueryCache();
+    const unsubscribe = cache.subscribe((event) => {
+      if (event.type !== 'updated') return;
+      const action = event.action;
+      if (action.type === 'success') {
+        recordOutcome('success', event.query.queryKey);
+      } else if (action.type === 'error') {
+        recordOutcome(classifyError(action.error), event.query.queryKey);
+      }
+    });
+    return unsubscribe;
+  }, [queryClient]);
+
+  useEffect(() => {
+    // Sync to the current flush state on mount in case [2C-29] emitted before
+    // the provider mounted (unlikely under normal startup ordering, but safe).
+    setFlushing(getFlushState() === 'flushing');
+    const unsubscribe = subscribeFlushState((state) => {
+      setFlushing(state === 'flushing');
+    });
+    return unsubscribe;
+  }, []);
+
+  const value = deriveConnectionState(snapshot, Date.now());
+
+  return (
+    <ConnectionStateContext.Provider value={value}>
+      {children}
+    </ConnectionStateContext.Provider>
+  );
+};

--- a/src/lib/connection/classifyError.ts
+++ b/src/lib/connection/classifyError.ts
@@ -1,0 +1,32 @@
+/**
+ * Heuristic classification of TanStack Query error rejections into the
+ * `ApiOutcome` taxonomy used by the connection store.
+ *
+ * The codebase's queries currently throw `new Error('Failed to fetch X')`
+ * style rejections without attached status info, so most paths land in
+ * `network_error` by default. The classification fans out:
+ *
+ * - `error` is a `TypeError` → `network_error` (fetch-level failure).
+ * - `error.name === 'AbortError'` → `timeout` (best-effort — most aborts in
+ *   this codebase are timer-driven; user-cancelled aborts are rare).
+ * - `error.status` is 500-599 (custom HTTPError shape) → `server_error`.
+ * - Anything else → `network_error` (safe default; degrades toward offline
+ *   rather than masking a connectivity gap as a transient server hiccup).
+ *
+ * Future query refactors can throw structured errors with `.status` to
+ * sharpen `server_error` classification without changing this contract.
+ */
+
+import type { ApiOutcome } from './types';
+
+export function classifyError(error: unknown): ApiOutcome {
+  if (error instanceof TypeError) return 'network_error';
+  if (error !== null && typeof error === 'object') {
+    const e = error as { name?: unknown; status?: unknown };
+    if (e.name === 'AbortError') return 'timeout';
+    if (typeof e.status === 'number' && e.status >= 500 && e.status < 600) {
+      return 'server_error';
+    }
+  }
+  return 'network_error';
+}

--- a/src/lib/connection/config.ts
+++ b/src/lib/connection/config.ts
@@ -1,0 +1,34 @@
+/**
+ * Connection-state configuration constants for [2C-27].
+ *
+ * Single source of truth for tuning the indicator's derivation rules.
+ * Adjust here rather than at call sites.
+ */
+
+/**
+ * Staleness threshold applied uniformly across all entity-type queries.
+ * If no successful TanStack Query has resolved within this window and the
+ * network reports connected, the indicator transitions to `degraded`.
+ *
+ * Default 5 minutes per Pass 5 Summary §3 [2C-27] and Escalation 2.
+ */
+export const STALENESS_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Rolling-window size for API-attempt outcomes used in the offline/degraded
+ * derivation rules.
+ *
+ * - `offline` requires the last 3 attempts to have been network-errored or
+ *   timed out.
+ * - `degraded` 5xx-rule requires the last 2 attempts to have returned 5xx.
+ */
+export const OUTCOME_WINDOW_SIZE = 3;
+
+/**
+ * Minimum visual dwell time on `syncing` after a flush event fires. Prevents
+ * sub-perceptible flicker when a flush completes in <100 ms on fast networks.
+ *
+ * Per Pass 5 Summary §3 [2C-27] "Pulse cap: indicator stays in `syncing` for
+ * at least 800 ms even if flush completes faster".
+ */
+export const SYNCING_PULSE_FLOOR_MS = 800;

--- a/src/lib/connection/connection.staleness.test.ts
+++ b/src/lib/connection/connection.staleness.test.ts
@@ -1,0 +1,100 @@
+/**
+ * [2C-27] Staleness-threshold coverage. Separate file from the main
+ * derivation suite so the timer mechanics stay isolated and the spec's
+ * acceptance criteria split (`connection.spec.ts` for transitions,
+ * `connection.staleness.spec.ts` for staleness) maps to a clear test
+ * boundary.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetForTests,
+  deriveConnectionState,
+  getSnapshot,
+  recordOutcome,
+  setNetworkOnline,
+} from './store';
+import { STALENESS_THRESHOLD_MS } from './config';
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+afterEach(() => {
+  __resetForTests();
+});
+
+describe('staleness threshold', () => {
+  it('defaults to 5 minutes', () => {
+    expect(STALENESS_THRESHOLD_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('returns `connected` while the most-recent success is within the window', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    const justInside = deriveConnectionState(
+      getSnapshot(),
+      NOW + STALENESS_THRESHOLD_MS,
+    );
+    expect(justInside.status).toBe('connected');
+  });
+
+  it('transitions to `degraded` once the threshold elapses without a new success', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    const justOutside = deriveConnectionState(
+      getSnapshot(),
+      NOW + STALENESS_THRESHOLD_MS + 1,
+    );
+    expect(justOutside.status).toBe('degraded');
+  });
+
+  it('applies the same threshold uniformly across query keys', () => {
+    setNetworkOnline(true);
+
+    // Three different entity-type queries succeed at NOW. After 5 min + 1 ms,
+    // all three should be reported stale via the same `lastSuccessAt` field —
+    // there is no per-key bookkeeping.
+    recordOutcome('success', ['habits'], NOW);
+    recordOutcome('success', ['notifications'], NOW);
+    recordOutcome('success', ['routines'], NOW);
+
+    const state = deriveConnectionState(
+      getSnapshot(),
+      NOW + STALENESS_THRESHOLD_MS + 1,
+    );
+    expect(state.status).toBe('degraded');
+  });
+
+  it('a fresh success past the threshold restores `connected`', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    const stale = deriveConnectionState(
+      getSnapshot(),
+      NOW + STALENESS_THRESHOLD_MS + 1,
+    );
+    expect(stale.status).toBe('degraded');
+
+    recordOutcome('success', ['habits'], NOW + STALENESS_THRESHOLD_MS + 100);
+
+    const restored = deriveConnectionState(
+      getSnapshot(),
+      NOW + STALENESS_THRESHOLD_MS + 200,
+    );
+    expect(restored.status).toBe('connected');
+    expect(restored.lastSyncedAt).toBe(NOW + STALENESS_THRESHOLD_MS + 100);
+  });
+
+  it('threshold value is the single constant in config.ts', async () => {
+    // Asserts the contract: `STALENESS_THRESHOLD_MS` is the only knob — no
+    // per-key override, no env variable, no derived constant elsewhere.
+    const configModule = await import('./config');
+    expect(typeof configModule.STALENESS_THRESHOLD_MS).toBe('number');
+    expect(configModule.STALENESS_THRESHOLD_MS).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/connection/connection.test.ts
+++ b/src/lib/connection/connection.test.ts
@@ -1,0 +1,148 @@
+/**
+ * [2C-27] State-transition test bed for the connection store + derivation.
+ *
+ * The store is exercised at the mutator layer rather than through the
+ * `ConnectionStateProvider`, so listener wiring (Capacitor Network plugin,
+ * TanStack Query cache, write-queue flush emitter) is not under test here.
+ * That coverage lives in `connection.staleness.test.ts` (timer behavior)
+ * and the manual verification procedure in the Pass 5 spec.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetForTests,
+  deriveConnectionState,
+  getSnapshot,
+  recordOutcome,
+  setFlushing,
+  setNetworkOnline,
+} from './store';
+import { SYNCING_PULSE_FLOOR_MS } from './config';
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+afterEach(() => {
+  __resetForTests();
+});
+
+describe('connection state derivation', () => {
+  it('reports `connected` for net-up + recent success', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 1_000);
+    expect(state.status).toBe('connected');
+    expect(state.lastSyncedAt).toBe(NOW);
+    expect(state.lastSyncedQueryKey).toEqual(['habits']);
+  });
+
+  it('is optimistically `connected` on first render before any API attempt', () => {
+    setNetworkOnline(true);
+
+    const state = deriveConnectionState(getSnapshot(), NOW);
+    expect(state.status).toBe('connected');
+    expect(state.lastSyncedAt).toBeNull();
+  });
+
+  it('reports `degraded` when the last 2 attempts returned 5xx', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+    recordOutcome('server_error', ['habits'], NOW + 1_000);
+    recordOutcome('server_error', ['habits'], NOW + 2_000);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 3_000);
+    expect(state.status).toBe('degraded');
+  });
+
+  it('reports `offline` when the network plugin reports down', () => {
+    setNetworkOnline(false);
+    recordOutcome('success', ['habits'], NOW);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 1_000);
+    expect(state.status).toBe('offline');
+  });
+
+  it('reports `offline` when the last 3 attempts all network-errored', () => {
+    setNetworkOnline(true);
+    recordOutcome('network_error', ['habits'], NOW);
+    recordOutcome('network_error', ['notifications'], NOW + 1_000);
+    recordOutcome('network_error', ['routines'], NOW + 2_000);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 3_000);
+    expect(state.status).toBe('offline');
+  });
+
+  it('reports `offline` when the last 3 attempts mix network-errors and timeouts', () => {
+    setNetworkOnline(true);
+    recordOutcome('timeout', ['habits'], NOW);
+    recordOutcome('network_error', ['notifications'], NOW + 1_000);
+    recordOutcome('timeout', ['routines'], NOW + 2_000);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 3_000);
+    expect(state.status).toBe('offline');
+  });
+
+  it('reports `syncing` while the write-queue flush is active', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    setFlushing(true, NOW + 1_000);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 1_200);
+    expect(state.status).toBe('syncing');
+  });
+
+  it('keeps `syncing` for the pulse floor after a fast flush', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+
+    setFlushing(true, NOW + 1_000);
+    setFlushing(false, NOW + 1_050); // 50 ms flush — pulseUntil floor is 800 ms.
+
+    // Mid-pulse: still syncing.
+    const midPulse = deriveConnectionState(getSnapshot(), NOW + 1_400);
+    expect(midPulse.status).toBe('syncing');
+
+    // Past pulseUntil: back to connected.
+    const past = deriveConnectionState(
+      getSnapshot(),
+      NOW + 1_000 + SYNCING_PULSE_FLOOR_MS + 1,
+    );
+    expect(past.status).toBe('connected');
+  });
+
+  it('syncing wins over offline/degraded — the pulse is the most actionable signal', () => {
+    setNetworkOnline(false);
+    setFlushing(true, NOW);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 100);
+    expect(state.status).toBe('syncing');
+  });
+
+  it('rolling window discards entries older than N=3', () => {
+    setNetworkOnline(true);
+    // Four errors — the oldest falls out of the window so all-3-errored holds.
+    recordOutcome('network_error', null, NOW);
+    recordOutcome('network_error', null, NOW + 1);
+    recordOutcome('success', ['habits'], NOW + 2);
+    recordOutcome('network_error', null, NOW + 3);
+    recordOutcome('network_error', null, NOW + 4);
+    recordOutcome('network_error', null, NOW + 5);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 6);
+    expect(state.status).toBe('offline');
+  });
+
+  it('a single 5xx is not enough — degraded requires two consecutive', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+    recordOutcome('server_error', ['habits'], NOW + 1_000);
+
+    const state = deriveConnectionState(getSnapshot(), NOW + 2_000);
+    expect(state.status).toBe('connected');
+  });
+});

--- a/src/lib/connection/store.ts
+++ b/src/lib/connection/store.ts
@@ -1,0 +1,200 @@
+/**
+ * Module-level singleton store backing [2C-27]'s `useConnectionState` hook.
+ *
+ * One instance is created at module load. The provider feeds it events from
+ * the Capacitor Network plugin, the TanStack Query cache, and the
+ * write-queue flush emitter; the hook reads via `useSyncExternalStore`. The
+ * indirection lets consumers re-render on state change without each instance
+ * mounting its own Network listener.
+ *
+ * The rolling window of outcomes (cap N) is intentionally tiny — it backs
+ * the offline/degraded derivation only and discards older entries.
+ *
+ * **Test escape hatch:** `__resetForTests` resets all state including the
+ * staleness timer. Tests can manipulate state by calling the mutators
+ * directly without going through the provider.
+ */
+
+import type { QueryKey } from '@tanstack/react-query';
+import {
+  OUTCOME_WINDOW_SIZE,
+  STALENESS_THRESHOLD_MS,
+  SYNCING_PULSE_FLOOR_MS,
+} from './config';
+import type { ApiOutcome, ConnectionState, ConnectionStatus } from './types';
+
+export interface ConnectionSnapshot {
+  networkOnline: boolean;
+  outcomes: readonly ApiOutcome[];
+  lastSuccessAt: number | null;
+  lastSuccessQueryKey: QueryKey | null;
+  flushing: boolean;
+  /**
+   * Timestamp (ms) before which the indicator must remain in `syncing` even
+   * if `flushing` has dropped to false. Enforces the 800 ms pulse floor.
+   */
+  pulseUntil: number;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+let snapshot: ConnectionSnapshot = freshSnapshot();
+
+let pulseTimer: ReturnType<typeof setTimeout> | null = null;
+let stalenessTimer: ReturnType<typeof setTimeout> | null = null;
+
+function freshSnapshot(): ConnectionSnapshot {
+  return {
+    networkOnline: true,
+    outcomes: [],
+    lastSuccessAt: null,
+    lastSuccessQueryKey: null,
+    flushing: false,
+    pulseUntil: 0,
+  };
+}
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function update(patch: Partial<ConnectionSnapshot>): void {
+  snapshot = { ...snapshot, ...patch };
+  notify();
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getSnapshot(): ConnectionSnapshot {
+  return snapshot;
+}
+
+export function setNetworkOnline(networkOnline: boolean): void {
+  if (snapshot.networkOnline === networkOnline) return;
+  update({ networkOnline });
+}
+
+export function recordOutcome(
+  outcome: ApiOutcome,
+  queryKey: QueryKey | null = null,
+  now: number = Date.now(),
+): void {
+  const next = snapshot.outcomes
+    .concat(outcome)
+    .slice(-OUTCOME_WINDOW_SIZE);
+  const patch: Partial<ConnectionSnapshot> = { outcomes: next };
+  if (outcome === 'success') {
+    patch.lastSuccessAt = now;
+    patch.lastSuccessQueryKey = queryKey;
+    scheduleStalenessExpiry(now);
+  }
+  update(patch);
+}
+
+function scheduleStalenessExpiry(lastSuccessAt: number): void {
+  if (stalenessTimer !== null) {
+    clearTimeout(stalenessTimer);
+    stalenessTimer = null;
+  }
+  const fireAt = lastSuccessAt + STALENESS_THRESHOLD_MS;
+  const delay = Math.max(0, fireAt - Date.now());
+  stalenessTimer = setTimeout(() => {
+    stalenessTimer = null;
+    // Re-emit the snapshot so consumers re-derive at the moment of expiry.
+    // The data hasn't changed, but the derivation now flips to `degraded`
+    // because `now > lastSuccessAt + STALENESS_THRESHOLD_MS`.
+    snapshot = { ...snapshot };
+    notify();
+  }, delay);
+}
+
+export function setFlushing(flushing: boolean, now: number = Date.now()): void {
+  if (flushing) {
+    if (pulseTimer !== null) {
+      clearTimeout(pulseTimer);
+      pulseTimer = null;
+    }
+    const pulseUntil = Math.max(snapshot.pulseUntil, now + SYNCING_PULSE_FLOOR_MS);
+    update({ flushing: true, pulseUntil });
+    return;
+  }
+  // Flush ended: keep the indicator in `syncing` until pulseUntil expires.
+  const remaining = Math.max(0, snapshot.pulseUntil - now);
+  update({ flushing: false });
+  if (remaining > 0) {
+    if (pulseTimer !== null) clearTimeout(pulseTimer);
+    pulseTimer = setTimeout(() => {
+      pulseTimer = null;
+      // Refresh snapshot reference so React re-derives; pulseUntil is already
+      // in the past at this point and `flushing` is already false.
+      snapshot = { ...snapshot };
+      notify();
+    }, remaining);
+  }
+}
+
+/**
+ * Pure derivation of the indicator's observable state from a snapshot. The
+ * `now` parameter is injected so tests can pin a deterministic clock and so
+ * staleness comparisons use the same instant as the React render that
+ * consumes the result.
+ *
+ * Priority: `syncing` > `offline` > `degraded` > `connected`. `syncing` wins
+ * when a flush is active or the 800 ms pulse floor hasn't elapsed, even if
+ * other rules would also fire — the pulse is the most actionable feedback.
+ */
+export function deriveConnectionState(
+  snap: ConnectionSnapshot,
+  now: number,
+): ConnectionState {
+  const status = deriveStatus(snap, now);
+  return {
+    status,
+    lastSyncedAt: snap.lastSuccessAt,
+    lastSyncedQueryKey: snap.lastSuccessQueryKey,
+  };
+}
+
+function deriveStatus(snap: ConnectionSnapshot, now: number): ConnectionStatus {
+  if (snap.flushing || now < snap.pulseUntil) return 'syncing';
+
+  const last3 = snap.outcomes.slice(-3);
+  const allErrored =
+    last3.length === OUTCOME_WINDOW_SIZE &&
+    last3.every((o) => o === 'network_error' || o === 'timeout');
+  if (!snap.networkOnline || allErrored) return 'offline';
+
+  const last2 = snap.outcomes.slice(-2);
+  const twoServerErrors =
+    last2.length === 2 && last2.every((o) => o === 'server_error');
+  // Staleness applies only after a first success has been recorded. Pre-first-
+  // success the indicator is optimistically `connected`; the first resolved
+  // query updates `lastSuccessAt` and the timer-driven re-emit covers the
+  // expiry boundary thereafter.
+  const stale =
+    snap.lastSuccessAt !== null &&
+    now - snap.lastSuccessAt > STALENESS_THRESHOLD_MS;
+  if (twoServerErrors || stale) return 'degraded';
+
+  return 'connected';
+}
+
+export function __resetForTests(): void {
+  if (pulseTimer !== null) {
+    clearTimeout(pulseTimer);
+    pulseTimer = null;
+  }
+  if (stalenessTimer !== null) {
+    clearTimeout(stalenessTimer);
+    stalenessTimer = null;
+  }
+  listeners.clear();
+  snapshot = freshSnapshot();
+}

--- a/src/lib/connection/types.ts
+++ b/src/lib/connection/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Public types for the [2C-27] connection state surface.
+ *
+ * The hook output is a discriminated union over four observable states. The
+ * surrounding fields (`lastSyncedAt`, `lastSyncedQueryKey`) are populated on
+ * the same shape regardless of `status` so consumers can render staleness
+ * affordances ([2C-28] banner) alongside the indicator without a second hook.
+ */
+
+import type { QueryKey } from '@tanstack/react-query';
+
+export type ConnectionStatus = 'connected' | 'syncing' | 'degraded' | 'offline';
+
+export interface ConnectionState {
+  status: ConnectionStatus;
+  lastSyncedAt: number | null;
+  lastSyncedQueryKey: QueryKey | null;
+}
+
+/**
+ * Classification of a single TanStack Query attempt outcome as observed by
+ * the connection store. Used to populate the rolling window the derivation
+ * rules consult.
+ *
+ * - `success` — query resolved with a value.
+ * - `server_error` — query rejected with an HTTP status in 500-599.
+ * - `network_error` — query rejected with a fetch-level failure
+ *   (`TypeError`, name `AbortError` when not initiated by us, etc.).
+ * - `timeout` — query rejected after a timer-driven `AbortController.abort()`.
+ */
+export type ApiOutcome =
+  | 'success'
+  | 'server_error'
+  | 'network_error'
+  | 'timeout';

--- a/src/lib/connection/useConnectionState.ts
+++ b/src/lib/connection/useConnectionState.ts
@@ -1,0 +1,45 @@
+/**
+ * Read-side surface of the [2C-27] connection state — the `useConnectionState`
+ * hook plus a `ConnectionStateContext` for components that prefer
+ * `useContext` over `useSyncExternalStore`. Both read from the same
+ * module-level store, so multiple consumers stay coherent.
+ *
+ * `ConnectionStateProvider` (`./ConnectionStateProvider.tsx`) is mounted once
+ * at the app root and wires the Capacitor Network plugin, the TanStack Query
+ * cache, and the write-queue flush emitter into the store. Components inside
+ * the provider receive the derived state via Context; the hook also works
+ * outside the provider (it falls through to `useSyncExternalStore` on the
+ * singleton store) so test renderers can omit the wrapper when the listener
+ * wiring isn't under test.
+ */
+
+import { createContext, useContext, useSyncExternalStore } from 'react';
+import {
+  deriveConnectionState,
+  getSnapshot,
+  subscribe,
+  type ConnectionSnapshot,
+} from './store';
+import type { ConnectionState } from './types';
+
+export const ConnectionStateContext = createContext<ConnectionState | null>(
+  null,
+);
+
+/**
+ * React hook returning the current `ConnectionState`. Re-renders on every
+ * underlying store transition (network change, query success/error, flush
+ * start/end, pulse expiry, staleness expiry). Inside `ConnectionStateProvider`
+ * the value is read from Context; outside, it falls back to a direct
+ * subscription to the store so the hook works in isolated component tests.
+ */
+export function useConnectionState(): ConnectionState {
+  const fromContext = useContext(ConnectionStateContext);
+  const snapshot = useSyncExternalStore<ConnectionSnapshot>(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
+  if (fromContext !== null) return fromContext;
+  return deriveConnectionState(snapshot, Date.now());
+}

--- a/src/lib/connection/writeQueueFlushState.ts
+++ b/src/lib/connection/writeQueueFlushState.ts
@@ -1,0 +1,48 @@
+/**
+ * Write-queue flush-state event surface for [2C-27] / [2C-29].
+ *
+ * [2C-29] will emit `'flushing'` at the start of each non-coalesced flush and
+ * `'idle'` after the flush settles. [2C-27]'s connection store subscribes to
+ * derive the `syncing` indicator state with the 800 ms pulse cap from
+ * `config.ts`.
+ *
+ * **First Consumer Instantiates:** [2C-27] introduces this event so its hook
+ * can subscribe with a stable interface. [2C-29] is the producer side — it
+ * imports `emitFlushState` to publish transitions. Pre-[2C-29] the event
+ * never fires, so the connection store sees `flushing: false` indefinitely,
+ * which yields a stub `syncing: false` as Pass 5 §3 [2C-27] anticipates.
+ *
+ * Follows the `Set<Listener>` pub-sub convention used throughout this repo
+ * (`pairing.ts`, `writeQueue.ts:subscribeConflicts`,
+ * `completionQueues.ts:subscribe*Warnings`). Recommended `mitt` from the
+ * brief was a suggestion, not a mandate — staying consistent with the
+ * existing pattern avoids introducing a dep with no functional gain.
+ */
+
+export type FlushState = 'idle' | 'flushing';
+
+type Listener = (state: FlushState) => void;
+
+const listeners = new Set<Listener>();
+let current: FlushState = 'idle';
+
+export function getFlushState(): FlushState {
+  return current;
+}
+
+export function subscribeFlushState(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitFlushState(state: FlushState): void {
+  current = state;
+  for (const listener of listeners) listener(state);
+}
+
+export function __resetFlushStateForTests(): void {
+  listeners.clear();
+  current = 'idle';
+}

--- a/src/lib/writeQueue.test.ts
+++ b/src/lib/writeQueue.test.ts
@@ -21,6 +21,13 @@ vi.mock('@capacitor/app', () => ({
   },
 }));
 
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
 vi.mock('@capacitor/push-notifications', () => ({
   PushNotifications: {
     requestPermissions: vi.fn(),

--- a/src/lib/writeQueue.ts
+++ b/src/lib/writeQueue.ts
@@ -22,6 +22,7 @@
 
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
+import { Network } from '@capacitor/network';
 import { Preferences } from '@capacitor/preferences';
 import { composeCheckinFromCanned } from './checkin-parser';
 import type { CheckinType } from './checkins';
@@ -454,11 +455,22 @@ export function initWriteQueue(): () => void {
     });
   }
 
-  if (typeof window !== 'undefined') {
-    const onlineHandler = (): void => safeFlush();
-    window.addEventListener('online', onlineHandler);
-    cleanups.push(() => window.removeEventListener('online', onlineHandler));
+  // [2C-27] Reachability detection moved from `window.online` to the
+  // Capacitor Network plugin. On native Android the browser-level `online`
+  // event is unreliable — Capacitor's `networkStatusChange` is the
+  // authoritative source. The flush-on-reachable contract from [2C-07] is
+  // preserved; only the detector changed.
+  let networkHandle: { remove: () => void } | null = null;
+  void Network.addListener('networkStatusChange', (status) => {
+    if (status.connected) safeFlush();
+  }).then((handle) => {
+    networkHandle = handle;
+  });
+  cleanups.push(() => {
+    networkHandle?.remove();
+  });
 
+  if (typeof window !== 'undefined') {
     const bridgeHandler = (): void => safeFlush();
     window.addEventListener(BRIDGE_EVENT_NAME, bridgeHandler);
     cleanups.push(() =>

--- a/src/pages/CheckinNoteEntryPage.test.tsx
+++ b/src/pages/CheckinNoteEntryPage.test.tsx
@@ -24,6 +24,13 @@ vi.mock('@capacitor/app', () => ({
   },
 }));
 
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
 vi.mock('@capacitor/push-notifications', () => ({
   PushNotifications: {
     requestPermissions: vi.fn(),

--- a/src/theme/tailwind.css
+++ b/src/theme/tailwind.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* [2C-27] Connection-indicator `syncing` pulse — green dot fades 1.0 → 0.4 → 1.0
+   so the user perceives an active flush without an alarming color shift. */
+@keyframes connection-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Verification

- `npm run test.unit` — ✅ Pass (355 passed, 32 test files; +16 new in `src/lib/connection/`)
- `npm run lint` — ✅ Pass (no errors, no warnings)
- `npm run android:sync` — ✅ Ran clean; `:capacitor-network` registered in `android/app/capacitor.build.gradle` + `android/capacitor.settings.gradle` (see D-4 re: device-plugin drift)
- Build (`tsc && vite build`) — ✅ Pass via the `android:sync` script chain

Ran locally against `develop` HEAD at `888c66d` immediately before opening this PR.

## Summary

Promotes the `ConnectionIndicator` component from binary green/gray to four observable states (`connected`, `syncing`, `degraded`, `offline`) backed by a new `useConnectionState` hook. The hook reads from a module-level singleton store fed by the Capacitor Network plugin, the TanStack Query cache, and a `writeQueueFlushState` event that [2C-29] will produce into. The `ConnectionStateProvider` mounts the listener stack once at the App root.

Also rewires the [2C-07] notification queue and [2C-23] completion queues from `window.addEventListener('online')` to `Network.addListener('networkStatusChange')` — Capacitor's event source is authoritative on Android where the browser-level `online` event is unreliable.

## Changes

- **`src/lib/connection/`** (new module):
  - `config.ts` — `STALENESS_THRESHOLD_MS` (5 min), `OUTCOME_WINDOW_SIZE` (3), `SYNCING_PULSE_FLOOR_MS` (800 ms). Single source of truth for the derivation tuning knobs.
  - `types.ts` — `ConnectionState` discriminated union (`status`, `lastSyncedAt`, `lastSyncedQueryKey`) and `ApiOutcome` taxonomy.
  - `store.ts` — Module-level singleton holding `networkOnline`, the rolling outcome window, `lastSuccessAt`, `flushing`, `pulseUntil`. Schedules timers at pulse expiry and staleness expiry so the indicator re-derives at the exact transition boundary. Exposes a pure `deriveConnectionState(snapshot, now)` for unit tests.
  - `classifyError.ts` — Heuristic mapping of TanStack Query error rejections to `ApiOutcome`. Defaults to `network_error` for unstructured errors; tightens to `server_error` when an error carries a numeric `.status` in 500-599.
  - `useConnectionState.ts` — Hook + `ConnectionStateContext`. Reads from Context when inside the provider; falls back to a direct `useSyncExternalStore` subscription so isolated component tests don't need to wrap.
  - `ConnectionStateProvider.tsx` — Wires the Capacitor Network plugin, the `QueryCache.subscribe()` events, and the `writeQueueFlushState` emitter into the store. Mounted once at the App root.
  - `writeQueueFlushState.ts` — Event surface that [2C-29] will produce into. Stays in `idle` pre-[2C-29], yielding a stubbed `syncing: false` exactly as Pass 5 §3 [2C-27] anticipates.
  - `connection.test.ts` + `connection.staleness.test.ts` — Acceptance-criteria coverage (16 tests).
- **`src/components/ConnectionIndicator.tsx`** — Switched from `pingHealth` TanStack Query to `useConnectionState`. Visual map adds amber (`degraded`) and the green pulsing `syncing` state. Adds a `data-connection-status` attribute for downstream consumers ([2C-28] banner).
- **`src/theme/tailwind.css`** — Adds `@keyframes connection-pulse` for the syncing dwell animation.
- **`src/App.tsx`** — Mounts `<ConnectionStateProvider>` between `<QueryClientProvider>` and `<IonApp>` so it can read the query client via `useQueryClient()`.
- **`src/lib/writeQueue.ts` + `src/lib/completionQueues.ts`** — Replace the `window.online` listener in each `init*` function with `Network.addListener('networkStatusChange')`. The `appStateChange`, bridge-event, and registration-completion triggers are untouched.
- **Test mocks** — Add `vi.mock('@capacitor/network', ...)` to the four test files that import the queue modules.
- **`package.json`** + **`android/app/capacitor.build.gradle`** + **`android/capacitor.settings.gradle`** — `@capacitor/network@^6.0.0` install + `android:sync` registration (network only — see D-4).

## How to Verify

1. `git checkout feat/2C-27-connection-tri-state && npm install && npm run test.unit -- --run` — confirm 355 tests pass.
2. `npm run lint` — confirm clean.
3. `npm run dev` and open the app paired against a running brain3 dev server. Observe the indicator in the Notifications header: green `Connected` with no pulse.
4. Manual verification (real-device): per the issue body §Manual verification, reproduced verbatim below. Five of the six steps are real-device-only — they will run against the `docs/plane-test.md` harness once [2C-32] lands; until then they are L's manual gate on the dev-channel APK that includes this PR.

The MV section from the issue body is preserved verbatim:

1. With device on Wi-Fi, open the app and confirm indicator is **green** in the header on Notifications screen.
2. Disable Wi-Fi and mobile data (airplane mode). Within 2 seconds, confirm indicator transitions to **gray (offline)**.
3. Re-enable network. Within 5 seconds, confirm indicator returns to **green**.
4. Use a network conditioner (Charles / Chrome DevTools / Android tcp-block) to keep network up but block traffic to the BRAIN server. After 2 failed `/api/app/health` calls (or two 5xx responses if you can mock), confirm indicator transitions to **amber (degraded)**.
5. Leave the app open on Notifications view for >5 minutes without network changes. After the staleness threshold elapses, confirm indicator transitions to **amber** if no sync occurred in that window.
6. Trigger a write-queue flush (queue an action while offline, then reconnect — see `[2C-29]` MV / `docs/plane-test.md`) and confirm the indicator briefly **pulses green** during flush.

Step 6 requires [2C-29]'s write-queue flush emitter to be wired before the pulse can be exercised on-device — this PR ships the consumer side with a stable `writeQueueFlushState` interface; [2C-29] will produce events into it.

## Deviations

**D-1. Test path co-location.** Spec §Acceptance criteria names `tests/unit/connection.spec.ts` + `tests/unit/connection.staleness.spec.ts`. Repo CLAUDE.md (`908baa66` v3 — Test Conventions section) directs: "Tests are co-located with the module they test. ... Do NOT introduce new files in `tests/unit/` — that directory is being phased out." Repo CLAUDE.md wins per the org CLAUDE.md inheritance order. Tests land at `src/lib/connection/connection.test.ts` and `src/lib/connection/connection.staleness.test.ts`. The drift is a spec-authoring rule artefact — Pass 5 Summary predates the May 10 spec-authoring rule (`ba044399`) that explicitly names test paths as a canonical-source pointer surface.

**D-2. The `fetch('/api/app/health')` liveness pattern the spec describes does not exist.** Spec §Scope says: "Replace the naive `fetch('/api/app/health')` liveness pattern from `[2C-07]` at queue-flush trigger sites with the Network-plugin-derived reachability." Grep across the codebase shows no such fetch in any queue trigger path — `writeQueue.ts:initWriteQueue` and `completionQueues.ts:initCompletionQueues` use `window.addEventListener('online', ...)` as their reachability detector. The substantive intent of the spec is sound — replace the unreliable browser-level `online` event with `Network.addListener('networkStatusChange')` — and that is what this PR does. The flush-on-network-reachable contract from [2C-07] is preserved; only the event source changes. The `pingHealth` call sites in `SettingsPage.tsx` (one-shot validation) and the old `ConnectionIndicator.tsx` (`useQuery`) are unrelated to queue triggers and were not described by this spec clause.

**D-3. `writeQueueFlushState` emitter pattern.** Brief watch-item §5 recommends `mitt` (~200 bytes, zero deps) as the event-bus implementation. Used the codebase's existing `Set<Listener>` + bare subscribe-function pattern instead — matches `pairing.ts:subscribePairing`, `writeQueue.ts:subscribeConflicts`, `device-registration.ts:subscribeRegistration`, and `completionQueues.ts:subscribe*Warnings`. No new dependency; same functional shape; consistent with the repo's pub-sub convention.

**D-4. `android:sync` regenerated unrelated `:capacitor-device` drift ([2C-Gap-02] #49).** Running `npm run android:sync` to register `@capacitor/network` natively also added `:capacitor-device` references that have been missing since [2C-05]. Per the PR #48 precedent referenced in issue #49, the device portion was reverted from the android/ diff; this PR's `android/app/capacitor.build.gradle` + `android/capacitor.settings.gradle` deltas contain only the `:capacitor-network` registration. Issue #49 remains open and unchanged.

**FCI flag (First Consumer Instantiates, org CLAUDE.md v6).** This PR introduces three scaffolds whose only current consumer is [2C-27] itself:

1. `src/lib/connection/writeQueueFlushState.ts` — event emitter consumed by `ConnectionStateProvider`; [2C-29] will be the producer.
2. `src/lib/connection/classifyError.ts` — heuristic shared by the `QueryCache.subscribe` handler. Future query refactors that throw structured errors with `.status` will sharpen the `server_error` classification without contract changes.
3. `src/lib/connection/store.ts:deriveConnectionState` — pure derivation function. [2C-28] staleness banner will consume `lastSyncedAt` from the same snapshot.

Introducing the writeQueueFlushState contract in [2C-27] (rather than waiting for [2C-29]) lets the consumer side ship with a stable interface. [2C-29] becomes a producer-side wiring change against an established contract rather than a contract + producer + consumer in one PR.

## Test Results

```
npm run test.unit -- --run
...
Test Files  32 passed (32)
     Tests  355 passed (355)
```

```
npm run lint
> brain3-companion@0.0.1 lint
> eslint
[no output — clean]
```

Sixteen new tests added in `src/lib/connection/`:
- `connection.test.ts` — 10 state-transition cases (connected, degraded via 5xx, offline via net-down + last-3-errored, syncing precedence, pulse floor, rolling window, single-5xx-not-degraded, optimistic-on-first-render).
- `connection.staleness.test.ts` — 6 staleness cases (default 5 min, threshold boundary, uniform across query keys, restore on fresh success, threshold constant locus).

## Acceptance Checklist

- [x] `connection.test.ts` covers state-transition cases: net-up + recent-success → connected; net-up + 2× 5xx → degraded; net-up + stale-cache (>5 min) → degraded; net-down → offline; flush-active → syncing.
- [x] `connection.staleness.test.ts` covers staleness threshold default 5 min applied uniformly across query keys; threshold value comes from a single constant in `src/lib/connection/config.ts`.
- [x] Capacitor Network plugin events exercised via mock in tests; real plugin behavior covered in Manual verification (above).
- [x] No regression in [2C-13]'s ping-on-Settings-save behavior — `SettingsPage.handleConnect` still calls `pingHealth` for one-shot validation before `savePairing`; that path is untouched.

Closes #21
