### PR TITLE
[2C-28] App: "Last synced" banner + pull-to-refresh on list surfaces

### DIFF
--- a/src/components/StalenessBanner.test.tsx
+++ b/src/components/StalenessBanner.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * [2C-28] StalenessBanner unit tests. Drives the [2C-27] connection store
+ * directly via the test escape hatch so the banner's visibility and copy can
+ * be exercised across all four `ConnectionStatus` values without mounting
+ * the provider or any real plugin listeners.
+ *
+ * Test paths: co-located per repo CLAUDE.md v3 ("Tests are co-located with
+ * the module they test"). Spec named `tests/unit/stalenessBanner.spec.tsx`;
+ * deferring to canonical-source pattern per org-level directive `ba044399`
+ * — flagged as Deviation #1 in the PR body.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import StalenessBanner from './StalenessBanner';
+import {
+  __resetForTests,
+  recordOutcome,
+  setFlushing,
+  setNetworkOnline,
+} from '../lib/connection/store';
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  __resetForTests();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __resetForTests();
+});
+
+function settle(): void {
+  // Banner debounce + any re-renders.
+  act(() => {
+    vi.advanceTimersByTime(300);
+  });
+}
+
+describe('StalenessBanner — visibility', () => {
+  it('is hidden when status is connected', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.queryByTestId('staleness-banner')).toBeNull();
+  });
+
+  it('is hidden when status is syncing', () => {
+    setNetworkOnline(true);
+    setFlushing(true, NOW);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.queryByTestId('staleness-banner')).toBeNull();
+  });
+
+  it('renders when status is offline (network down)', () => {
+    setNetworkOnline(false);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveAttribute(
+      'data-connection-status',
+      'offline',
+    );
+  });
+
+  it('renders when status is degraded (two 5xx in a row)', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW - 1_000);
+    recordOutcome('server_error', ['habits'], NOW);
+    recordOutcome('server_error', ['habits'], NOW + 100);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveAttribute(
+      'data-connection-status',
+      'degraded',
+    );
+  });
+
+  it('debounces visibility transitions by 250 ms', () => {
+    // Start connected.
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW);
+    const { rerender } = render(<StalenessBanner />);
+    settle();
+    expect(screen.queryByTestId('staleness-banner')).toBeNull();
+
+    // Flip to offline; banner does NOT appear immediately.
+    setNetworkOnline(false);
+    rerender(<StalenessBanner />);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.queryByTestId('staleness-banner')).toBeNull();
+
+    // After 250 ms total, banner appears.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.getByTestId('staleness-banner')).toBeInTheDocument();
+  });
+});
+
+describe('StalenessBanner — copy', () => {
+  it('offline + lastSyncedAt → "Showing cached data — last synced X ago"', () => {
+    // 5 minutes ago.
+    setNetworkOnline(false);
+    recordOutcome('success', ['habits'], NOW - 5 * 60 * 1000);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'Showing cached data — last synced 5 minutes ago',
+    );
+  });
+
+  it('offline + null lastSyncedAt → "never synced" copy', () => {
+    setNetworkOnline(false);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'Showing cached data — never synced. Pull down to refresh.',
+    );
+  });
+
+  it('degraded + lastSyncedAt → "Connection issues — last synced X ago"', () => {
+    setNetworkOnline(true);
+    recordOutcome('success', ['habits'], NOW - 2 * 60 * 1000);
+    recordOutcome('server_error', ['habits'], NOW - 1_000);
+    recordOutcome('server_error', ['habits'], NOW);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'Connection issues — last synced 2 minutes ago',
+    );
+  });
+
+  it('per-surface lastSyncedAt prop overrides the hook value', () => {
+    setNetworkOnline(false);
+    // Hook would report NOW - 1 min; surface override is NOW - 15 min.
+    recordOutcome('success', ['habits'], NOW - 60 * 1000);
+    render(<StalenessBanner lastSyncedAt={NOW - 15 * 60 * 1000} />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'last synced 15 minutes ago',
+    );
+  });
+
+  it('per-surface null prop forces "never synced" copy', () => {
+    setNetworkOnline(false);
+    // Hook reports a recent success but the surface explicitly passes null
+    // because its own queries have not loaded yet.
+    recordOutcome('success', ['habits'], NOW - 60 * 1000);
+    render(<StalenessBanner lastSyncedAt={null} />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'never synced',
+    );
+  });
+});
+
+describe('StalenessBanner — degraded + null lastSyncedAt edge case', () => {
+  it('falls through to the "never synced" copy when degraded with no prior success', () => {
+    // Two 5xx in a row with no prior success → degraded + null lastSyncedAt.
+    setNetworkOnline(true);
+    recordOutcome('server_error', ['habits'], NOW);
+    recordOutcome('server_error', ['habits'], NOW + 100);
+    render(<StalenessBanner />);
+    settle();
+    expect(screen.getByTestId('staleness-banner')).toHaveTextContent(
+      'Showing cached data — never synced. Pull down to refresh.',
+    );
+  });
+});

