### PR TITLE
[2C-29] App: Write-queue exponential backoff + permanent-failure handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
 import { initWriteQueue } from './lib/writeQueue';
 import { initCompletionQueues } from './lib/completionQueues';
 import { ConnectionStateProvider } from './lib/connection/ConnectionStateProvider';
+import PermanentFailureToast from './components/PermanentFailureToast';
 import {
   clearPendingIntent,
   pendingIntentRoute,
@@ -151,6 +152,7 @@ const App: React.FC = () => (
       <IonApp>
         <DeviceRegistrar />
         <WriteQueueRunner />
+        <PermanentFailureToast />
         <IonReactRouter>
           <PendingIntentRunner />
           <IonRouterOutlet>

--- a/src/components/PermanentFailureToast.tsx
+++ b/src/components/PermanentFailureToast.tsx
@@ -1,0 +1,45 @@
+/**
+ * Foreground toast for [2C-29]'s permanent-failure counter.
+ *
+ * Subscribes to `subscribePermanentFailureToast` and renders a single
+ * passive `IonToast` carrying the new-drops count emitted on app
+ * foreground. Pre-mounted at the app root so a foreground event during
+ * any route can present the toast — the indicator is global, not
+ * page-scoped.
+ *
+ * Per Pass 5 Summary §3 [2C-29] Escalation 3 the surface is intentionally
+ * passive (no buttons, no modal). Detail lives in Settings → Pending sync,
+ * which [2C-30] adds in Wave 2.
+ */
+
+import { useEffect, useState } from 'react';
+import { IonToast } from '@ionic/react';
+import { subscribePermanentFailureToast } from '../lib/writeQueue';
+
+const TOAST_DURATION_MS = 5_000;
+
+function buildMessage(count: number): string {
+  return `${count} pending sync ${count === 1 ? 'item' : 'items'} couldn't be saved. View in Settings → Pending sync.`;
+}
+
+const PermanentFailureToast: React.FC = () => {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    return subscribePermanentFailureToast((next) => {
+      setCount(next);
+    });
+  }, []);
+
+  return (
+    <IonToast
+      isOpen={count !== null}
+      message={count !== null ? buildMessage(count) : ''}
+      duration={TOAST_DURATION_MS}
+      position="bottom"
+      onDidDismiss={() => setCount(null)}
+    />
+  );
+};
+
+export default PermanentFailureToast;

--- a/src/lib/completionQueues.ts
+++ b/src/lib/completionQueues.ts
@@ -29,8 +29,11 @@ import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { Network } from '@capacitor/network';
 import {
+  classifyHttpStatus,
   createWriteQueue,
   flushWriteQueue,
+  parseRetryAfter,
+  readServerMessage,
   type FlushSummary,
   type QueueFlushSummary,
 } from './writeQueue';
@@ -194,28 +197,45 @@ const habitQueue = createWriteQueue<HabitCompletionEntry>(
         return { kind: 'stop' };
       }
 
-      if (response.status === 200 || response.status === 201) {
-        return { kind: 'remove' };
-      }
+      const cls = classifyHttpStatus(response.status);
+      if (cls === 'success') return { kind: 'remove' };
       if (response.status === 400) {
+        // [2C-23]'s habit-paused path: drops + emits a `paused` warning the
+        // habit detail UX surfaces. Stays out of the [2C-29] failures log
+        // per Pass 5 §3 [2C-29] Scope "(except [2C-23]'s habit 400 paused
+        // path which already drops + toasts)".
         const paused = await bodyContainsPaused(response);
         if (paused) {
           emitHabitWarning({ kind: 'paused', habit_id: entry.habit_id });
           return { kind: 'discard' };
         }
-        // Other 400s: malformed payload, etc. Drop to avoid a poison-pill loop
-        // and log; the entry is otherwise unrecoverable on retry.
-        console.warn(
-          `[habitCompletions] dropping ${entry.habit_id}: 400 with non-paused detail`,
-        );
-        return { kind: 'discard' };
       }
-      if (response.status === 404) {
-        console.warn(
-          `[habitCompletions] dropping ${entry.habit_id}: habit not found (404)`,
-        );
-        emitHabitWarning({ kind: 'not_found', habit_id: entry.habit_id });
-        return { kind: 'discard' };
+      if (cls === 'terminal') {
+        if (response.status === 404) {
+          // 404 keeps its [2C-23] not_found warning AND records to the
+          // failures log — habit-specific UX and the cross-queue toast are
+          // independent surfaces.
+          console.warn(
+            `[habitCompletions] dropping ${entry.habit_id}: habit not found (404)`,
+          );
+          emitHabitWarning({ kind: 'not_found', habit_id: entry.habit_id });
+        } else {
+          console.warn(
+            `[habitCompletions] dropping ${entry.habit_id}: terminal ${response.status}`,
+          );
+        }
+        const serverMessage = await readServerMessage(response);
+        return {
+          kind: 'discard',
+          failure: {
+            http_status: response.status,
+            server_message: serverMessage,
+          },
+        };
+      }
+      if (response.status === 429) {
+        const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+        return { kind: 'stop', retryAfterMs };
       }
       return { kind: 'stop' };
     },
@@ -247,24 +267,12 @@ const routineQueue = createWriteQueue<RoutineCompletionEntry>(
         return { kind: 'stop' };
       }
 
-      if (response.status === 200 || response.status === 201) {
-        return { kind: 'remove' };
-      }
-      if (response.status === 404) {
-        console.warn(
-          `[routineCompletions] dropping ${entry.routine_id}: routine not found (404)`,
-        );
-        emitRoutineWarning({
-          kind: 'not_found',
-          routine_id: entry.routine_id,
-          status: entry.status,
-        });
-        return { kind: 'discard' };
-      }
-      if (response.status === 409) {
-        // Server returns 409 for non-active routines. Mirror habit's 400-paused
-        // pattern: log + warn + drop so the queue does not stall on a routine
-        // that was paused or archived after the entry was enqueued.
+      const cls = classifyHttpStatus(response.status);
+      if (cls === 'success') return { kind: 'remove' };
+      if (cls === 'conflict') {
+        // Server returns 409 for non-active routines. Mirrors habit's
+        // 400-paused pattern: routine-specific warning is the visibility
+        // channel, so the entry drops without entering the failures log.
         console.warn(
           `[routineCompletions] dropping ${entry.routine_id}: routine not active (409)`,
         );
@@ -274,6 +282,34 @@ const routineQueue = createWriteQueue<RoutineCompletionEntry>(
           status: entry.status,
         });
         return { kind: 'discard' };
+      }
+      if (cls === 'terminal') {
+        if (response.status === 404) {
+          console.warn(
+            `[routineCompletions] dropping ${entry.routine_id}: routine not found (404)`,
+          );
+          emitRoutineWarning({
+            kind: 'not_found',
+            routine_id: entry.routine_id,
+            status: entry.status,
+          });
+        } else {
+          console.warn(
+            `[routineCompletions] dropping ${entry.routine_id}: terminal ${response.status}`,
+          );
+        }
+        const serverMessage = await readServerMessage(response);
+        return {
+          kind: 'discard',
+          failure: {
+            http_status: response.status,
+            server_message: serverMessage,
+          },
+        };
+      }
+      if (response.status === 429) {
+        const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+        return { kind: 'stop', retryAfterMs };
       }
       return { kind: 'stop' };
     },

--- a/src/lib/connection/writeQueueFlushState.ts
+++ b/src/lib/connection/writeQueueFlushState.ts
@@ -1,48 +1,111 @@
 /**
- * Write-queue flush-state event surface for [2C-27] / [2C-29].
+ * Write-queue flush-state event surface shared by [2C-27] (consumer) and
+ * [2C-29] (producer).
  *
- * [2C-29] will emit `'flushing'` at the start of each non-coalesced flush and
- * `'idle'` after the flush settles. [2C-27]'s connection store subscribes to
- * derive the `syncing` indicator state with the 800 ms pulse cap from
- * `config.ts`.
+ * Two layered surfaces:
  *
- * **First Consumer Instantiates:** [2C-27] introduces this event so its hook
- * can subscribe with a stable interface. [2C-29] is the producer side — it
- * imports `emitFlushState` to publish transitions. Pre-[2C-29] the event
- * never fires, so the connection store sees `flushing: false` indefinitely,
- * which yields a stub `syncing: false` as Pass 5 §3 [2C-27] anticipates.
+ * - **Aggregate `FlushState`** — `'idle' | 'flushing' | 'backoff'`, single
+ *   value derived across all queues. [2C-27]'s connection store subscribes
+ *   via {@link subscribeFlushState} to drive the indicator's `syncing` pulse.
+ *   Backoff is reported as a distinct state from `idle` so future surfaces
+ *   can distinguish "queue settled" from "queue waiting for retry," but
+ *   [2C-27] treats it as not-flushing today (the pulse only fires while a
+ *   flush is actively in progress).
+ *
+ * - **Per-queue `FlushDetail`** — `{ status, queueKey, nextRetryAt }`,
+ *   carries the queue identifier and the timestamp of the next scheduled
+ *   retry. [2C-30] (Settings → Pending sync) will subscribe to surface the
+ *   retry countdown per queue. [2C-29] is the sole producer.
  *
  * Follows the `Set<Listener>` pub-sub convention used throughout this repo
  * (`pairing.ts`, `writeQueue.ts:subscribeConflicts`,
- * `completionQueues.ts:subscribe*Warnings`). Recommended `mitt` from the
- * brief was a suggestion, not a mandate — staying consistent with the
- * existing pattern avoids introducing a dep with no functional gain.
+ * `completionQueues.ts:subscribe*Warnings`). The Pass 5 brief's `mitt`
+ * suggestion was a recommendation, not a mandate — staying consistent with
+ * the existing pattern avoids introducing a dep with no functional gain.
  */
 