--- a/src/components/StalenessBanner.tsx
+++ b/src/components/StalenessBanner.tsx
@@ -1,0 +1,89 @@
+/**
+ * [2C-28] "Last synced" banner. Slim secondary line rendered under the page
+ * header on list and detail surfaces. Visible only when the [2C-27]
+ * `useConnectionState` reports `degraded` or `offline`; hidden during
+ * `connected` and `syncing`.
+ *
+ * Banner copy follows the Pass 5 spec:
+ *   - offline + lastSyncedAt:    "Showing cached data — last synced Xm ago"
+ *   - offline + null:            "Showing cached data — never synced. Pull down to refresh."
+ *   - degraded + lastSyncedAt:   "Connection issues — last synced Xm ago"
+ *   - degraded + null:           Falls through to the "never synced" copy.
+ *     (Spec is explicit on the offline/null fallback only; degraded with no
+ *     prior success is an edge case that arises if the first 2 API attempts
+ *     return 5xx — using the same copy avoids printing "— ago" with a missing
+ *     timestamp.)
+ *
+ * Visibility transitions are debounced by 250 ms so the banner does not
+ * flash in or out during rapid status flips (e.g., a write-queue flush that
+ * briefly carries the indicator through `syncing` → `connected`).
+ *
+ * Per-surface `lastSyncedAt`: surfaces that compose multiple TanStack queries
+ * (e.g. habit detail = habit + graduation) pass the max of their
+ * `dataUpdatedAt` via the optional `lastSyncedAt` prop. Surfaces that read a
+ * single query (or no TanStack query) can omit the prop and fall back to the
+ * connection hook's global value.
+ */
+
+import { useEffect, useState } from 'react';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { useConnectionState } from '../lib/connection/useConnectionState';
+
+export interface StalenessBannerProps {
+  /**
+   * Per-surface lastSyncedAt timestamp (epoch ms). When provided, takes
+   * precedence over the connection hook's global `lastSyncedAt`. Pass `null`
+   * to explicitly force the "never synced" copy; omit to fall back to the
+   * global value.
+   */
+  lastSyncedAt?: number | null;
+}
+
+const DEBOUNCE_MS = 250;
+
+const StalenessBanner: React.FC<StalenessBannerProps> = ({ lastSyncedAt }) => {
+  const state = useConnectionState();
+  const wantVisible = state.status === 'degraded' || state.status === 'offline';
+  const [visible, setVisible] = useState(wantVisible);
+
+  useEffect(() => {
+    if (wantVisible === visible) return;
+    const id = window.setTimeout(() => setVisible(wantVisible), DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [wantVisible, visible]);
+
+  if (!visible) return null;
+
+  const status: 'degraded' | 'offline' =
+    state.status === 'offline' ? 'offline' : 'degraded';
+  const effective =
+    lastSyncedAt !== undefined ? lastSyncedAt : state.lastSyncedAt;
+
+  return (
+    <div
+      className="px-4 pt-3 pb-2 text-sm text-neutral-300"
+      role="status"
+      aria-live="polite"
+      data-testid="staleness-banner"
+      data-connection-status={status}
+    >
+      {bannerCopy(status, effective)}
+    </div>
+  );
+};
+
+function bannerCopy(
+  status: 'degraded' | 'offline',
+  lastSyncedAt: number | null,
+): string {
+  if (lastSyncedAt === null) {
+    return 'Showing cached data — never synced. Pull down to refresh.';
+  }
+  const ago = formatDistanceToNowStrict(lastSyncedAt);
+  if (status === 'offline') {
+    return `Showing cached data — last synced ${ago} ago`;
+  }
+  return `Connection issues — last synced ${ago} ago`;
+}
+
+export default StalenessBanner;

--- a/src/lib/connection/useSurfaceLastSync.test.tsx
+++ b/src/lib/connection/useSurfaceLastSync.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * [2C-28] useSurfaceLastSync — co-located helper test. Exercises the
+ * Math.max-over-`dataUpdatedAt` logic by populating a real QueryClient
+ * cache (no provider needed; the hook is a synchronous read).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useSurfaceLastSync } from './useSurfaceLastSync';
+
+let client: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  client = new QueryClient();
+});
+
+afterEach(() => {
+  client.clear();
+});
+
+describe('useSurfaceLastSync', () => {
+  it('returns null when no key has been fetched', () => {
+    const { result } = renderHook(
+      () => useSurfaceLastSync([['habit', 'a'], ['habit-graduation', 'a']]),
+      { wrapper },
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the single dataUpdatedAt when only one key has been fetched', () => {
+    const t = 1_700_000_000_000;
+    client.setQueryData(['habit', 'a'], { id: 'a' }, { updatedAt: t });
+    const { result } = renderHook(
+      () => useSurfaceLastSync([['habit', 'a'], ['habit-graduation', 'a']]),
+      { wrapper },
+    );
+    expect(result.current).toBe(t);
+  });
+
+  it('returns the max across multiple keys', () => {
+    const t1 = 1_700_000_000_000;
+    const t2 = t1 + 5_000;
+    client.setQueryData(['habit', 'a'], { id: 'a' }, { updatedAt: t1 });
+    client.setQueryData(
+      ['habit-graduation', 'a'],
+      { status: 'accountable' },
+      { updatedAt: t2 },
+    );
+    const { result } = renderHook(
+      () => useSurfaceLastSync([['habit', 'a'], ['habit-graduation', 'a']]),
+      { wrapper },
+    );
+    expect(result.current).toBe(t2);
+  });
+
+  it('accepts an empty key list', () => {
+    const { result } = renderHook(() => useSurfaceLastSync([]), { wrapper });
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/lib/connection/useSurfaceLastSync.ts
+++ b/src/lib/connection/useSurfaceLastSync.ts
@@ -1,0 +1,32 @@
+/**
+ * [2C-28] per-surface `lastSyncedAt` helper. Returns `Math.max(...)` across
+ * the `dataUpdatedAt` of the passed TanStack Query keys, or `null` when none
+ * has been fetched.
+ *
+ * Surfaces composing multiple queries (e.g., habit detail = habit +
+ * graduation) call this and pass the result to the StalenessBanner's
+ * `lastSyncedAt` prop. Surfaces with a single query — or none — can omit the
+ * banner prop and fall back to the connection hook's global
+ * `lastSyncedAt`.
+ *
+ * No subscription: this returns a synchronous read from the QueryClient on
+ * each render. Callers must already re-render when the relevant queries
+ * update (which they do automatically when they consume `useQuery` for the
+ * same keys). The connection hook + provider drive the broader connection
+ * state; this helper is just a per-surface granularity hook on top of the
+ * existing TanStack cache.
+ */
+
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
+
+export function useSurfaceLastSync(keys: readonly QueryKey[]): number | null {
+  const client = useQueryClient();
+  let max = -1;
+  for (const key of keys) {
+    const state = client.getQueryState(key);
+    if (state && state.dataUpdatedAt > max) {
+      max = state.dataUpdatedAt;
+    }
+  }
+  return max > 0 ? max : null;
+}

--- a/src/pages/CheckinsPage.test.tsx
+++ b/src/pages/CheckinsPage.test.tsx
@@ -245,7 +245,7 @@ describe('CheckinsPage — navigation', () => {
 });
 
 describe('CheckinsPage — offline cache', () => {
-  it('renders cached items + cache hint when the network fetch fails', async () => {
+  it('renders cached items from initialData when the network fetch fails', async () => {
     pair();
     seedCache([
       makeCheckin({
@@ -258,11 +258,11 @@ describe('CheckinsPage — offline cache', () => {
 
     renderPage();
 
+    // Cache-fallback affordance: cached rows render. The "this is cached"
+    // affordance moved to the [2C-28] StalenessBanner (connection-state
+    // gated; covered in StalenessBanner.test.tsx).
     expect(await screen.findByText('Midday check-in')).toBeInTheDocument();
     expect(screen.getByText('cached entry')).toBeInTheDocument();
-    expect(
-      await screen.findByText(/showing cached data/i),
-    ).toBeInTheDocument();
   });
 });
 

--- a/src/pages/CheckinsPage.tsx
+++ b/src/pages/CheckinsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { useHistory } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   composeNumericSubtitle,
@@ -144,8 +145,6 @@ const CheckinsBody: React.FC<BodyProps> = ({
   });
 
   const items = checkinsQuery.data;
-  const showCacheHint =
-    checkinsQuery.isError && items !== undefined && items.length >= 0;
 
   const handleRefresh = useCallback(
     async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
@@ -171,15 +170,7 @@ const CheckinsBody: React.FC<BodyProps> = ({
         <IonRefresherContent />
       </IonRefresher>
 
-      {showCacheHint ? (
-        <div
-          className="px-4 pt-3 text-sm text-neutral-300"
-          role="status"
-          aria-live="polite"
-        >
-          Showing cached data
-        </div>
-      ) : null}
+      <StalenessBanner />
 
       {items !== undefined && items.length === 0 ? (
         <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">

--- a/src/pages/HabitDetailPage.tsx
+++ b/src/pages/HabitDetailPage.tsx
@@ -29,7 +29,9 @@ import { format, formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { useHistory, useParams } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import StatusPill from '../components/StatusPill';
+import { useSurfaceLastSync } from '../lib/connection/useSurfaceLastSync';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   fetchHabitCompletions,
@@ -253,10 +255,13 @@ const DetailBody: React.FC<BodyProps> = ({
   const habit = habitQuery.data;
   const graduation = graduationQuery.data;
   const completions = completionsQuery.data;
-  const showCacheHint =
-    habitQuery.isError &&
-    !isNotFoundError(habitQuery.error) &&
-    habit !== undefined;
+  // Per Pass 5 §3 [2C-28]: habit detail composes two cached queries; the
+  // banner reads the max `dataUpdatedAt` across both so the displayed
+  // "last synced X ago" matches the most recent of habit + graduation.
+  const surfaceLastSync = useSurfaceLastSync([
+    HABIT_QUERY_KEY(habitId),
+    HABIT_GRADUATION_QUERY_KEY(habitId),
+  ]);
 
   // Wire the [2C-23] habit-completion warning subscription. Per the Group 3
   // close ledger this surface lands in [2C-25] alongside the routine warning
@@ -506,15 +511,7 @@ const DetailBody: React.FC<BodyProps> = ({
         <IonRefresherContent />
       </IonRefresher>
 
-      {showCacheHint ? (
-        <div
-          className="px-4 pt-3 text-sm text-neutral-300"
-          role="status"
-          aria-live="polite"
-        >
-          Showing cached data
-        </div>
-      ) : null}
+      <StalenessBanner lastSyncedAt={surfaceLastSync} />
 
       <DefinitionPane
         habit={habit}

--- a/src/pages/HabitsPage.refresh.test.tsx
+++ b/src/pages/HabitsPage.refresh.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * [2C-28] pull-to-refresh integration test on the representative list
+ * surface (habit list per Pass 5 §3 [2C-28] Acceptance criteria item 2).
+ *
+ * Spec named the path `tests/integration/pullToRefresh.spec.tsx`; co-located
+ * here per repo CLAUDE.md v3 ("Tests are co-located with the module they
+ * test") and org directive `ba044399` (specs defer to canonical-source
+ * conventions on test paths). Flagged as Deviation #1 in the PR body.
+ *
+ * What this test covers:
+ *   - The IonRefresher's `ionRefresh` event triggers a TanStack Query
+ *     refetch (asserted via a second `fetch` call to the habits endpoint).
+ *   - On successful refetch, the connection store records a `success`
+ *     outcome which the StalenessBanner observes via `useConnectionState`.
+ *   - The banner copy reflects the updated `lastSyncedAt` once the refetch
+ *     completes (the banner is visible when the test forces the indicator
+ *     into a degraded/offline state before the refresh).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+vi.mock('../lib/completionQueues', () => ({
+  enqueueHabitCompletion: vi.fn(),
+  flushAllQueues: vi.fn(),
+}));
+
+vi.mock('../lib/local-date', async () => {
+  const actual = await vi.importActual<typeof import('../lib/local-date')>(
+    '../lib/local-date',
+  );
+  return {
+    ...actual,
+    todayLocalDate: () => '2026-05-02',
+  };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { type HabitResponse } from '../lib/habits';
+import { PAIRING_TOKEN_KEY, PAIRING_URL_KEY } from '../lib/pairing';
+import HabitsPage from './HabitsPage';
+import {
+  __resetForTests,
+  recordOutcome,
+  setNetworkOnline,
+} from '../lib/connection/store';
+
+const PAIRED_URL = 'https://brain.local:8000';
+const PAIRED_TOKEN = 'tk-1';
+
+const prefsStore = new Map<string, string>();
+
+function pair(): void {
+  prefsStore.set(PAIRING_URL_KEY, PAIRED_URL);
+  prefsStore.set(PAIRING_TOKEN_KEY, PAIRED_TOKEN);
+}
+
+function makeHabit(id: string, title: string): HabitResponse {
+  return {
+    id,
+    routine_id: null,
+    title,
+    description: null,
+    status: 'active',
+    frequency: 'daily',
+    notification_frequency: 'daily',
+    scaffolding_status: 'tracking',
+    accountable_since: null,
+    graduation_window: null,
+    graduation_target: null,
+    graduation_threshold: null,
+    friction_score: null,
+    position: null,
+    re_scaffold_count: 0,
+    last_frequency_changed_at: null,
+    graduated_at: null,
+    current_streak: 1,
+    best_streak: 1,
+    last_completed: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    effective_graduation_params: {
+      window_days: 30,
+      target_rate: 0.8,
+      threshold_days: 5,
+      source: 'friction_default',
+    },
+  };
+}
+
+beforeEach(() => {
+  __resetForTests();
+  prefsStore.clear();
+
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetForTests();
+});
+
+function renderPage(client: QueryClient) {
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/habits']}>
+        <HabitsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('HabitsPage — pull-to-refresh wires StalenessBanner refresh', () => {
+  it('refetches the habits query and updates banner copy after success', async () => {
+    pair();
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ items: [makeHabit('h-1', 'Stretch')], count: 1 }), {
+          status: 200,
+        }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    // Subscribe the connection store to the test QueryClient's cache so
+    // refetch successes are recorded as outcomes (mirrors the
+    // ConnectionStateProvider's wiring without mounting the provider).
+    const cache = client.getQueryCache();
+    const unsubscribe = cache.subscribe((event) => {
+      if (event.type !== 'updated') return;
+      if (event.action.type === 'success') {
+        recordOutcome('success', event.query.queryKey);
+      } else if (event.action.type === 'error') {
+        recordOutcome('network_error', event.query.queryKey);
+      }
+    });
+
+    // Force the banner into "offline" so the StalenessBanner is visible
+    // before the refresh — the test asserts the copy updates after the
+    // refresh refreshes the connection store's `lastSyncedAt`.
+    setNetworkOnline(false);
+
+    try {
+      renderPage(client);
+
+      // Initial paint: the habit row appears once the first fetch resolves.
+      expect(await screen.findByText('Stretch')).toBeInTheDocument();
+
+      // The banner is visible — debounce expires after the initial render.
+      const banner = await waitFor(
+        () => screen.findByTestId('staleness-banner'),
+      );
+      expect(banner).toBeInTheDocument();
+
+      const initialFetchCount = fetchSpy.mock.calls.filter((c) => {
+        const url = typeof c[0] === 'string' ? c[0] : c[0]?.toString() ?? '';
+        return url.includes('/api/habits/');
+      }).length;
+      expect(initialFetchCount).toBeGreaterThanOrEqual(1);
+
+      // Fire the IonRefresher's `ionRefresh` event. The handler captures the
+      // CustomEvent and calls `event.detail.complete()` to dismiss the
+      // spinner — supply a `complete` spy so we can assert dismissal.
+      const refresher = document.querySelector('ion-refresher');
+      expect(refresher).not.toBeNull();
+      const completeSpy = vi.fn();
+      await act(async () => {
+        refresher!.dispatchEvent(
+          new CustomEvent('ionRefresh', {
+            detail: { complete: completeSpy },
+            bubbles: true,
+          }),
+        );
+        // Allow the awaited refetch + the post-refetch state updates to flush.
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The refetch triggered another habits call.
+      await waitFor(() => {
+        const calls = fetchSpy.mock.calls.filter((c) => {
+          const url = typeof c[0] === 'string' ? c[0] : c[0]?.toString() ?? '';
+          return url.includes('/api/habits/');
+        });
+        expect(calls.length).toBeGreaterThan(initialFetchCount);
+      });
+
+      // The IonRefresher dismissed its spinner.
+      await waitFor(() => expect(completeSpy).toHaveBeenCalled());
+
+      // The banner is still mounted (still offline). The copy should now
+      // reflect a fresh `lastSyncedAt` ("0 seconds ago"-style strict
+      // duration) since the connection store recorded the success.
+      const bannerCopy = screen.getByTestId('staleness-banner').textContent ?? '';
+      expect(bannerCopy).toMatch(/Showing cached data — last synced .* ago/);
+      expect(bannerCopy).not.toMatch(/never synced/);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/src/pages/HabitsPage.test.tsx
+++ b/src/pages/HabitsPage.test.tsx
@@ -411,7 +411,7 @@ describe('HabitsPage — quick-complete optimistic flip', () => {
 });
 
 describe('HabitsPage — offline cache render', () => {
-  it('renders cached items and the cache hint when the network fetch fails', async () => {
+  it('renders cached items from initialData when the network fetch fails', async () => {
     pair();
     seedCache([
       makeHabit({
@@ -426,12 +426,10 @@ describe('HabitsPage — offline cache render', () => {
 
     renderPage();
 
-    // Cached item paints immediately from initialData.
+    // Cached item paints immediately from initialData. The user-facing
+    // "this is cached" affordance is the [2C-28] StalenessBanner, which is
+    // connection-state gated (covered in StalenessBanner.test.tsx) rather
+    // than gated on a single failed fetch as the prior inline hint was.
     expect(await screen.findByText('Cached habit')).toBeInTheDocument();
-
-    // The fetch failure surfaces the cache hint.
-    expect(
-      await screen.findByText(/showing cached data/i),
-    ).toBeInTheDocument();
   });
 });

--- a/src/pages/HabitsPage.tsx
+++ b/src/pages/HabitsPage.tsx
@@ -28,6 +28,7 @@ import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { useHistory } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import StatusPill from '../components/StatusPill';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
@@ -168,8 +169,6 @@ const HabitsBody: React.FC<BodyProps> = ({
   });
 
   const items = habitsQuery.data;
-  const showCacheHint =
-    habitsQuery.isError && items !== undefined && items.length >= 0;
 
   const partitioned = useMemo(
     () => (items ? partitionAndSortHabits(items) : null),
@@ -254,15 +253,7 @@ const HabitsBody: React.FC<BodyProps> = ({
         <IonRefresherContent />
       </IonRefresher>
 
-      {showCacheHint ? (
-        <div
-          className="px-4 pt-3 text-sm text-neutral-300"
-          role="status"
-          aria-live="polite"
-        >
-          Showing cached data
-        </div>
-      ) : null}
+      <StalenessBanner />
 
       {partitioned &&
       partitioned.primary.length === 0 &&

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { format, parseISO } from 'date-fns';
 import { useHistory } from 'react-router-dom';
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   fetchNotifications,
@@ -233,18 +234,10 @@ const NotificationsPage: React.FC = () => {
           </div>
         ) : null}
 
+        <StalenessBanner />
+
         {state.kind === 'ready' && partition ? (
           <>
-            {state.fromCache ? (
-              <div
-                className="px-4 pt-3 text-sm text-neutral-300"
-                role="status"
-                aria-live="polite"
-              >
-                Showing cached data
-              </div>
-            ) : null}
-
             <IonList>
               <IonListHeader>
                 <IonLabel>

--- a/src/pages/RoutineDetailPage.tsx
+++ b/src/pages/RoutineDetailPage.tsx
@@ -30,6 +30,7 @@ import { format, formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { useHistory, useParams } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   fetchRoutineDetail,
@@ -301,11 +302,6 @@ const DetailBody: React.FC<BodyProps> = ({
     return () => unsubscribe();
   }, [routineId]);
 
-  const showCacheHint =
-    routineQuery.isError &&
-    !isNotFoundError(routineQuery.error) &&
-    routine !== undefined;
-
   const handleRefresh = useCallback(
     async (event: CustomEvent<RefresherEventDetail>): Promise<void> => {
       try {
@@ -479,15 +475,7 @@ const DetailBody: React.FC<BodyProps> = ({
           <IonRefresherContent />
         </IonRefresher>
 
-        {showCacheHint ? (
-          <div
-            className="px-4 pt-3 text-sm text-neutral-300"
-            role="status"
-            aria-live="polite"
-          >
-            Showing cached data
-          </div>
-        ) : null}
+        <StalenessBanner />
 
         <HeaderPane routine={routine} />
 

--- a/src/pages/RoutinesPage.test.tsx
+++ b/src/pages/RoutinesPage.test.tsx
@@ -324,7 +324,7 @@ describe('RoutinesPage — navigation', () => {
 });
 
 describe('RoutinesPage — offline cache render', () => {
-  it('renders cached items and the cache hint when the network fetch fails', async () => {
+  it('renders cached items from initialData when the network fetch fails', async () => {
     pair();
     seedCache([
       makeRoutine({
@@ -338,12 +338,9 @@ describe('RoutinesPage — offline cache render', () => {
 
     renderPage();
 
-    // Cached item paints immediately from initialData.
+    // Cached item paints immediately from initialData. The "this is cached"
+    // affordance moved to the [2C-28] StalenessBanner (connection-state
+    // gated; covered in StalenessBanner.test.tsx).
     expect(await screen.findByText('Cached routine')).toBeInTheDocument();
-
-    // The fetch failure surfaces the cache hint.
-    expect(
-      await screen.findByText(/showing cached data/i),
-    ).toBeInTheDocument();
   });
 });

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -22,6 +22,7 @@ import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { useHistory } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   fetchActiveRoutines,
@@ -158,8 +159,6 @@ const RoutinesBody: React.FC<BodyProps> = ({
   });
 
   const items = routinesQuery.data;
-  const showCacheHint =
-    routinesQuery.isError && items !== undefined && items.length >= 0;
 
   const sortedItems = useMemo(
     () => (items ? sortRoutinesByTitle(items) : null),
@@ -190,15 +189,7 @@ const RoutinesBody: React.FC<BodyProps> = ({
         <IonRefresherContent />
       </IonRefresher>
 
-      {showCacheHint ? (
-        <div
-          className="px-4 pt-3 text-sm text-neutral-300"
-          role="status"
-          aria-live="polite"
-        >
-          Showing cached data
-        </div>
-      ) : null}
+      <StalenessBanner />
 
       {sortedItems && sortedItems.length === 0 ? (
         <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">

--- a/src/pages/RuleDetailPage.tsx
+++ b/src/pages/RuleDetailPage.tsx
@@ -24,6 +24,7 @@ import { useHistory, useParams } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
 import RuleEnabledPill from '../components/RuleEnabledPill';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   fetchRule,
@@ -199,6 +200,8 @@ const DetailBody: React.FC<BodyProps> = ({ ruleId, pairing }) => {
       <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
         <IonRefresherContent />
       </IonRefresher>
+
+      <StalenessBanner />
 
       <DefinitionPane rule={rule} onCopyEntityId={onCopyEntityId} />
 

--- a/src/pages/RulesPage.test.tsx
+++ b/src/pages/RulesPage.test.tsx
@@ -266,7 +266,7 @@ describe('RulesPage — navigation', () => {
 });
 
 describe('RulesPage — offline cache', () => {
-  it('renders cached items + cache hint when the network fetch fails', async () => {
+  it('renders cached items from initialData when the network fetch fails', async () => {
     pair();
     seedCache([
       makeRule({ id: 'r-cached', name: 'Cached rule', enabled: true }),
@@ -275,10 +275,10 @@ describe('RulesPage — offline cache', () => {
 
     renderPage();
 
+    // Cache-fallback affordance: cached row renders. The "this is cached"
+    // user signal moved to the [2C-28] StalenessBanner (connection-state
+    // gated; covered in StalenessBanner.test.tsx).
     expect(await screen.findByText('Cached rule')).toBeInTheDocument();
-    expect(
-      await screen.findByText(/showing cached data/i),
-    ).toBeInTheDocument();
   });
 });
 

--- a/src/pages/RulesPage.tsx
+++ b/src/pages/RulesPage.tsx
@@ -19,6 +19,7 @@ import { useHistory } from 'react-router-dom';
 
 import ConnectionIndicator from '../components/ConnectionIndicator';
 import RuleEnabledPill from '../components/RuleEnabledPill';
+import StalenessBanner from '../components/StalenessBanner';
 import { loadPairing, type Pairing } from '../lib/pairing';
 import {
   RULES_QUERY_KEY,
@@ -140,8 +141,6 @@ const RulesBody: React.FC<BodyProps> = ({
   });
 
   const items = rulesQuery.data;
-  const showCacheHint =
-    rulesQuery.isError && items !== undefined && items.length >= 0;
 
   const sorted = useMemo(
     () => (items ? sortRulesForList(items) : null),
@@ -172,15 +171,7 @@ const RulesBody: React.FC<BodyProps> = ({
         <IonRefresherContent />
       </IonRefresher>
 
-      {showCacheHint ? (
-        <div
-          className="px-4 pt-3 text-sm text-neutral-300"
-          role="status"
-          aria-live="polite"
-        >
-          Showing cached data
-        </div>
-      ) : null}
+      <StalenessBanner />
 
       {sorted !== null && sorted.length === 0 ? (
         <div className="flex h-full w-full items-center justify-center px-4 text-center text-neutral-300">


### PR DESCRIPTION
## Verification

- `npx tsc --noEmit` — ✅ Pass (no errors)
- `npm run lint` — ✅ Pass (0 errors, 0 warnings)
- `npx vitest run` — ✅ Pass (400 passed, 37 test files, 11.57s)
- Postgres-backed test confirmed: n/a (client-only ticket)
- Migration applied locally on brain3-dev: n/a (client-only ticket)

Ran locally against develop HEAD at `cacba96` immediately before opening this PR.

## Summary

Adds a single staleness banner that surfaces "this is cached data" across the 8 unique list/detail pages in the companion app. The banner reads the [2C-27] `useConnectionState` hook and renders only when the derived status is `degraded` or `offline`. Pull-to-refresh wiring was already present on every spec'd surface from earlier Stream C work — this PR audits each, removes the pre-existing per-page inline "Showing cached data" hints, and replaces them with one centrally-tested component.

Also adds a small `useSurfaceLastSync(...keys)` helper so surfaces that compose multiple TanStack queries (habit detail: habit + graduation) can show a per-surface `lastSyncedAt` rather than the connection hook's global value.

## Changes

- `src/components/StalenessBanner.tsx` — slim secondary line under the page header; visible on `degraded` / `offline`, hidden on `connected` / `syncing`; 250 ms debounce on visibility flips; accepts an optional `lastSyncedAt` prop that overrides the connection hook's global value.
- `src/lib/connection/useSurfaceLastSync.ts` — returns `Math.max(dataUpdatedAt)` across the passed TanStack query keys, or `null` when none has been fetched. Synchronous read; relies on the caller's `useQuery` consumers to re-render on cache changes.
- 8 page files wired with `<StalenessBanner />` mounted directly after `<IonRefresher>` and before the surface's content. The pre-existing inline `showCacheHint` blocks on 7 of these surfaces are removed — the spec explicitly identifies them as the v1 affordance the banner promotes to global ("Pass 4 Summary §[2C-22] (cached-data hint behavior — Chunk 5 promotes to global banner)").
- `HabitDetailPage.tsx` additionally uses `useSurfaceLastSync` over the `['habit', id]` and `['habit-graduation', id]` keys and passes the result to the banner.
- 4 page tests had assertions on the old inline hint string (single-fetch-errored gate). They drop those assertions; the cache-fallback behavior remains tested via the "cached row renders" assertion in each. The banner copy + gating is covered centrally in `StalenessBanner.test.tsx`.
- New integration test `HabitsPage.refresh.test.tsx` covers the representative pull-to-refresh path (AC #2): pull gesture triggers TanStack `refetch`, the `IonRefresher`'s `complete` is invoked, the connection store records the refetch success, banner copy updates.

## How to Verify

Automated:

1. From the repo root, `git checkout feat/2C-28-staleness-banner`.
2. `npm install` (no new dependencies, but lockfile-aware tooling helps).
3. `npx tsc --noEmit` — passes clean.
4. `npm run lint` — passes clean.
5. `npx vitest run` — 400 passed across 37 files.

Manual: see `Manual verification` in issue #23 — five steps requiring airplane-mode toggling + a 5xx force on a dev surface. The plane-test harness ([2C-32]) will be the canonical home for the full procedure; this PR ships pre-[2C-32] so the steps are followed directly from the issue body.

## Deviations

1. **Test paths.** Pass 5 §3 [2C-28] AC names `tests/unit/stalenessBanner.spec.tsx` and `tests/integration/pullToRefresh.spec.tsx`. The repo's `tests/` directory does not exist; every existing test in the codebase is co-located with its module (e.g. `src/lib/connection/connection.test.ts`). Repo CLAUDE.md v3 ("Test Conventions") canonicalizes this: "Tests are co-located with the module they test. Pattern: `src/lib/foo.ts` → `src/lib/foo.test.ts`. Do NOT introduce new files in `tests/unit/` — that directory is being phased out." Per org directive `ba044399` (specs defer to repo CLAUDE.md on test paths), tests land at:
   - `src/components/StalenessBanner.test.tsx`
   - `src/lib/connection/useSurfaceLastSync.test.tsx`
   - `src/pages/HabitsPage.refresh.test.tsx`

2. **Surface count: spec lists 9, implementation wires 8 unique pages.** [2C-17] "Pattern observation filter" (spec surface 7) is the `IonSegment` filter view on `NotificationsPage.tsx` (per issue #12 §Scope: "Extend [2C-09]'s `/notifications` view with a filter control" — no separate page). The banner wiring on `NotificationsPage` covers both spec surface 1 (Notifications list) and surface 7 (Pattern observation filter view). 8 file-level edits map to 9 spec'd UX surfaces.

3. **Inline cache-hint trigger semantics shifted.** The pre-existing per-page `showCacheHint` blocks gated visibility on `query.isError && data !== undefined` (single fetch errored, cached data is showing). The new banner gates on connection state (`degraded` requires 2 consecutive 5xx or a staleness expiry; `offline` requires network down or 3 consecutive network errors). The Pass 5 spec explicitly cites this shift as intended ("Chunk 5 promotes to global banner"). Net effect: the banner appears less aggressively (no flash on a single failed fetch) but more accurately reflects the connection's actual health.

4. **`degraded + null lastSyncedAt` copy.** Spec specifies the "never synced" fallback for `offline + null` only; it is silent on the (rare) `degraded + null` case that arises if the first two API attempts both return 5xx with no prior success. The banner falls through to the same "never synced" copy in that case rather than printing "— ago" with a missing timestamp. Covered explicitly in `StalenessBanner.test.tsx`.

## FCI flag

`src/lib/connection/useSurfaceLastSync.ts` is introduced here with a single consumer (`HabitDetailPage`). Naming it as a separate file (rather than inlining `Math.max(habit.dataUpdatedAt, graduation.dataUpdatedAt)` in the page) is the **spec's recommended pattern** (Pass 5 §3 [2C-28] Technical notes: "Recommended pattern: a small `useSurfaceLastSync(...queryKeys)` helper that returns the max across the passed keys"). The near-term next consumer is any future multi-query surface (e.g., a routine detail variant that composes routine + child-habits cache reads). Flagged here per org CLAUDE.md v6 "First Consumer Instantiates".

## Test Results

```
> brain3-companion@0.0.1 test.unit
> vitest run

 Test Files  37 passed (37)
      Tests  400 passed (400)
   Start at  16:32:11
   Duration  11.57s
```

ESLint: 0 errors, 0 warnings.
TypeScript: clean (no `tsc --noEmit` output).

## Acceptance Checklist

- [x] `<StalenessBanner />` at `src/components/StalenessBanner.tsx` — slim secondary line under page header
- [x] Renders on `degraded` / `offline`; hidden on `connected` / `syncing`
- [x] `offline + lastSyncedAt` copy: "Showing cached data — last synced X ago"
- [x] `offline + null lastSyncedAt` copy: "Showing cached data — never synced. Pull down to refresh."
- [x] `degraded + lastSyncedAt` copy: "Connection issues — last synced X ago"
- [x] Per-surface pull-to-refresh via `<IonRefresher slot="fixed">` wired to TanStack `refetch()` on all surfaces with TanStack-backed queries
- [x] Banner + refresh applied to all 9 spec surfaces (8 unique pages: Notifications, Habits, Habit detail, Routines, Routine detail (entry-list banner only), Rules, Rule detail (banner only), Recent check-ins)
- [x] Habit detail banner reads `Math.max(habit.dataUpdatedAt, graduation.dataUpdatedAt)` via `useSurfaceLastSync`
- [x] 250 ms render-debounce on visibility transitions
- [x] `StalenessBanner.test.tsx` covers hidden/visible/copy/lastSyncedAt-formatting/debounce
- [x] `HabitsPage.refresh.test.tsx` covers representative pull-to-refresh + banner-copy-update
- [x] Banner does not overlap IonHeader / toolbars / IonRefresher indicator (mounted after IonRefresher, before content; visually inspected via test-rendered DOM)

Closes #23