-export type FlushState = 'idle' | 'flushing';
+export type FlushState = 'idle' | 'flushing' | 'backoff';
 
-type Listener = (state: FlushState) => void;
-
-const listeners = new Set<Listener>();
-let current: FlushState = 'idle';
-
-export function getFlushState(): FlushState {
-  return current;
+export interface FlushDetail {
+  status: FlushState;
+  queueKey: string;
+  /**
+   * Epoch-milliseconds timestamp of the next scheduled retry when the queue
+   * is in `backoff`, or `null` for `idle` / `flushing`. Settings consumers
+   * can derive a countdown from `nextRetryAt - Date.now()`.
+   */
+  nextRetryAt: number | null;
 }
 
-export function subscribeFlushState(listener: Listener): () => void {
-  listeners.add(listener);
+type AggregateListener = (state: FlushState) => void;
+type DetailListener = (detail: FlushDetail) => void;
+
+const aggregateListeners = new Set<AggregateListener>();
+const detailListeners = new Set<DetailListener>();
+
+const details = new Map<string, FlushDetail>();
+let aggregate: FlushState = 'idle';
+
+function deriveAggregate(): FlushState {
+  let sawBackoff = false;
+  for (const detail of details.values()) {
+    if (detail.status === 'flushing') return 'flushing';
+    if (detail.status === 'backoff') sawBackoff = true;
+  }
+  return sawBackoff ? 'backoff' : 'idle';
+}
+
+export function getFlushState(): FlushState {
+  return aggregate;
+}
+
+export function subscribeFlushState(listener: AggregateListener): () => void {
+  aggregateListeners.add(listener);
   return () => {
-    listeners.delete(listener);
+    aggregateListeners.delete(listener);
   };
 }
 
-export function emitFlushState(state: FlushState): void {
-  current = state;
-  for (const listener of listeners) listener(state);
+export function getFlushDetail(queueKey: string): FlushDetail {
+  return (
+    details.get(queueKey) ?? {
+      status: 'idle',
+      queueKey,
+      nextRetryAt: null,
+    }
+  );
+}
+
+export function getAllFlushDetail(): FlushDetail[] {
+  return Array.from(details.values());
+}
+
+export function subscribeFlushDetail(listener: DetailListener): () => void {
+  detailListeners.add(listener);
+  return () => {
+    detailListeners.delete(listener);
+  };
+}
+
+/**
+ * Publish a per-queue transition. Computes the aggregate `FlushState` and
+ * emits to {@link subscribeFlushState} listeners only when it changes,
+ * keeping the existing single-flag consumer (`ConnectionStateProvider`)
+ * untouched on no-op transitions.
+ */
+export function emitFlushDetail(detail: FlushDetail): void {
+  details.set(detail.queueKey, detail);
+  for (const listener of detailListeners) listener(detail);
+  const next = deriveAggregate();
+  if (next !== aggregate) {
+    aggregate = next;
+    for (const listener of aggregateListeners) listener(aggregate);
+  }
 }
 
 export function __resetFlushStateForTests(): void {
-  listeners.clear();
-  current = 'idle';
+  aggregateListeners.clear();
+  detailListeners.clear();
+  details.clear();
+  aggregate = 'idle';
 }

--- a/src/lib/writeQueue.backoff.test.ts
+++ b/src/lib/writeQueue.backoff.test.ts
@@ -1,0 +1,339 @@
+/**
+ * [2C-29] Exponential-backoff scheduling for write-queue flushes.
+ *
+ * Covers the factory-level retry policy: schedule progression
+ * (30s → 60s → 2m → 4m → 8m → 15m), attempt-counter reset on a delivered
+ * entry, foreground / reachable preemption of the pending timer, and
+ * Retry-After honoring for 429.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn(),
+    register: vi.fn(),
+    addListener: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/device', () => ({
+  Device: {
+    getInfo: vi.fn(async () => ({ model: 'Pixel 8' })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  __resetForTests,
+  BACKOFF_CAP_MS,
+  BACKOFF_INITIAL_DELAY_MS,
+  BACKOFF_MULTIPLIER,
+  createWriteQueue,
+  parseRetryAfter,
+  type FlushOutcome,
+} from './writeQueue';
+import {
+  __resetFlushStateForTests,
+  getFlushDetail,
+  subscribeFlushDetail,
+  type FlushDetail,
+} from './connection/writeQueueFlushState';
+
+const KEY = 'brain.test.backoffQueue';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetForTests();
+  __resetFlushStateForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+interface Entry {
+  id: string;
+}
+
+function makeQueueWithOutcomes(outcomes: FlushOutcome[]): {
+  queue: ReturnType<typeof createWriteQueue<Entry>>;
+  flushCalls: () => number;
+} {
+  let call = 0;
+  const queue = createWriteQueue<Entry>(KEY, {
+    flushOne: async () => {
+      const outcome = outcomes[call] ?? { kind: 'stop' };
+      call += 1;
+      return outcome;
+    },
+  });
+  return { queue, flushCalls: () => call };
+}
+
+describe('createWriteQueue — backoff schedule progression', () => {
+  it('matches the canonical schedule 30s → 60s → 2m → 4m → 8m → 15m', () => {
+    expect(BACKOFF_INITIAL_DELAY_MS).toBe(30_000);
+    expect(BACKOFF_MULTIPLIER).toBe(2);
+    expect(BACKOFF_CAP_MS).toBe(900_000);
+
+    // The cap is hit at attempt 5 (30s * 2^5 = 960s clamped to 900s).
+    const slot = (n: number): number =>
+      Math.min(BACKOFF_INITIAL_DELAY_MS * BACKOFF_MULTIPLIER ** n, BACKOFF_CAP_MS);
+    expect([0, 1, 2, 3, 4, 5, 6].map(slot)).toEqual([
+      30_000,
+      60_000,
+      120_000,
+      240_000,
+      480_000,
+      900_000,
+      900_000,
+    ]);
+  });
+
+  it('schedules the first retry at 30s and progresses to 60s on second halt', async () => {
+    const { queue, flushCalls } = makeQueueWithOutcomes([
+      { kind: 'stop' },
+      { kind: 'stop' },
+      { kind: 'stop' },
+    ]);
+    await queue.enqueue({ id: 'a' });
+
+    await queue.flush();
+    expect(flushCalls()).toBe(1);
+    let detail = getFlushDetail(KEY);
+    expect(detail.status).toBe('backoff');
+    const firstRetryAt = detail.nextRetryAt!;
+    expect(firstRetryAt - Date.now()).toBeGreaterThanOrEqual(29_999);
+    expect(firstRetryAt - Date.now()).toBeLessThanOrEqual(30_001);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(flushCalls()).toBe(2);
+    detail = getFlushDetail(KEY);
+    expect(detail.status).toBe('backoff');
+    expect(detail.nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(59_999);
+    expect(detail.nextRetryAt! - Date.now()).toBeLessThanOrEqual(60_001);
+  });
+
+  it('caps the delay at 15 minutes after the schedule reaches the ceiling', async () => {
+    const stops: FlushOutcome[] = Array.from({ length: 10 }, () => ({
+      kind: 'stop' as const,
+    }));
+    const { queue, flushCalls } = makeQueueWithOutcomes(stops);
+    await queue.enqueue({ id: 'a' });
+
+    await queue.flush();
+    // Advance through 30s, 60s, 2m, 4m, 8m to get to the cap.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(240_000);
+    await vi.advanceTimersByTimeAsync(480_000);
+    expect(flushCalls()).toBe(6);
+    // Next schedule slot would be 960s; capped to 900s.
+    const detail = getFlushDetail(KEY);
+    expect(detail.nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(BACKOFF_CAP_MS - 1);
+    expect(detail.nextRetryAt! - Date.now()).toBeLessThanOrEqual(BACKOFF_CAP_MS + 1);
+
+    await vi.advanceTimersByTimeAsync(BACKOFF_CAP_MS);
+    expect(flushCalls()).toBe(7);
+    // Still at the cap.
+    expect(getFlushDetail(KEY).nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(
+      BACKOFF_CAP_MS - 1,
+    );
+  });
+});
+
+describe('createWriteQueue — backoff reset on success', () => {
+  it('resets the attempt counter to 0 after a flush delivers an entry', async () => {
+    let call = 0;
+    const queue = createWriteQueue<Entry>(KEY, {
+      flushOne: async () => {
+        call += 1;
+        // First flush halts, scheduled retry succeeds, then we enqueue and
+        // halt again to confirm the next schedule restarts at 30s.
+        if (call === 1) return { kind: 'stop' };
+        if (call === 2) return { kind: 'remove' };
+        return { kind: 'stop' };
+      },
+    });
+    await queue.enqueue({ id: 'a' });
+    await queue.flush();
+    expect(getFlushDetail(KEY).nextRetryAt! - Date.now()).toBeLessThanOrEqual(30_001);
+
+    // Retry succeeds — queue drains, attempt resets, status returns to idle.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getFlushDetail(KEY).status).toBe('idle');
+
+    // Re-enqueue + halt → next schedule should be 30s, not 60s.
+    await queue.enqueue({ id: 'b' });
+    await queue.flush();
+    const detail = getFlushDetail(KEY);
+    expect(detail.status).toBe('backoff');
+    expect(detail.nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(29_999);
+    expect(detail.nextRetryAt! - Date.now()).toBeLessThanOrEqual(30_001);
+  });
+
+  it('does not schedule a retry when the queue drains on first flush', async () => {
+    const queue = createWriteQueue<Entry>(KEY, {
+      flushOne: async () => ({ kind: 'remove' }),
+    });
+    await queue.enqueue({ id: 'a' });
+    await queue.enqueue({ id: 'b' });
+
+    const summary = await queue.flush();
+
+    expect(summary.delivered).toBe(2);
+    expect(summary.remaining).toBe(0);
+    expect(getFlushDetail(KEY).status).toBe('idle');
+    expect(getFlushDetail(KEY).nextRetryAt).toBeNull();
+  });
+});
+
+describe('createWriteQueue — preemption', () => {
+  it('cancels the scheduled timer when flush is called manually mid-backoff', async () => {
+    const { queue, flushCalls } = makeQueueWithOutcomes([
+      { kind: 'stop' },
+      { kind: 'remove' },
+    ]);
+    await queue.enqueue({ id: 'a' });
+
+    await queue.flush();
+    expect(flushCalls()).toBe(1);
+
+    // Manual flush before the timer would fire (e.g., foreground or reachable
+    // trigger). The factory cancels its own pending timer at the start of
+    // each flush.
+    await queue.flush();
+    expect(flushCalls()).toBe(2);
+
+    // Advance past the original 30s slot — the canceled timer must NOT fire.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(flushCalls()).toBe(2);
+  });
+
+  it('emits backoff → idle transitions through the FlushDetail surface', async () => {
+    const received: FlushDetail[] = [];
+    subscribeFlushDetail((detail) => received.push(detail));
+
+    const { queue } = makeQueueWithOutcomes([
+      { kind: 'stop' },
+      { kind: 'remove' },
+    ]);
+    await queue.enqueue({ id: 'a' });
+
+    await queue.flush();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const statuses = received.map((d) => d.status);
+    expect(statuses).toContain('flushing');
+    expect(statuses).toContain('backoff');
+    expect(statuses[statuses.length - 1]).toBe('idle');
+    for (const detail of received) {
+      expect(detail.queueKey).toBe(KEY);
+    }
+  });
+});
+
+describe('createWriteQueue — Retry-After override', () => {
+  it('uses retryAfterMs from a stop outcome instead of the natural schedule slot', async () => {
+    let call = 0;
+    const queue = createWriteQueue<Entry>(KEY, {
+      flushOne: async () => {
+        call += 1;
+        if (call === 1) return { kind: 'stop', retryAfterMs: 5_000 };
+        return { kind: 'remove' };
+      },
+    });
+    await queue.enqueue({ id: 'a' });
+
+    await queue.flush();
+    const detail = getFlushDetail(KEY);
+    expect(detail.status).toBe('backoff');
+    expect(detail.nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(4_999);
+    expect(detail.nextRetryAt! - Date.now()).toBeLessThanOrEqual(5_001);
+
+    // The natural 30s slot would have come next — advancing only 5s must
+    // trigger the scheduled retry.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(call).toBe(2);
+  });
+
+  it('falls back to the natural slot when retryAfterMs is null', async () => {
+    const { queue } = makeQueueWithOutcomes([
+      { kind: 'stop', retryAfterMs: null },
+      { kind: 'stop' },
+    ]);
+    await queue.enqueue({ id: 'a' });
+    await queue.flush();
+
+    const detail = getFlushDetail(KEY);
+    expect(detail.nextRetryAt! - Date.now()).toBeGreaterThanOrEqual(29_999);
+    expect(detail.nextRetryAt! - Date.now()).toBeLessThanOrEqual(30_001);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('parses a seconds-int header to milliseconds', () => {
+    expect(parseRetryAfter('5')).toBe(5_000);
+    expect(parseRetryAfter('  30  ')).toBe(30_000);
+    expect(parseRetryAfter('0')).toBe(0);
+  });
+
+  it('clamps values above the cap to the cap', () => {
+    expect(parseRetryAfter('99999')).toBe(BACKOFF_CAP_MS);
+  });
+
+  it('returns null for malformed inputs', () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter('')).toBeNull();
+    expect(parseRetryAfter('abc')).toBeNull();
+    // Date-form Retry-After is intentionally unsupported per Pass 5 §3 [2C-29].
+    expect(parseRetryAfter('Wed, 21 Oct 2026 07:28:00 GMT')).toBeNull();
+    expect(parseRetryAfter('-5')).toBeNull();
+  });
+});

--- a/src/lib/writeQueue.permanentFailure.test.ts
+++ b/src/lib/writeQueue.permanentFailure.test.ts
@@ -1,0 +1,323 @@
+/**
+ * [2C-29] Permanent-failure detection + failures log + foreground toast.
+ *
+ * Covers HTTP-status classification across the three queues' shared
+ * factory, persistence of dropped entries to `brain.writeQueue.failures.*`
+ * with FIFO eviction at the 10-entry cap, and the toast counter's dedup
+ * semantics across foregrounds.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+    getPlatform: vi.fn(() => 'web'),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/network', () => ({
+  Network: {
+    getStatus: vi.fn(async () => ({ connected: true, connectionType: 'wifi' })),
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn(),
+    register: vi.fn(),
+    addListener: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/device', () => ({
+  Device: {
+    getInfo: vi.fn(async () => ({ model: 'Pixel 8' })),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  __resetForTests,
+  acknowledgePermanentFailureToast,
+  checkPermanentFailuresOnForeground,
+  classifyHttpStatus,
+  createWriteQueue,
+  FAILURES_LOG_CAP,
+  readFailures,
+  subscribePermanentFailureToast,
+  type FlushOutcome,
+  type PermanentFailureRecord,
+} from './writeQueue';
+import { __resetFlushStateForTests } from './connection/writeQueueFlushState';
+
+const KEY = 'brain.test.permFailureQueue';
+
+const prefsStore = new Map<string, string>();
+
+interface Entry {
+  id: string;
+}
+
+beforeEach(() => {
+  __resetForTests();
+  __resetFlushStateForTests();
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeQueue(outcomes: FlushOutcome[]): {
+  queue: ReturnType<typeof createWriteQueue<Entry>>;
+} {
+  let call = 0;
+  return {
+    queue: createWriteQueue<Entry>(KEY, {
+      flushOne: async () => {
+        const outcome = outcomes[call] ?? { kind: 'stop' };
+        call += 1;
+        return outcome;
+      },
+    }),
+  };
+}
+
+describe('classifyHttpStatus', () => {
+  it('treats 200/201 as success', () => {
+    expect(classifyHttpStatus(200)).toBe('success');
+    expect(classifyHttpStatus(201)).toBe('success');
+  });
+
+  it('treats 409 as conflict (per-queue UX handles)', () => {
+    expect(classifyHttpStatus(409)).toBe('conflict');
+  });
+
+  it('treats 400/401/403/404/410/422 as terminal', () => {
+    expect(classifyHttpStatus(400)).toBe('terminal');
+    expect(classifyHttpStatus(401)).toBe('terminal');
+    expect(classifyHttpStatus(403)).toBe('terminal');
+    expect(classifyHttpStatus(404)).toBe('terminal');
+    expect(classifyHttpStatus(410)).toBe('terminal');
+    expect(classifyHttpStatus(422)).toBe('terminal');
+  });
+
+  it('treats 408, 429, and 5xx as retryable', () => {
+    expect(classifyHttpStatus(408)).toBe('retryable');
+    expect(classifyHttpStatus(429)).toBe('retryable');
+    expect(classifyHttpStatus(500)).toBe('retryable');
+    expect(classifyHttpStatus(502)).toBe('retryable');
+    expect(classifyHttpStatus(503)).toBe('retryable');
+  });
+
+  it('defaults unknown 4xx (e.g., 405, 411) to retryable to preserve unspecified statuses', () => {
+    expect(classifyHttpStatus(405)).toBe('retryable');
+    expect(classifyHttpStatus(411)).toBe('retryable');
+    expect(classifyHttpStatus(418)).toBe('retryable');
+  });
+});
+
+describe('terminal-status drops record to the failures log', () => {
+  const terminalStatuses = [400, 401, 403, 404, 410, 422] as const;
+  for (const status of terminalStatuses) {
+    it(`drops the entry and writes the failures log for ${status}`, async () => {
+      const { queue } = makeQueue([
+        {
+          kind: 'discard',
+          failure: { http_status: status, server_message: `msg-${status}` },
+        },
+      ]);
+      await queue.enqueue({ id: 'a' });
+
+      const summary = await queue.flush();
+
+      expect(summary.delivered).toBe(0);
+      expect(summary.remaining).toBe(0);
+      const failures = await readFailures<Entry>(KEY);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.http_status).toBe(status);
+      expect(failures[0]?.server_message).toBe(`msg-${status}`);
+      expect(failures[0]?.original_entry).toEqual({ id: 'a' });
+      expect(typeof failures[0]?.dropped_at).toBe('string');
+    });
+  }
+});
+
+describe('retryable-status preserves the entry and halts', () => {
+  it('preserves the entry on a 5xx-shaped stop and does not write the failures log', async () => {
+    const { queue } = makeQueue([{ kind: 'stop' }]);
+    await queue.enqueue({ id: 'a' });
+    await queue.enqueue({ id: 'b' });
+
+    const summary = await queue.flush();
+
+    expect(summary.delivered).toBe(0);
+    expect(summary.remaining).toBe(2);
+    const failures = await readFailures(KEY);
+    expect(failures).toEqual([]);
+    const preserved = await queue.peek();
+    expect(preserved.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('failures-log cap and FIFO eviction', () => {
+  it(`evicts the oldest entry once the log exceeds ${FAILURES_LOG_CAP}`, async () => {
+    const outcomes: FlushOutcome[] = Array.from(
+      { length: FAILURES_LOG_CAP + 3 },
+      (_, i) => ({
+        kind: 'discard' as const,
+        failure: { http_status: 422, server_message: `m-${i}` },
+      }),
+    );
+    const { queue } = makeQueue(outcomes);
+    for (let i = 0; i < outcomes.length; i += 1) {
+      await queue.enqueue({ id: `e-${i}` });
+    }
+
+    await queue.flush();
+
+    const failures = await readFailures<Entry>(KEY);
+    expect(failures).toHaveLength(FAILURES_LOG_CAP);
+    // First three should be evicted; remaining ten are e-3..e-12.
+    expect(failures[0]?.original_entry).toEqual({ id: 'e-3' });
+    expect(failures[FAILURES_LOG_CAP - 1]?.original_entry).toEqual({
+      id: `e-${FAILURES_LOG_CAP + 2}`,
+    });
+  });
+});
+
+describe('foreground toast dedup', () => {
+  it('emits once on first foreground after a new drop, then stays quiet until a new drop arrives', async () => {
+    const observed: number[] = [];
+    subscribePermanentFailureToast((count) => observed.push(count));
+
+    const { queue } = makeQueue([
+      {
+        kind: 'discard',
+        failure: { http_status: 422, server_message: 'bad' },
+      },
+    ]);
+    await queue.enqueue({ id: 'a' });
+    await queue.flush();
+
+    // First foreground after the drop — toast emits with N=1.
+    await checkPermanentFailuresOnForeground();
+    expect(observed).toEqual([1]);
+
+    // Second foreground with no new drops — no emission.
+    await checkPermanentFailuresOnForeground();
+    expect(observed).toEqual([1]);
+
+    // Third foreground after another drop — emits with N=1 (the new one only).
+    const { queue: queue2 } = makeQueue([
+      {
+        kind: 'discard',
+        failure: { http_status: 422, server_message: 'bad2' },
+      },
+    ]);
+    await queue2.enqueue({ id: 'b' });
+    await queue2.flush();
+    await checkPermanentFailuresOnForeground();
+    expect(observed).toEqual([1, 1]);
+  });
+
+  it('counts across queues — three drops across two queues yield a single toast with N=3', async () => {
+    const observed: number[] = [];
+    subscribePermanentFailureToast((count) => observed.push(count));
+
+    const queueA = createWriteQueue<Entry>('brain.test.qA', {
+      flushOne: async () => ({
+        kind: 'discard',
+        failure: { http_status: 422, server_message: 'a' },
+      }),
+    });
+    const queueB = createWriteQueue<Entry>('brain.test.qB', {
+      flushOne: async () => ({
+        kind: 'discard',
+        failure: { http_status: 401, server_message: 'b' },
+      }),
+    });
+    await queueA.enqueue({ id: 'a1' });
+    await queueA.enqueue({ id: 'a2' });
+    await queueB.enqueue({ id: 'b1' });
+
+    await queueA.flush();
+    await queueB.flush();
+
+    await checkPermanentFailuresOnForeground();
+
+    expect(observed).toEqual([3]);
+  });
+
+  it('respects manual acknowledgement — calling acknowledge before foreground suppresses the toast', async () => {
+    const observed: number[] = [];
+    subscribePermanentFailureToast((count) => observed.push(count));
+
+    const { queue } = makeQueue([
+      {
+        kind: 'discard',
+        failure: { http_status: 422, server_message: 'x' },
+      },
+    ]);
+    await queue.enqueue({ id: 'a' });
+    await queue.flush();
+
+    await acknowledgePermanentFailureToast();
+    await checkPermanentFailuresOnForeground();
+
+    expect(observed).toEqual([]);
+  });
+});
+
+describe('failures log shape — for [2C-30] consumption', () => {
+  it('stores entries in chronological order, newest last', async () => {
+    const { queue } = makeQueue([
+      {
+        kind: 'discard',
+        failure: { http_status: 400, server_message: 'first' },
+      },
+      {
+        kind: 'discard',
+        failure: { http_status: 422, server_message: 'second' },
+      },
+    ]);
+    await queue.enqueue({ id: 'a' });
+    await queue.enqueue({ id: 'b' });
+    await queue.flush();
+
+    const failures = await readFailures<Entry>(KEY);
+    expect(failures.map((f: PermanentFailureRecord<Entry>) => f.original_entry.id)).toEqual([
+      'a',
+      'b',
+    ]);
+    expect(failures.map((f) => f.http_status)).toEqual([400, 422]);
+  });
+});

--- a/src/lib/writeQueue.ts
+++ b/src/lib/writeQueue.ts
@@ -8,13 +8,35 @@
  * for habit and routine completion writes ([2C-23]) and any future write
  * pipeline that needs the same offline-first shape.
  *
+ * [2C-29] extends the factory with three additive policies inherited
+ * uniformly by all three queues:
+ *
+ * - **Exponential backoff** between flushes that halt with pending entries.
+ *   30s → 60s → 2m → 4m → 8m → 15m, capped at 15 min. Attempt counter
+ *   resets on any flush that delivers ≥ 1 entry. Per-queue `setTimeout`
+ *   timers are stored in-memory; foreground / network-reachable triggers
+ *   preempt the schedule so a natural reconnection flushes immediately.
+ *
+ * - **Permanent-failure detection.** Adapters classify each HTTP response
+ *   via {@link classifyHttpStatus} and signal a terminal-status drop by
+ *   returning `{ kind: 'discard', failure: {...} }`. The factory persists
+ *   the dropped entry to a per-queue failures log capped at 10 entries
+ *   (FIFO eviction) and increments the total-drops counter that drives the
+ *   foreground toast.
+ *
+ * - **Flush-state event.** Each flush emits per-queue {@link FlushDetail}
+ *   transitions (`idle → flushing → idle` on success; `idle → flushing →
+ *   backoff` on halt with pending entries) through the shared
+ *   `./connection/writeQueueFlushState` surface. [2C-27]'s
+ *   `ConnectionStateProvider` subscribes to the aggregate; [2C-30]'s
+ *   Settings inspection will subscribe to the per-queue detail.
+ *
  * The `[2C-07]` notification-response queue is preserved as a concrete
  * instance of the factory: the `brain.writeQueue` Preferences key, the
- * `WriteQueueEntry` shape, the 200/201/409/error flush semantics, conflict
- * warning emission, and the `initWriteQueue` trigger wiring all behave
- * identically to the pre-refactor module. Callers of `enqueueResponse`,
- * `flushWriteQueue`, `subscribeConflicts`, and `initWriteQueue` see no
- * observable change.
+ * `WriteQueueEntry` shape, the conflict warning emission, and the
+ * `initWriteQueue` trigger wiring all behave identically. The notification
+ * adapter's `flushOne` is updated to classify HTTP statuses uniformly with
+ * the habit and routine adapters via {@link classifyHttpStatus}.
  *
  * See {@link createWriteQueue} for the factory shape and
  * {@link ./completionQueues} for habit/routine consumers.
@@ -27,6 +49,10 @@ import { Preferences } from '@capacitor/preferences';
 import { composeCheckinFromCanned } from './checkin-parser';
 import type { CheckinType } from './checkins';
 import {
+  emitFlushDetail,
+  __resetFlushStateForTests,
+} from './connection/writeQueueFlushState';
+import {
   loadRegisteredToken,
   subscribeRegistration,
 } from './device-registration';
@@ -36,26 +62,128 @@ export const WRITE_QUEUE_KEY = 'brain.writeQueue';
 export const BRIDGE_EVENT_NAME = 'brainCannedResponse';
 export const QUEUE_SOFT_CAP = 500;
 
+/**
+ * Exponential-backoff schedule parameters per Pass 5 Summary Escalation 1.
+ * Schedule: 30s → 60s → 2m → 4m → 8m → 15m, then 15m indefinitely at cap.
+ */
+export const BACKOFF_INITIAL_DELAY_MS = 30_000;
+export const BACKOFF_MULTIPLIER = 2;
+export const BACKOFF_CAP_MS = 900_000;
+
+/** Maximum entries retained in `brain.writeQueue.failures.{queueKey}`. */
+export const FAILURES_LOG_CAP = 10;
+
+const FAILURES_TOTAL_KEY = 'brain.writeQueue.failures.totalDropsCount';
+const FAILURES_SEEN_KEY = 'brain.writeQueue.failures.seenCount';
+
+// ---------------------------------------------------------------------------
+// HTTP classification + Retry-After parsing
+// ---------------------------------------------------------------------------
+
+export type HttpStatusClass =
+  | 'success'
+  | 'conflict'
+  | 'terminal'
+  | 'retryable';
+
+/**
+ * Classify an HTTP status into the four buckets the write-queue policy
+ * cares about. Each adapter calls this on the response status to keep the
+ * policy uniform across queues per Pass 5 Summary §3 [2C-29]:
+ *
+ * - `success` — 200, 201. Entry delivered.
+ * - `conflict` — 409. Per-queue UX (notification conflict bus, habit
+ *   `paused` toast, routine `not_active` warning) handles surfacing; the
+ *   entry is dropped without entering the failures log.
+ * - `terminal` — 400, 401, 403, 404, 410, 422. Drop the entry and persist
+ *   to the failures log so the user sees a foreground toast.
+ * - `retryable` — 408, 429, 5xx. Preserve the entry and halt the flush;
+ *   the factory schedules an exponential-backoff retry.
+ *
+ * Statuses outside these buckets default to `retryable` (halt). 2xx
+ * non-200/201 (204, 207, etc.) classify as `success` so an idempotent
+ * 200-equivalent return from the server still drains the entry.
+ */
+export function classifyHttpStatus(status: number): HttpStatusClass {
+  if (status === 200 || status === 201) return 'success';
+  if (status === 409) return 'conflict';
+  if (
+    status === 400 ||
+    status === 401 ||
+    status === 403 ||
+    status === 404 ||
+    status === 410 ||
+    status === 422
+  ) {
+    return 'terminal';
+  }
+  if (status === 408 || status === 429) return 'retryable';
+  if (status >= 500 && status < 600) return 'retryable';
+  if (status >= 200 && status < 300) return 'success';
+  return 'retryable';
+}
+
+/**
+ * Parse the seconds-int form of `Retry-After` per RFC 7231 §7.1.3 and
+ * convert to milliseconds, clamped to the backoff cap. Returns `null` when
+ * the header is absent or unparseable.
+ *
+ * Date-form `Retry-After` is not supported in v2.0.0 — the BRAIN server
+ * doesn't emit it per Pass 5 Summary §3 [2C-29].
+ *
+ * The lower bound is intentionally `0` (not `BACKOFF_INITIAL_DELAY_MS`) so
+ * a server-honored short retry-after (5s in MV step 4) schedules at the
+ * server's chosen interval rather than the natural 30s slot. See PR body
+ * Deviation #2 for the spec-vs-MV reconciliation.
+ */
+export function parseRetryAfter(headerValue: string | null): number | null {
+  if (headerValue === null) return null;
+  const trimmed = headerValue.trim();
+  if (trimmed === '') return null;
+  if (!/^\d+$/.test(trimmed)) return null;
+  const seconds = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  const ms = seconds * 1000;
+  return Math.min(ms, BACKOFF_CAP_MS);
+}
+
 // ---------------------------------------------------------------------------
 // Generic factory
 // ---------------------------------------------------------------------------
+
+/**
+ * Metadata captured alongside a permanent-failure drop. The adapter
+ * populates this when it returns `{ kind: 'discard', failure }`; the
+ * factory persists it to the failures log and the foreground toast.
+ */
+export interface PermanentFailureMeta {
+  http_status: number;
+  server_message: string | null;
+}
 
 /**
  * Per-entry flush outcome returned by an adapter's {@link WriteQueueAdapter.flushOne}.
  *
  * - `remove` — server delivered the entry (200/201, idempotent re-confirm).
  *   The entry is dropped from the queue and counted as delivered.
- * - `discard` — entry is unrecoverable (404 not-found, 4xx terminal-rejection)
- *   and must be dropped to keep the queue moving. Flush continues, but the
- *   entry is *not* counted as delivered. Adapters typically surface a warning
- *   alongside a discard so the UI can flag what happened.
- * - `stop` — transient failure (network, 5xx, timeout). The entry stays at
- *   the head of the queue and the flush halts to preserve enqueue order.
+ * - `discard` (without `failure`) — entry dropped because a queue-specific
+ *   UX already surfaced the outcome (notification 409 conflict, habit 400
+ *   paused, routine 409 not_active). Not added to the failures log; the
+ *   per-queue warning bus is the visibility channel.
+ * - `discard` (with `failure`) — terminal HTTP status (400/401/403/404/
+ *   410/422). The factory persists the entry + status + message to
+ *   `brain.writeQueue.failures.{queueKey}` and the next foreground toast
+ *   includes it in the count.
+ * - `stop` — transient failure (network, 5xx, 408, 429, timeout). The
+ *   entry stays at the head of the queue and the flush halts to preserve
+ *   enqueue order. When `retryAfterMs` is set (parsed from a 429
+ *   `Retry-After` header), the factory schedules the next retry at that
+ *   exact interval instead of the natural exponential slot.
  */
 export type FlushOutcome =
   | { kind: 'remove' }
-  | { kind: 'discard' }
-  | { kind: 'stop' };
+  | { kind: 'discard'; failure?: PermanentFailureMeta }
+  | { kind: 'stop'; retryAfterMs?: number | null };
 
 export interface WriteQueueAdapter<T> {
   /**
@@ -97,10 +225,229 @@ export interface WriteQueueInstance<T> {
 }
 
 /**
+ * Persistent record of a dropped queue entry, surfaced via Settings →
+ * Pending sync once [2C-30] ships. Generic over the entry type so the
+ * Settings UI can render the original payload alongside the failure cause.
+ */
+export interface PermanentFailureRecord<T = unknown> {
+  original_entry: T;
+  http_status: number;
+  server_message: string | null;
+  dropped_at: string;
+}
+
+interface BackoffState {
+  attempt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  nextRetryAt: number | null;
+}
+
+const backoffStates = new Map<string, BackoffState>();
+const scheduledFlushers = new Map<string, () => Promise<unknown>>();
+
+function backoffStateFor(key: string): BackoffState {
+  let state = backoffStates.get(key);
+  if (!state) {
+    state = { attempt: 0, timer: null, nextRetryAt: null };
+    backoffStates.set(key, state);
+  }
+  return state;
+}
+
+function cancelBackoffTimer(key: string): void {
+  const state = backoffStateFor(key);
+  if (state.timer !== null) {
+    clearTimeout(state.timer);
+    state.timer = null;
+  }
+  state.nextRetryAt = null;
+}
+
+/**
+ * Cancel all pending backoff timers and trigger an immediate flush for any
+ * queue currently waiting. Wired to app-foreground and
+ * network-status-connected events so a natural reconnection preempts the
+ * exponential schedule per Pass 5 Summary §3 [2C-29].
+ */
+function preemptBackoffSchedules(): void {
+  for (const [key, state] of backoffStates.entries()) {
+    if (state.timer === null) continue;
+    clearTimeout(state.timer);
+    state.timer = null;
+    state.nextRetryAt = null;
+    const flusher = scheduledFlushers.get(key);
+    if (flusher) void flusher();
+  }
+}
+
+function delayForAttempt(attempt: number): number {
+  const raw = BACKOFF_INITIAL_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, attempt);
+  return Math.min(raw, BACKOFF_CAP_MS);
+}
+
+function scheduleBackoff(
+  key: string,
+  flush: () => Promise<unknown>,
+  retryAfterMs: number | null,
+): void {
+  const state = backoffStateFor(key);
+  if (state.timer !== null) {
+    clearTimeout(state.timer);
+    state.timer = null;
+  }
+  const delay = retryAfterMs ?? delayForAttempt(state.attempt);
+  state.attempt += 1;
+  state.nextRetryAt = Date.now() + delay;
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    state.nextRetryAt = null;
+    void flush();
+  }, delay);
+  emitFlushDetail({
+    status: 'backoff',
+    queueKey: key,
+    nextRetryAt: state.nextRetryAt,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Failures log + foreground toast counter
+// ---------------------------------------------------------------------------
+
+function failuresKeyFor(queueKey: string): string {
+  return `brain.writeQueue.failures.${queueKey}`;
+}
+
+async function readPreferencesNumber(key: string): Promise<number> {
+  const { value } = await Preferences.get({ key });
+  if (value === null || value === undefined) return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+async function writePreferencesNumber(
+  key: string,
+  value: number,
+): Promise<void> {
+  await Preferences.set({ key, value: String(value) });
+}
+
+async function loadFailuresList(
+  queueKey: string,
+): Promise<PermanentFailureRecord[]> {
+  const { value } = await Preferences.get({ key: failuresKeyFor(queueKey) });
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as PermanentFailureRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function saveFailuresList(
+  queueKey: string,
+  list: PermanentFailureRecord[],
+): Promise<void> {
+  await Preferences.set({
+    key: failuresKeyFor(queueKey),
+    value: JSON.stringify(list),
+  });
+}
+
+/**
+ * Read the persisted recent-failures log for a queue. Returned newest-last;
+ * older entries are evicted at {@link FAILURES_LOG_CAP}.
+ */
+export async function readFailures<T = unknown>(
+  queueKey: string,
+): Promise<PermanentFailureRecord<T>[]> {
+  return (await loadFailuresList(queueKey)) as PermanentFailureRecord<T>[];
+}
+
+async function recordPermanentFailure<T>(
+  queueKey: string,
+  entry: T,
+  failure: PermanentFailureMeta,
+): Promise<void> {
+  const list = await loadFailuresList(queueKey);
+  list.push({
+    original_entry: entry,
+    http_status: failure.http_status,
+    server_message: failure.server_message,
+    dropped_at: new Date().toISOString(),
+  });
+  while (list.length > FAILURES_LOG_CAP) list.shift();
+  await saveFailuresList(queueKey, list);
+  const total = await readPreferencesNumber(FAILURES_TOTAL_KEY);
+  await writePreferencesNumber(FAILURES_TOTAL_KEY, total + 1);
+}
+
+type PermanentFailureToastListener = (count: number) => void;
+
+const toastListeners = new Set<PermanentFailureToastListener>();
+
+/**
+ * Subscribe to the foreground toast event. The listener fires at most once
+ * per foreground, with `count` = drops since the user last saw the toast.
+ * Cleared by acknowledging via {@link acknowledgePermanentFailureToast}.
+ */
+export function subscribePermanentFailureToast(
+  listener: PermanentFailureToastListener,
+): () => void {
+  toastListeners.add(listener);
+  return () => {
+    toastListeners.delete(listener);
+  };
+}
+
+/**
+ * Mark all currently-recorded permanent failures as "seen" so a subsequent
+ * foreground does not re-fire the toast. Called by the toast surface after
+ * presentation; also called implicitly when a fresh foreground emits its
+ * count, so explicit acknowledgement is only required if the surface needs
+ * to dismiss without an emit (e.g., user dismissed during dwell).
+ */
+export async function acknowledgePermanentFailureToast(): Promise<void> {
+  const total = await readPreferencesNumber(FAILURES_TOTAL_KEY);
+  await writePreferencesNumber(FAILURES_SEEN_KEY, total);
+}
+
+/**
+ * Compute the count of new permanent-failure drops since the user last saw
+ * a toast and, if non-zero, advance the seen pointer and emit the toast
+ * event to {@link subscribePermanentFailureToast} listeners. Wired to the
+ * `appStateChange` foreground event by {@link initWriteQueue}; tests and
+ * programmatic callers can invoke directly.
+ */
+export async function checkPermanentFailuresOnForeground(): Promise<void> {
+  const total = await readPreferencesNumber(FAILURES_TOTAL_KEY);
+  const seen = await readPreferencesNumber(FAILURES_SEEN_KEY);
+  if (total <= seen) return;
+  const count = total - seen;
+  await writePreferencesNumber(FAILURES_SEEN_KEY, total);
+  for (const listener of toastListeners) listener(count);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
  * Build a write queue persisted to `@capacitor/preferences` under `key` and
  * flushed via `adapter`. Each instance owns its own concurrency guard — a
  * second call to `flush()` while one is in flight returns immediately with a
  * zero-attempt summary rather than racing the queue.
+ *
+ * [2C-29] additions, applied uniformly to every instance:
+ * - Per-queue backoff state tracked in the module-level
+ *   {@link backoffStates} map keyed by `key`.
+ * - Permanent-failure drops (`{ kind: 'discard', failure }`) persist to
+ *   `brain.writeQueue.failures.{key}` and increment the global toast
+ *   counter.
+ * - Each non-coalesced flush emits `'flushing'` at start and either
+ *   `'idle'` (queue drained) or `'backoff'` (queue halted with pending
+ *   entries) at end, via `emitFlushDetail`.
  */
 export function createWriteQueue<T>(
   key: string,
@@ -140,11 +487,21 @@ export function createWriteQueue<T>(
       return { attempted: 0, delivered: 0, remaining, coalesced: true };
     }
     flushing = true;
+    // Foreground/reachable triggers already cancel pending timers via
+    // preemptBackoffSchedules; cancel defensively here too in case flush is
+    // invoked from an unscheduled path while a timer is pending.
+    cancelBackoffTimer(key);
+    emitFlushDetail({ status: 'flushing', queueKey: key, nextRetryAt: null });
     try {
       if (adapter.shouldFlush) {
         const ok = await adapter.shouldFlush();
         if (!ok) {
           const remaining = (await load()).length;
+          emitFlushDetail({
+            status: 'idle',
+            queueKey: key,
+            nextRetryAt: null,
+          });
           return { attempted: 0, delivered: 0, remaining, coalesced: false };
         }
       }
@@ -152,20 +509,42 @@ export function createWriteQueue<T>(
       let queue = await load();
       let attempted = 0;
       let delivered = 0;
+      let halted = false;
+      let retryAfterOverride: number | null = null;
       while (queue.length > 0) {
         const entry = queue[0]!;
         attempted += 1;
         const outcome = await adapter.flushOne(entry);
-        if (outcome.kind === 'stop') break;
+        if (outcome.kind === 'stop') {
+          halted = true;
+          retryAfterOverride = outcome.retryAfterMs ?? null;
+          break;
+        }
+        if (outcome.kind === 'discard' && outcome.failure) {
+          await recordPermanentFailure(key, entry, outcome.failure);
+        }
         queue = queue.slice(1);
         await save(queue);
         if (outcome.kind === 'remove') delivered += 1;
+      }
+      const state = backoffStateFor(key);
+      if (delivered > 0) state.attempt = 0;
+      if (halted && queue.length > 0) {
+        scheduleBackoff(key, flush, retryAfterOverride);
+      } else {
+        emitFlushDetail({
+          status: 'idle',
+          queueKey: key,
+          nextRetryAt: null,
+        });
       }
       return { attempted, delivered, remaining: queue.length, coalesced: false };
     } finally {
       flushing = false;
     }
   }
+
+  scheduledFlushers.set(key, flush);
 
   async function clear(): Promise<void> {
     await save([]);
@@ -326,6 +705,44 @@ async function readConflictResponse(
   }
 }
 
+/**
+ * Read a server-supplied error message from a response body. Tries common
+ * shapes (`{detail: "..."}`, `{message: "..."}`, plain text) and falls back
+ * to `null` if nothing useful is available. Used to populate the
+ * `server_message` field of the failures log.
+ */
+export async function readServerMessage(
+  response: Response,
+): Promise<string | null> {
+  try {
+    const cloned = response.clone();
+    const text = await cloned.text();
+    if (!text) return null;
+    try {
+      const data = JSON.parse(text) as unknown;
+      if (data && typeof data === 'object') {
+        if (
+          'detail' in data &&
+          typeof (data as { detail: unknown }).detail === 'string'
+        ) {
+          return (data as { detail: string }).detail;
+        }
+        if (
+          'message' in data &&
+          typeof (data as { message: unknown }).message === 'string'
+        ) {
+          return (data as { message: string }).message;
+        }
+      }
+    } catch {
+      // Not JSON — return raw text (capped).
+    }
+    return text.slice(0, 500);
+  } catch {
+    return null;
+  }
+}
+
 const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
   shouldFlush: async () => {
     const [pairing, registered] = await Promise.all([
@@ -348,16 +765,17 @@ const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
     } catch {
       return { kind: 'stop' };
     }
-    const respondDelivered =
-      response.status === 200 || response.status === 201;
-    if (respondDelivered) {
+    const cls = classifyHttpStatus(response.status);
+    if (cls === 'success') {
       // [2C-19] Escalation 2 Option A: `checkin_prompt` entries fire a
       // companion `/api/checkins/` POST after `/respond` succeeds. Treat any
       // network or 5xx failure on the check-in POST as a halt — the entry
       // stays at the head so the next flush retries. Server-side `/respond`
       // is idempotent per [2C-03], so the retry re-sends `/respond` safely.
       // Terminal 4xx on the check-in POST drops to a discard so the queue
-      // doesn't stall on a permanently-bad payload.
+      // doesn't stall on a permanently-bad payload. The check-in POST
+      // failure is wrapped by the parent entry's drop, so it does not log
+      // to the permanent-failures surface independently.
       const checkinPayload = resolveCheckinPayload(entry);
       if (checkinPayload !== null) {
         let checkinResponse: Response;
@@ -366,11 +784,9 @@ const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
         } catch {
           return { kind: 'stop' };
         }
-        if (
-          checkinResponse.status !== 200 &&
-          checkinResponse.status !== 201
-        ) {
-          if (checkinResponse.status >= 400 && checkinResponse.status < 500) {
+        const checkinCls = classifyHttpStatus(checkinResponse.status);
+        if (checkinCls !== 'success') {
+          if (checkinCls === 'terminal') {
             console.warn(
               `[writeQueue] check-in POST rejected (${checkinResponse.status}) for notification ${entry.notification_id}; dropping entry`,
             );
@@ -381,7 +797,7 @@ const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
       }
       return { kind: 'remove' };
     }
-    if (response.status === 409) {
+    if (cls === 'conflict') {
       const serverResponse = await readConflictResponse(response);
       if (serverResponse !== null && serverResponse !== entry.response) {
         emitConflict({
@@ -392,6 +808,18 @@ const notificationQueue = createWriteQueue<WriteQueueEntry>(WRITE_QUEUE_KEY, {
       }
       pendingConflicts += 1;
       return { kind: 'discard' };
+    }
+    if (cls === 'terminal') {
+      const serverMessage = await readServerMessage(response);
+      return {
+        kind: 'discard',
+        failure: { http_status: response.status, server_message: serverMessage },
+      };
+    }
+    // retryable — 408, 429, 5xx. Honor Retry-After for 429.
+    if (response.status === 429) {
+      const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+      return { kind: 'stop', retryAfterMs };
     }
     return { kind: 'stop' };
   },
@@ -429,6 +857,13 @@ let initialised = false;
  * `initCompletionQueues` in `./completionQueues` — the two are independent
  * because the FCM-token gate and the bridge event are notification-specific
  * concerns that should not extend their reach into completion writes.
+ *
+ * [2C-29] additions: app-foreground and `networkStatusChange.connected`
+ * preempt any pending backoff timer across ALL queues (the spec requires
+ * "natural reconnection should flush immediately, not wait for the timer")
+ * and the foreground event additionally checks for new permanent-failure
+ * drops and emits the toast event when at least one new drop has landed
+ * since the user last saw the toast.
  */
 export function initWriteQueue(): () => void {
   if (initialised) return () => undefined;
@@ -437,6 +872,11 @@ export function initWriteQueue(): () => void {
   const cleanups: Array<() => void> = [];
   const safeFlush = (): void => {
     void flushWriteQueue();
+  };
+  const safeOnForeground = (): void => {
+    preemptBackoffSchedules();
+    safeFlush();
+    void checkPermanentFailuresOnForeground();
   };
 
   // Initial drain — picks up entries persisted by the native receiver while
@@ -447,7 +887,7 @@ export function initWriteQueue(): () => void {
     const handlePromise = App.addListener(
       'appStateChange',
       ({ isActive }) => {
-        if (isActive) safeFlush();
+        if (isActive) safeOnForeground();
       },
     );
     cleanups.push(() => {
@@ -460,9 +900,16 @@ export function initWriteQueue(): () => void {
   // event is unreliable — Capacitor's `networkStatusChange` is the
   // authoritative source. The flush-on-reachable contract from [2C-07] is
   // preserved; only the detector changed.
+  //
+  // [2C-29] extension: a connect event preempts every queue's pending
+  // backoff timer so the queues drain at the moment the user observes a
+  // reconnection rather than waiting on the exponential schedule.
   let networkHandle: { remove: () => void } | null = null;
   void Network.addListener('networkStatusChange', (status) => {
-    if (status.connected) safeFlush();
+    if (status.connected) {
+      preemptBackoffSchedules();
+      safeFlush();
+    }
   }).then((handle) => {
     networkHandle = handle;
   });
@@ -497,6 +944,13 @@ export function initWriteQueue(): () => void {
 
 export function __resetForTests(): void {
   conflictListeners.clear();
+  toastListeners.clear();
   pendingConflicts = 0;
   initialised = false;
+  for (const state of backoffStates.values()) {
+    if (state.timer !== null) clearTimeout(state.timer);
+  }
+  backoffStates.clear();
+  scheduledFlushers.clear();
+  __resetFlushStateForTests();
 }


### PR DESCRIPTION
## Verification

- `npm run lint` (eslint) — ✅ Pass (no errors)
- `npm run test.unit -- --run` (vitest) — ✅ Pass (384 passed across 34 files, 29 new in this PR)
- `npx tsc --noEmit` — ✅ Pass (no errors)
- Android sync: ✅ N/A (no Capacitor plugins added — `mitt` was recommended by spec but rejected per Deviation #3 below, so `package.json` is unchanged)

Ran locally against develop HEAD at `ff8b84d` immediately before opening this PR.

## Summary

Augments `createWriteQueue<T>` at `src/lib/writeQueue.ts` with the three offline-hardening policies the Pass 5 spec called out — exponential-backoff retry, terminal-status detection with a per-queue failures log, and a flush-state event surface for the [2C-27] indicator. All three queues (`brain.writeQueue`, `brain.writeQueue.habitCompletions`, `brain.writeQueue.routineCompletions`) inherit the policy uniformly through the shared factory chokepoint.

The factory now tracks per-queue backoff state in-memory (attempt counter + `setTimeout` handle + `nextRetryAt`). On a halt with pending entries it schedules the next retry on the canonical schedule (30s → 60s → 2m → 4m → 8m → 15m, capped at 15 min); the counter resets to 0 on any flush that delivers ≥ 1 entry. Foreground (`appStateChange.isActive`) and network-reachable (`Network.networkStatusChange.connected`) events preempt the pending timer for every queue so a natural reconnection drains immediately.

Adapters now classify each HTTP response via `classifyHttpStatus`. Terminal statuses (400 except `[2C-23]`'s habit-paused path, 401, 403, 404, 410, 422) drop the entry and persist it to `brain.writeQueue.failures.{queueKey}` with a 10-entry FIFO cap. Retryable statuses (408, 429, 5xx, network errors) preserve the entry and halt; 429 honors a seconds-int `Retry-After` header to override the next schedule slot.

A global drops counter feeds a foreground toast: on `appStateChange.isActive`, the factory compares the persisted total against the seen-count Preferences pointer and emits a single passive "N pending sync items couldn't be saved" toast through `subscribePermanentFailureToast`. A new `PermanentFailureToast` component mounted at the app root renders it through `IonToast`.

`writeQueueFlushState` (the surface [2C-27] forward-defined in PR #71) is extended with a `'backoff'` aggregate state and a parallel per-queue `FlushDetail` event carrying `{ status, queueKey, nextRetryAt }`. [2C-27]'s existing `state === 'flushing'` consumer is type-additive-safe — it sees `false` during backoff, which is the correct indicator behavior (the pulse fires only during active flush). [2C-30] will subscribe to the detail surface in Wave 2.

## Changes

- `src/lib/connection/writeQueueFlushState.ts` — extended `FlushState` with `'backoff'`; added `FlushDetail` payload type and `subscribeFlushDetail`/`getFlushDetail`/`getAllFlushDetail`; aggregate is now derived from the union of per-queue details so existing single-flag consumers stay untouched on no-op transitions.
- `src/lib/writeQueue.ts` — added `classifyHttpStatus` and `parseRetryAfter` helpers; extended `FlushOutcome` to carry optional permanent-failure metadata on `discard` and optional `retryAfterMs` on `stop`; added per-queue backoff state map + `scheduleBackoff`/`cancelBackoffTimer`/`preemptBackoffSchedules`; added failures-log read/write/cap utilities + global drops counter + `subscribePermanentFailureToast` / `acknowledgePermanentFailureToast` / `checkPermanentFailuresOnForeground`; wove flush-state event transitions into the `flush()` loop; updated the notification flusher to route through `classifyHttpStatus`; extended `initWriteQueue` listeners to preempt backoff schedules and emit the foreground toast.
- `src/lib/completionQueues.ts` — updated the habit and routine flushers to route through `classifyHttpStatus` and emit permanent-failure metadata uniformly. Existing per-queue UX paths (habit 400-paused, routine 409 not_active) preserve their drop-without-failures-log semantics; previously-unclassified statuses now route through the failures log.
- `src/components/PermanentFailureToast.tsx` — new app-root toast component subscribing to `subscribePermanentFailureToast` and rendering an `IonToast`.
- `src/App.tsx` — mounted `<PermanentFailureToast />` inside `<IonApp>` so foreground emissions surface across all routes.
- `src/lib/writeQueue.backoff.test.ts` — 12 tests covering schedule progression, cap behavior, attempt-counter reset on delivery, preemption on manual flush, flush-state event transitions, Retry-After override, and `parseRetryAfter` edge cases.
- `src/lib/writeQueue.permanentFailure.test.ts` — 17 tests covering `classifyHttpStatus` per status, terminal-status drops + failures-log persistence, retryable-status preservation, failures-log FIFO cap eviction, foreground-toast dedup across foregrounds and across queues, and the manual acknowledgement path.

## How to Verify

1. `git checkout feat/2C-29-queue-backoff-failure && npm install`
2. `npm run lint` — expect no errors
3. `npx tsc --noEmit` — expect no errors
4. `npm run test.unit -- --run` — expect 384 passing across 34 test files (29 new in `writeQueue.backoff.test.ts` and `writeQueue.permanentFailure.test.ts`)
5. Targeted run: `npm run test.unit -- --run src/lib/writeQueue.backoff.test.ts src/lib/writeQueue.permanentFailure.test.ts` — expect 29 passing

Per-device manual verification follows the procedure preserved verbatim from the issue body. The `docs/plane-test.md` reference in MV step 5 ships in [2C-32] (Wave 3); the earlier-wave PR references the path forward.

## Deviations

1. **Test file location.** Spec acceptance criteria name `tests/unit/writeQueue.backoff.spec.ts` and `tests/unit/writeQueue.permanentFailure.spec.ts`. The brain3-companion `CLAUDE.md` Test Conventions section codifies co-located tests as `src/lib/foo.test.ts` and that `tests/unit/` is being phased out — every [2C-23] and [2C-27] test already lives under `src/lib/`. Tests landed at `src/lib/writeQueue.backoff.test.ts` and `src/lib/writeQueue.permanentFailure.test.ts`. CLAUDE.md wins per the inheritance order documented in the org CLAUDE.md "CLAUDE.md Inheritance and Source of Truth" section; the spec intent (write tests covering these scenarios) is preserved.

2. **`Retry-After` clamp lower bound dropped.** Spec technical note says "clamped to `[initialDelayMs, capMs]`" but MV step 4 asserts "the next retry schedules at ~5s rather than the natural 30s schedule slot" for `Retry-After: 5` — a 5s value clamped to `[30s, 15m]` would land at 30s and contradict the MV. Resolved in favor of MV: `parseRetryAfter` clamps to `[0, capMs]` only, honoring the server's chosen retry interval. The factory uses the parsed value as-is when present; otherwise the natural schedule slot applies.

3. **`mitt` rejected; flush-state surface kept at `connection/writeQueueFlushState.ts`.** Spec recommends adding `mitt` to `package.json` and exposing the event from `src/lib/writeQueue.ts`. [2C-27] PR #71 (merged into develop) established `src/lib/connection/writeQueueFlushState.ts` with the `Set<Listener>` pub-sub convention used throughout this repo (`pairing.ts`, `writeQueue.ts:subscribeConflicts`, `completionQueues.ts:subscribe*Warnings`) and explicitly cited the brief's `mitt` suggestion as a recommendation rather than a mandate. Per directive `5cb98368` Shape A (follow the codebase reality, not the imagined state) and the CLAUDE.md "First Consumer Instantiates" pattern, the surface stays where [2C-27] established it; this PR extends the existing module rather than introducing a parallel mitt-based emitter at the spec's literal path. `writeQueue.ts` remains the producer per the spec's intent (it calls `emitFlushDetail`); `package.json` is unchanged (no new dependency).

## First Consumer Instantiates

Three forward-looking hooks are introduced by this PR whose only current consumer is `[2C-29]` itself; flagging here so reviewers can confirm the scaffold belongs in this PR rather than a consuming one:

- `subscribeFlushDetail` / `getFlushDetail` / `getAllFlushDetail` on `connection/writeQueueFlushState` — the producer side is wired here; the near-term consumer is `[2C-30]`'s Settings → Pending sync surface (Wave 2), which subscribes per-queue to render the retry countdown. Defining the shape here keeps the contract testable independently of the consumer.
- `acknowledgePermanentFailureToast` on `writeQueue.ts` — exported as a public API for `[2C-30]`'s Settings disclosure when the user dismisses a failure entry. Today only the producer references it (via `checkPermanentFailuresOnForeground` which auto-advances seen-count on emit), so the explicit-acknowledgement path is unused in this PR.
- `readFailures<T>(queueKey)` on `writeQueue.ts` — exported for `[2C-30]`'s read-only inspection of the recent-failures log per queue. The factory writes the log; this PR has no consumer call sites.

## Test Results

```
$ npm run test.unit -- --run
Test Files  34 passed (34)
Tests       384 passed (384)
Duration    10.96s
```

Targeted run for the new files:

```
$ npm run test.unit -- --run src/lib/writeQueue.backoff.test.ts src/lib/writeQueue.permanentFailure.test.ts
✓ src/lib/writeQueue.permanentFailure.test.ts  (17 tests) 6ms
✓ src/lib/writeQueue.backoff.test.ts  (12 tests) 7ms
Test Files  2 passed (2)
Tests       29 passed (29)
```

## Acceptance Checklist

- [x] `src/lib/writeQueue.backoff.test.ts` covers: schedule progression (30s → 60s → 2m → 4m → 8m → 15m cap), reset on success, preemption on foreground / reachable event, `Retry-After` parsing for 429. _(Test file co-located per Deviation #1.)_
- [x] `src/lib/writeQueue.permanentFailure.test.ts` covers: each terminal status drops the entry and writes to the failures log, retryable statuses preserve the entry, dedup of the foreground toast across multiple foregrounds with no new drops.
- [x] Existing [2C-07] and [2C-23] queue behaviors continue to pass — no changes to entry shapes or flush ordering. All 384 pre-existing tests remain green.
- [x] Failures-log cap enforced (>10 entries → oldest evicted FIFO).
- [x] Exponential-backoff parameters match Escalation 1 constants: `BACKOFF_INITIAL_DELAY_MS = 30_000`, `BACKOFF_MULTIPLIER = 2`, `BACKOFF_CAP_MS = 900_000`.
- [x] Foreground / network-reachable triggers preempt the backoff schedule across all queues.
- [x] Per-queue failures log persisted at `brain.writeQueue.failures.{queueKey}` with the spec'd `{ original_entry, http_status, server_message, dropped_at }` shape.
- [x] `writeQueueFlushState` emits `{ status, queueKey, nextRetryAt }` per Pass 5 §3 [2C-29] (via `emitFlushDetail`; aggregate state remains available via `subscribeFlushState` for [2C-27]).

Closes #22
