### PR TITLE
[2C-30]: Settings — Pending sync inspection + Clear local cache

### DIFF
--- a/src/components/ClearLocalCacheSection.test.tsx
+++ b/src/components/ClearLocalCacheSection.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * [2C-30] ClearLocalCacheSection UI tests. Co-located per repo CLAUDE.md v3;
+ * spec named `tests/integration/settingsClearCache.spec.tsx` — see PR body
+ * Deviation #1 (precedent: [2C-28] PR #73).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+// IonAlert and IonToast use shadow-DOM internals that jsdom does not exercise.
+// Replace with thin wrappers exposing the same prop contract via plain DOM —
+// same pattern as src/pages/HabitDetailPage.test.tsx.
+vi.mock('@ionic/react', async () => {
+  const actual = await vi.importActual<typeof import('@ionic/react')>(
+    '@ionic/react',
+  );
+  type AlertButton = {
+    text: string;
+    role?: string;
+    handler?: () => void;
+  };
+  interface IonAlertProps {
+    isOpen: boolean;
+    header?: string;
+    message?: string;
+    buttons?: AlertButton[];
+    onDidDismiss?: () => void;
+  }
+  interface IonToastProps {
+    isOpen: boolean;
+    message?: string;
+  }
+  const IonAlert: React.FC<IonAlertProps> = ({
+    isOpen,
+    header,
+    message,
+    buttons,
+    onDidDismiss,
+  }) =>
+    isOpen ? (
+      <div role="alertdialog" aria-label={header} data-testid="alert">
+        {header ? <h2>{header}</h2> : null}
+        {message ? <p>{message}</p> : null}
+        {(buttons ?? []).map((b, i) => (
+          <button
+            key={i}
+            type="button"
+            data-testid={`alert-button-${i}`}
+            data-role={b.role ?? 'action'}
+            onClick={() => {
+              b.handler?.();
+              onDidDismiss?.();
+            }}
+          >
+            {b.text}
+          </button>
+        ))}
+      </div>
+    ) : null;
+  const IonToast: React.FC<IonToastProps> = ({ isOpen, message }) =>
+    isOpen ? (
+      <div role="status" data-testid="toast">
+        {message ?? ''}
+      </div>
+    ) : null;
+  return { ...actual, IonAlert, IonToast };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import ClearLocalCacheSection from './ClearLocalCacheSection';
+
+const prefsStore = new Map<string, string>();
+
+function withQueryClient(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.keys).mockReset();
+  vi.mocked(Preferences.keys).mockImplementation(async () => ({
+    keys: Array.from(prefsStore.keys()),
+  }));
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ClearLocalCacheSection', () => {
+  it('opens the confirm modal when the button is tapped', async () => {
+    const qc = new QueryClient();
+    render(<ClearLocalCacheSection />, { wrapper: withQueryClient(qc) });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('clear-cache-button'));
+    expect(screen.getByTestId('alert')).toBeDefined();
+    expect(screen.getByText(/Pending sync items are NOT cleared/)).toBeDefined();
+  });
+
+  it('cancel button dismisses the modal without clearing anything', async () => {
+    prefsStore.set('brain.cache.habits.active', '[]');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    const qc = new QueryClient();
+    qc.setQueryData(['habits', 'active'], [{ id: 'h1', title: 't' }]);
+    render(<ClearLocalCacheSection />, { wrapper: withQueryClient(qc) });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('clear-cache-button'));
+    // First button is "Cancel" (role=cancel).
+    const cancelButton = screen.getByTestId('alert-button-0');
+    expect(cancelButton.getAttribute('data-role')).toBe('cancel');
+    await user.click(cancelButton);
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue')).toBe(true);
+    expect(qc.getQueryData(['habits', 'active'])).toBeDefined();
+  });
+
+  it('confirm wipes brain.cache.* keys, preserves brain.writeQueue*, clears query cache, shows toast', async () => {
+    prefsStore.set('brain.cache.habits.active', '[]');
+    prefsStore.set('brain.cache.routines.active', '[]');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    prefsStore.set('brain.writeQueue.habitCompletions', '[{}]');
+    prefsStore.set('brain.writeQueue.failures.brain.writeQueue', '[{}]');
+    prefsStore.set('brain.pairing.url', 'https://x');
+    const qc = new QueryClient();
+    qc.setQueryData(['habits', 'active'], [{ id: 'h1', title: 't' }]);
+    qc.setQueryData(['routines', 'active'], [{ id: 'r1' }]);
+
+    render(<ClearLocalCacheSection />, { wrapper: withQueryClient(qc) });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('clear-cache-button'));
+    // Second button is "Confirm".
+    const confirmButton = screen.getByTestId('alert-button-1');
+    expect(confirmButton.getAttribute('data-role')).toBe('destructive');
+    await user.click(confirmButton);
+
+    // Allow the async handler to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.routines.active')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.habitCompletions')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.failures.brain.writeQueue')).toBe(
+      true,
+    );
+    expect(prefsStore.has('brain.pairing.url')).toBe(true);
+    expect(qc.getQueryData(['habits', 'active'])).toBeUndefined();
+    expect(qc.getQueryData(['routines', 'active'])).toBeUndefined();
+    expect(await screen.findByTestId('toast')).toBeDefined();
+    expect(screen.getByTestId('toast').textContent).toBe('Local cache cleared.');
+  });
+});

--- a/src/components/ClearLocalCacheSection.tsx
+++ b/src/components/ClearLocalCacheSection.tsx
@@ -1,0 +1,77 @@
+/**
+ * [2C-30] Clear-local-cache action at the bottom of Settings.
+ *
+ * Destructive-actions section: red button + confirm modal + toast. Wipes
+ * every `brain.cache.*` Preferences key and clears the TanStack Query
+ * cache. Live write-queue keys (`brain.writeQueue*`) survive — pending
+ * writes are not touched.
+ */
+
+import { useState } from 'react';
+import { IonAlert, IonButton, IonText, IonToast } from '@ionic/react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { clearLocalCache } from '../lib/clearLocalCache';
+
+const CONFIRM_MESSAGE =
+  'Clear all cached data? Pending sync items are NOT cleared. The app will refetch when online.';
+const TOAST_MESSAGE = 'Local cache cleared.';
+
+const ClearLocalCacheSection: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [toastOpen, setToastOpen] = useState(false);
+
+  const handleConfirm = async (): Promise<void> => {
+    await clearLocalCache(queryClient);
+    setToastOpen(true);
+  };
+
+  return (
+    <section
+      aria-label="Destructive actions"
+      data-testid="clear-cache-section"
+      className="ion-margin-top"
+      style={{ marginTop: '2rem' }}
+    >
+      <IonButton
+        expand="block"
+        fill="outline"
+        color="danger"
+        onClick={() => setConfirmOpen(true)}
+        data-testid="clear-cache-button"
+      >
+        <IonText>Clear local cache</IonText>
+      </IonButton>
+
+      <IonAlert
+        isOpen={confirmOpen}
+        header="Clear local cache"
+        message={CONFIRM_MESSAGE}
+        buttons={[
+          {
+            text: 'Cancel',
+            role: 'cancel',
+          },
+          {
+            text: 'Confirm',
+            role: 'destructive',
+            handler: () => {
+              void handleConfirm();
+            },
+          },
+        ]}
+        onDidDismiss={() => setConfirmOpen(false)}
+      />
+
+      <IonToast
+        isOpen={toastOpen}
+        message={TOAST_MESSAGE}
+        duration={3000}
+        onDidDismiss={() => setToastOpen(false)}
+      />
+    </section>
+  );
+};
+
+export default ClearLocalCacheSection;

--- a/src/components/PendingSyncSection.test.tsx
+++ b/src/components/PendingSyncSection.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * [2C-30] PendingSyncSection UI tests. Co-located per repo CLAUDE.md v3;
+ * spec named `tests/integration/settingsPendingSync.spec.tsx` — see PR body
+ * Deviation #1 (precedent: [2C-28] PR #73).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import PendingSyncSection from './PendingSyncSection';
+import { __resetPendingSyncForTests } from '../lib/pendingSync';
+import {
+  __resetFlushStateForTests,
+  emitFlushDetail,
+} from '../lib/connection/writeQueueFlushState';
+import { WRITE_QUEUE_KEY } from '../lib/writeQueue';
+import {
+  HABIT_COMPLETIONS_KEY,
+  ROUTINE_COMPLETIONS_KEY,
+} from '../lib/completionQueues';
+
+const prefsStore = new Map<string, string>();
+
+function withQueryClient(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  __resetPendingSyncForTests();
+  __resetFlushStateForTests();
+});
+
+afterEach(() => {
+  __resetPendingSyncForTests();
+  __resetFlushStateForTests();
+});
+
+describe('PendingSyncSection — hidden state', () => {
+  it('renders nothing when all queues + failures are empty', async () => {
+    const qc = new QueryClient();
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    expect(screen.queryByTestId('pending-sync-section')).toBeNull();
+  });
+
+  it('renders when only the failures log has entries (live queue empty)', async () => {
+    prefsStore.set(
+      `brain.writeQueue.failures.${WRITE_QUEUE_KEY}`,
+      JSON.stringify([
+        {
+          original_entry: { notification_id: 'n1' },
+          http_status: 422,
+          server_message: 'rejected',
+          dropped_at: '2026-05-12T08:00:00.000Z',
+        },
+      ]),
+    );
+    const qc = new QueryClient();
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    expect(screen.getByTestId('pending-sync-section')).toBeDefined();
+  });
+});
+
+describe('PendingSyncSection — collapsed copy', () => {
+  it('renders "Pending sync: N writes" summing all three queues', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        {
+          notification_id: 'n1',
+          response: 'Already done',
+          response_note: null,
+          enqueued_at: '2026-05-12T10:00:00.000Z',
+        },
+        {
+          notification_id: 'n2',
+          response: 'Snooze',
+          response_note: null,
+          enqueued_at: '2026-05-12T10:01:00.000Z',
+        },
+      ]),
+    );
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        {
+          habit_id: 'h1',
+          completed_date: '2026-05-12',
+          notes: null,
+          enqueued_at: '2026-05-12T10:02:00.000Z',
+        },
+      ]),
+    );
+    prefsStore.set(
+      ROUTINE_COMPLETIONS_KEY,
+      JSON.stringify([
+        {
+          routine_id: 'r1',
+          completed_date: '2026-05-12',
+          status: 'all_done',
+          freeform_note: null,
+          child_habit_completions: null,
+          enqueued_at: '2026-05-12T10:03:00.000Z',
+        },
+      ]),
+    );
+    const qc = new QueryClient();
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    const toggle = screen.getByTestId('pending-sync-toggle');
+    expect(toggle.textContent).toMatch(/Pending sync: 4 writes/);
+  });
+
+  it('omits "last attempt" suffix when no flush has been observed', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        {
+          notification_id: 'n1',
+          response: 'Already done',
+          response_note: null,
+          enqueued_at: '2026-05-12T10:00:00.000Z',
+        },
+      ]),
+    );
+    const qc = new QueryClient();
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    const toggle = screen.getByTestId('pending-sync-toggle');
+    expect(toggle.textContent).not.toMatch(/last attempt/);
+  });
+
+  it('includes "last attempt" suffix once a flushing transition fires', async () => {
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        {
+          habit_id: 'h1',
+          completed_date: '2026-05-12',
+          notes: null,
+          enqueued_at: '2026-05-12T10:00:00.000Z',
+        },
+      ]),
+    );
+    const qc = new QueryClient();
+    const { rerender } = render(<PendingSyncSection />, {
+      wrapper: withQueryClient(qc),
+    });
+    await flushPromises();
+    act(() => {
+      emitFlushDetail({
+        status: 'flushing',
+        queueKey: HABIT_COMPLETIONS_KEY,
+        nextRetryAt: null,
+      });
+    });
+    await flushPromises();
+    rerender(<PendingSyncSection />);
+    const toggle = screen.getByTestId('pending-sync-toggle');
+    expect(toggle.textContent).toMatch(/last attempt/);
+  });
+});
+
+describe('PendingSyncSection — expanded sections', () => {
+  it('renders all four sections on toggle, with title resolution from query cache', async () => {
+    prefsStore.set(
+      WRITE_QUEUE_KEY,
+      JSON.stringify([
+        {
+          notification_id: '12345678-aaaa-bbbb-cccc-dddddddddddd',
+          response: 'Already done',
+          response_note: null,
+          enqueued_at: '2026-05-12T10:00:00.000Z',
+        },
+      ]),
+    );
+    prefsStore.set(
+      HABIT_COMPLETIONS_KEY,
+      JSON.stringify([
+        {
+          habit_id: 'habit-abc-1',
+          completed_date: '2026-05-12',
+          notes: null,
+          enqueued_at: '2026-05-12T10:00:00.000Z',
+        },
+        {
+          habit_id: 'habit-unknown',
+          completed_date: '2026-05-12',
+          notes: null,
+          enqueued_at: '2026-05-12T10:01:00.000Z',
+        },
+      ]),
+    );
+    prefsStore.set(
+      ROUTINE_COMPLETIONS_KEY,
+      JSON.stringify([
+        {
+          routine_id: 'routine-xyz-1',
+          completed_date: '2026-05-12',
+          status: 'partial',
+          freeform_note: null,
+          child_habit_completions: null,
+          enqueued_at: '2026-05-12T10:02:00.000Z',
+        },
+      ]),
+    );
+    prefsStore.set(
+      `brain.writeQueue.failures.${WRITE_QUEUE_KEY}`,
+      JSON.stringify([
+        {
+          original_entry: { notification_id: 'old-n1' },
+          http_status: 422,
+          server_message: 'Validation failed: response not in allowed set',
+          dropped_at: '2026-05-12T09:00:00.000Z',
+        },
+      ]),
+    );
+
+    const qc = new QueryClient();
+    qc.setQueryData(
+      ['habits', 'active'],
+      [{ id: 'habit-abc-1', title: 'Morning meds' }],
+    );
+    qc.setQueryData(
+      ['routines', 'active'],
+      [{ id: 'routine-xyz-1', title: 'Wind-down' }],
+    );
+
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('pending-sync-toggle'));
+
+    const expanded = screen.getByTestId('pending-sync-expanded');
+    expect(within(expanded).getByText('Notification responses')).toBeDefined();
+    expect(within(expanded).getByText('Habit completions')).toBeDefined();
+    expect(within(expanded).getByText('Routine completions')).toBeDefined();
+    expect(within(expanded).getByText('Recent failures')).toBeDefined();
+
+    // Habit title resolved from cache.
+    expect(within(expanded).getByText('Morning meds')).toBeDefined();
+    // Unknown habit falls back to short ID prefix (first 8 chars).
+    expect(within(expanded).getByText('habit-un')).toBeDefined();
+    // Routine title resolved from cache.
+    expect(within(expanded).getByText('Wind-down')).toBeDefined();
+  });
+
+  it('renders failure rows with a red pill containing the HTTP status', async () => {
+    prefsStore.set(
+      `brain.writeQueue.failures.${WRITE_QUEUE_KEY}`,
+      JSON.stringify([
+        {
+          original_entry: { notification_id: 'old-n1' },
+          http_status: 422,
+          server_message: 'rejected',
+          dropped_at: '2026-05-12T09:00:00.000Z',
+        },
+      ]),
+    );
+    const qc = new QueryClient();
+    render(<PendingSyncSection />, { wrapper: withQueryClient(qc) });
+    await flushPromises();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('pending-sync-toggle'));
+    const pill = screen.getByTestId('pending-sync-failure-pill');
+    expect(pill.textContent).toBe('422');
+    expect(pill.className).toMatch(/red/);
+  });
+});

--- a/src/components/PendingSyncSection.tsx
+++ b/src/components/PendingSyncSection.tsx
@@ -1,0 +1,325 @@
+/**
+ * [2C-30] Pending sync disclosure under Settings.
+ *
+ * Read-only collapsed/expanded row that surfaces the three offline write
+ * queues + the permanent-failure log. Hidden entirely when there is nothing
+ * pending and no recorded failures — a clean state is silent. Live updates
+ * via `subscribePendingSync` (subscribes to `[2C-29]`'s
+ * `writeQueueFlushState` + `document.visibilitychange`).
+ *
+ * Titles for habit/routine completions resolve from the TanStack Query
+ * caches at `['habits', 'active']` and `['routines', 'active']`. If a habit
+ * or routine has dropped out of the active list (e.g., paused after the
+ * entry was enqueued), the row falls back to a short ID prefix per Pass 5
+ * Summary §3 [2C-30].
+ *
+ * Read-only by design: no retry, edit, or delete controls in v2.0.0 — the
+ * underlying queues drain on app foreground / network reconnect.
+ */
+
+import { useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonText,
+} from '@ionic/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+
+import {
+  countFailures,
+  countPending,
+  getPendingSyncSnapshot,
+  getServerSnapshot,
+  subscribePendingSync,
+  type PendingSyncSnapshot,
+} from '../lib/pendingSync';
+import type { WriteQueueEntry } from '../lib/writeQueue';
+import type {
+  HabitCompletionEntry,
+  RoutineCompletionEntry,
+} from '../lib/completionQueues';
+import type { HabitResponse } from '../lib/habits';
+import type { RoutineResponse } from '../lib/routines';
+
+function formatRelative(iso: string): string {
+  try {
+    const date = parseISO(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    return `${formatDistanceToNowStrict(date, {
+      addSuffix: false,
+    })} ago`;
+  } catch {
+    return iso;
+  }
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function resolveTitle<T extends { id: string; title?: string }>(
+  list: T[] | undefined,
+  id: string,
+): string {
+  if (!list) return shortId(id);
+  const found = list.find((item) => item.id === id);
+  if (found && typeof found.title === 'string' && found.title.length > 0) {
+    return found.title;
+  }
+  return shortId(id);
+}
+
+function truncate(value: string | null, max: number): string {
+  if (value === null) return '';
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function pluralizeWrites(n: number): string {
+  return n === 1 ? '1 write' : `${n} writes`;
+}
+
+interface NotificationRowProps {
+  entry: WriteQueueEntry;
+}
+
+const NotificationRow: React.FC<NotificationRowProps> = ({ entry }) => (
+  <IonItem lines="none" data-testid="pending-sync-notification-row">
+    <IonLabel className="ion-text-wrap">
+      <h3>{entry.response}</h3>
+      <IonText color="medium">
+        <p>
+          {shortId(entry.notification_id)} · {formatRelative(entry.enqueued_at)}
+        </p>
+      </IonText>
+    </IonLabel>
+  </IonItem>
+);
+
+interface HabitRowProps {
+  entry: HabitCompletionEntry;
+  habits: HabitResponse[] | undefined;
+}
+
+const HabitRow: React.FC<HabitRowProps> = ({ entry, habits }) => (
+  <IonItem lines="none" data-testid="pending-sync-habit-row">
+    <IonLabel className="ion-text-wrap">
+      <h3>{resolveTitle(habits, entry.habit_id)}</h3>
+      <IonText color="medium">
+        <p>
+          {entry.completed_date} · {formatRelative(entry.enqueued_at)}
+        </p>
+      </IonText>
+    </IonLabel>
+  </IonItem>
+);
+
+interface RoutineRowProps {
+  entry: RoutineCompletionEntry;
+  routines: RoutineResponse[] | undefined;
+}
+
+const RoutineRow: React.FC<RoutineRowProps> = ({ entry, routines }) => (
+  <IonItem lines="none" data-testid="pending-sync-routine-row">
+    <IonLabel className="ion-text-wrap">
+      <h3>{resolveTitle(routines, entry.routine_id)}</h3>
+      <IonText color="medium">
+        <p>
+          {entry.completed_date} · {entry.status} ·{' '}
+          {formatRelative(entry.enqueued_at)}
+        </p>
+      </IonText>
+    </IonLabel>
+  </IonItem>
+);
+
+interface FailureRowProps {
+  http_status: number;
+  server_message: string | null;
+  dropped_at: string;
+}
+
+const FailureRow: React.FC<FailureRowProps> = ({
+  http_status,
+  server_message,
+  dropped_at,
+}) => (
+  <IonItem lines="none" data-testid="pending-sync-failure-row">
+    <IonLabel className="ion-text-wrap">
+      <div className="flex items-center gap-2">
+        <span
+          data-testid="pending-sync-failure-pill"
+          className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 ring-1 ring-inset ring-red-200"
+        >
+          {http_status}
+        </span>
+        <span className="text-sm">{truncate(server_message, 80)}</span>
+      </div>
+      <IonText color="medium">
+        <p>{formatRelative(dropped_at)}</p>
+      </IonText>
+    </IonLabel>
+  </IonItem>
+);
+
+const PendingSyncSection: React.FC = () => {
+  const snapshot = useSyncExternalStore<PendingSyncSnapshot>(
+    subscribePendingSync,
+    getPendingSyncSnapshot,
+    getServerSnapshot,
+  );
+  const [expanded, setExpanded] = useState(false);
+  const queryClient = useQueryClient();
+
+  const pending = countPending(snapshot);
+  const failures = countFailures(snapshot);
+
+  const habits = queryClient.getQueryData<HabitResponse[]>([
+    'habits',
+    'active',
+  ]);
+  const routines = queryClient.getQueryData<RoutineResponse[]>([
+    'routines',
+    'active',
+  ]);
+
+  const lastAttemptText = useMemo(() => {
+    if (snapshot.lastAttemptAt === null) return null;
+    return `last attempt ${formatDistanceToNowStrict(snapshot.lastAttemptAt)} ago`;
+  }, [snapshot.lastAttemptAt]);
+
+  if (pending === 0 && failures === 0) return null;
+
+  const summary = lastAttemptText
+    ? `Pending sync: ${pluralizeWrites(pending)}, ${lastAttemptText}`
+    : `Pending sync: ${pluralizeWrites(pending)}`;
+
+  return (
+    <section
+      aria-label="Pending sync"
+      data-testid="pending-sync-section"
+      className="ion-margin-top"
+    >
+      <IonItem
+        button
+        detail
+        onClick={() => setExpanded((value) => !value)}
+        data-testid="pending-sync-toggle"
+        aria-expanded={expanded}
+      >
+        <IonLabel>
+          <h2>{summary}</h2>
+        </IonLabel>
+      </IonItem>
+
+      {expanded ? (
+        <div data-testid="pending-sync-expanded">
+          {snapshot.notificationEntries.length > 0 ? (
+            <>
+              <IonItem lines="none">
+                <IonLabel>
+                  <h3 className="text-sm font-semibold">
+                    Notification responses
+                  </h3>
+                </IonLabel>
+                <IonNote slot="end">
+                  {snapshot.notificationEntries.length}
+                </IonNote>
+              </IonItem>
+              <IonList>
+                {snapshot.notificationEntries.map((entry, index) => (
+                  <NotificationRow
+                    key={`${entry.notification_id}-${index}`}
+                    entry={entry}
+                  />
+                ))}
+              </IonList>
+            </>
+          ) : null}
+
+          {snapshot.habitEntries.length > 0 ? (
+            <>
+              <IonItem lines="none">
+                <IonLabel>
+                  <h3 className="text-sm font-semibold">Habit completions</h3>
+                </IonLabel>
+                <IonNote slot="end">{snapshot.habitEntries.length}</IonNote>
+              </IonItem>
+              <IonList>
+                {snapshot.habitEntries.map((entry, index) => (
+                  <HabitRow
+                    key={`${entry.habit_id}-${entry.completed_date}-${index}`}
+                    entry={entry}
+                    habits={habits}
+                  />
+                ))}
+              </IonList>
+            </>
+          ) : null}
+
+          {snapshot.routineEntries.length > 0 ? (
+            <>
+              <IonItem lines="none">
+                <IonLabel>
+                  <h3 className="text-sm font-semibold">Routine completions</h3>
+                </IonLabel>
+                <IonNote slot="end">{snapshot.routineEntries.length}</IonNote>
+              </IonItem>
+              <IonList>
+                {snapshot.routineEntries.map((entry, index) => (
+                  <RoutineRow
+                    key={`${entry.routine_id}-${entry.completed_date}-${index}`}
+                    entry={entry}
+                    routines={routines}
+                  />
+                ))}
+              </IonList>
+            </>
+          ) : null}
+
+          {failures > 0 ? (
+            <>
+              <IonItem lines="none">
+                <IonLabel>
+                  <h3 className="text-sm font-semibold">Recent failures</h3>
+                </IonLabel>
+                <IonNote slot="end">{failures}</IonNote>
+              </IonItem>
+              <IonList>
+                {snapshot.failures.notifications.map((failure, index) => (
+                  <FailureRow
+                    key={`notif-${index}`}
+                    http_status={failure.http_status}
+                    server_message={failure.server_message}
+                    dropped_at={failure.dropped_at}
+                  />
+                ))}
+                {snapshot.failures.habits.map((failure, index) => (
+                  <FailureRow
+                    key={`habit-${index}`}
+                    http_status={failure.http_status}
+                    server_message={failure.server_message}
+                    dropped_at={failure.dropped_at}
+                  />
+                ))}
+                {snapshot.failures.routines.map((failure, index) => (
+                  <FailureRow
+                    key={`routine-${index}`}
+                    http_status={failure.http_status}
+                    server_message={failure.server_message}
+                    dropped_at={failure.dropped_at}
+                  />
+                ))}
+              </IonList>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default PendingSyncSection;

--- a/src/lib/clearLocalCache.test.ts
+++ b/src/lib/clearLocalCache.test.ts
@@ -1,0 +1,119 @@
+/**
+ * [2C-30] clearLocalCache tests. Co-located per repo CLAUDE.md v3; spec
+ * named `tests/integration/settingsClearCache.spec.tsx` — see PR body
+ * Deviation #1.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { QueryClient } from '@tanstack/react-query';
+import { clearLocalCache } from './clearLocalCache';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.keys).mockReset();
+  vi.mocked(Preferences.keys).mockImplementation(async () => ({
+    keys: Array.from(prefsStore.keys()),
+  }));
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('clearLocalCache', () => {
+  it('removes every brain.cache.* key', async () => {
+    prefsStore.set('brain.cache.habits.active', '[]');
+    prefsStore.set('brain.cache.routines.active', '[]');
+    prefsStore.set('brain.cache.notifications', '[]');
+    prefsStore.set('brain.cache.habit.abc', '{}');
+    const queryClient = new QueryClient();
+    await clearLocalCache(queryClient);
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.routines.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.notifications')).toBe(false);
+    expect(prefsStore.has('brain.cache.habit.abc')).toBe(false);
+  });
+
+  it('preserves brain.writeQueue and brain.writeQueue.* keys', async () => {
+    prefsStore.set('brain.cache.habits.active', '[]');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    prefsStore.set('brain.writeQueue.habitCompletions', '[{}]');
+    prefsStore.set('brain.writeQueue.routineCompletions', '[]');
+    prefsStore.set('brain.writeQueue.failures.brain.writeQueue', '[{}]');
+    prefsStore.set(
+      'brain.writeQueue.failures.brain.writeQueue.habitCompletions',
+      '[]',
+    );
+    prefsStore.set('brain.writeQueue.failures.totalDropsCount', '3');
+    prefsStore.set('brain.writeQueue.failures.seenCount', '0');
+    const queryClient = new QueryClient();
+    await clearLocalCache(queryClient);
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.habitCompletions')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.routineCompletions')).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.failures.brain.writeQueue')).toBe(
+      true,
+    );
+    expect(
+      prefsStore.has('brain.writeQueue.failures.brain.writeQueue.habitCompletions'),
+    ).toBe(true);
+    expect(prefsStore.has('brain.writeQueue.failures.totalDropsCount')).toBe(
+      true,
+    );
+    expect(prefsStore.has('brain.writeQueue.failures.seenCount')).toBe(true);
+  });
+
+  it('preserves non-brain.cache keys (e.g., pairing, registration)', async () => {
+    prefsStore.set('brain.pairing.url', 'https://x');
+    prefsStore.set('brain.pairing.token', 'secret');
+    prefsStore.set('brain.deviceRegistration.fcmToken', 'fcm');
+    prefsStore.set('brain.cache.notifications', '[]');
+    const queryClient = new QueryClient();
+    await clearLocalCache(queryClient);
+    expect(prefsStore.has('brain.pairing.url')).toBe(true);
+    expect(prefsStore.has('brain.pairing.token')).toBe(true);
+    expect(prefsStore.has('brain.deviceRegistration.fcmToken')).toBe(true);
+    expect(prefsStore.has('brain.cache.notifications')).toBe(false);
+  });
+
+  it('calls queryClient.clear()', async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['habits', 'active'], [{ id: 'h1', title: 't' }]);
+    queryClient.setQueryData(['routines', 'active'], [{ id: 'r1' }]);
+    expect(queryClient.getQueryData(['habits', 'active'])).toBeDefined();
+    await clearLocalCache(queryClient);
+    expect(queryClient.getQueryData(['habits', 'active'])).toBeUndefined();
+    expect(queryClient.getQueryData(['routines', 'active'])).toBeUndefined();
+  });
+
+  it('no-ops cleanly when nothing matches the prefix', async () => {
+    prefsStore.set('brain.pairing.url', 'https://x');
+    const queryClient = new QueryClient();
+    await clearLocalCache(queryClient);
+    expect(prefsStore.has('brain.pairing.url')).toBe(true);
+    expect(vi.mocked(Preferences.remove)).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/clearLocalCache.ts
+++ b/src/lib/clearLocalCache.ts
@@ -1,0 +1,28 @@
+/**
+ * [2C-30] "Clear local cache" action.
+ *
+ * Scans `@capacitor/preferences` for keys with the `brain.cache.` prefix and
+ * removes them, then invalidates the TanStack Query cache so the app-shell
+ * refetches on next interaction. Live write-queue keys (`brain.writeQueue`,
+ * `brain.writeQueue.habitCompletions`, `brain.writeQueue.routineCompletions`)
+ * and the failures log (`brain.writeQueue.failures.*`) are preserved by the
+ * prefix filter — pending writes survive the clear, per Pass 5 Summary §3
+ * [2C-30] Scope.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { QueryClient } from '@tanstack/react-query';
+
+export const CACHE_KEY_PREFIX = 'brain.cache.';
+
+/**
+ * Remove every Preferences key starting with `brain.cache.` and clear the
+ * passed query client. Does not touch `brain.writeQueue*` keys or the
+ * pairing keys.
+ */
+export async function clearLocalCache(queryClient: QueryClient): Promise<void> {
+  const { keys } = await Preferences.keys();
+  const cacheKeys = keys.filter((key) => key.startsWith(CACHE_KEY_PREFIX));
+  await Promise.all(cacheKeys.map((key) => Preferences.remove({ key })));
+  queryClient.clear();
+}

--- a/src/lib/pendingSync.test.ts
+++ b/src/lib/pendingSync.test.ts
@@ -1,0 +1,213 @@
+/**
+ * [2C-30] pendingSync aggregator tests. Co-located per repo CLAUDE.md v3;
+ * spec named `tests/integration/settingsPendingSync.spec.tsx` — see PR body
+ * Deviation #1 (precedent: [2C-28] PR #73).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  __resetPendingSyncForTests,
+  countFailures,
+  countPending,
+  getPendingSyncSnapshot,
+  refreshPendingSync,
+  subscribePendingSync,
+} from './pendingSync';
+import { __resetFlushStateForTests, emitFlushDetail } from './connection/writeQueueFlushState';
+import { WRITE_QUEUE_KEY } from './writeQueue';
+import {
+  HABIT_COMPLETIONS_KEY,
+  ROUTINE_COMPLETIONS_KEY,
+} from './completionQueues';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+  __resetPendingSyncForTests();
+  __resetFlushStateForTests();
+});
+
+afterEach(() => {
+  __resetPendingSyncForTests();
+  __resetFlushStateForTests();
+});
+
+function seedNotificationEntries(count: number): void {
+  const entries = Array.from({ length: count }, (_, i) => ({
+    notification_id: `notif-${i}`,
+    response: `Already done ${i}`,
+    response_note: null,
+    enqueued_at: '2026-05-12T10:00:00.000Z',
+  }));
+  prefsStore.set(WRITE_QUEUE_KEY, JSON.stringify(entries));
+}
+
+function seedHabitEntries(count: number): void {
+  const entries = Array.from({ length: count }, (_, i) => ({
+    habit_id: `habit-${i}`,
+    completed_date: '2026-05-12',
+    notes: null,
+    enqueued_at: '2026-05-12T10:00:00.000Z',
+  }));
+  prefsStore.set(HABIT_COMPLETIONS_KEY, JSON.stringify(entries));
+}
+
+function seedRoutineEntries(count: number): void {
+  const entries = Array.from({ length: count }, (_, i) => ({
+    routine_id: `routine-${i}`,
+    completed_date: '2026-05-12',
+    status: 'all_done',
+    freeform_note: null,
+    child_habit_completions: null,
+    enqueued_at: '2026-05-12T10:00:00.000Z',
+  }));
+  prefsStore.set(ROUTINE_COMPLETIONS_KEY, JSON.stringify(entries));
+}
+
+function seedFailures(queueKey: string, count: number): void {
+  const entries = Array.from({ length: count }, (_, i) => ({
+    original_entry: { id: `entry-${i}` },
+    http_status: 422,
+    server_message: `Server rejected ${i}`,
+    dropped_at: '2026-05-12T09:00:00.000Z',
+  }));
+  prefsStore.set(`brain.writeQueue.failures.${queueKey}`, JSON.stringify(entries));
+}
+
+describe('refreshPendingSync', () => {
+  it('reads all three queue keys + all three failure logs', async () => {
+    seedNotificationEntries(2);
+    seedHabitEntries(1);
+    seedRoutineEntries(3);
+    seedFailures(WRITE_QUEUE_KEY, 1);
+    seedFailures(HABIT_COMPLETIONS_KEY, 2);
+    seedFailures(ROUTINE_COMPLETIONS_KEY, 0);
+
+    await refreshPendingSync();
+    const snap = getPendingSyncSnapshot();
+
+    expect(snap.notificationEntries).toHaveLength(2);
+    expect(snap.habitEntries).toHaveLength(1);
+    expect(snap.routineEntries).toHaveLength(3);
+    expect(snap.failures.notifications).toHaveLength(1);
+    expect(snap.failures.habits).toHaveLength(2);
+    expect(snap.failures.routines).toHaveLength(0);
+    expect(countPending(snap)).toBe(6);
+    expect(countFailures(snap)).toBe(3);
+  });
+
+  it('returns empty arrays when all keys are absent', async () => {
+    await refreshPendingSync();
+    const snap = getPendingSyncSnapshot();
+    expect(countPending(snap)).toBe(0);
+    expect(countFailures(snap)).toBe(0);
+    expect(snap.lastAttemptAt).toBeNull();
+  });
+
+  it('tolerates malformed JSON on a queue key', async () => {
+    prefsStore.set(WRITE_QUEUE_KEY, '{ not valid json');
+    seedHabitEntries(1);
+    await refreshPendingSync();
+    const snap = getPendingSyncSnapshot();
+    expect(snap.notificationEntries).toEqual([]);
+    expect(snap.habitEntries).toHaveLength(1);
+  });
+
+  it('coalesces concurrent refresh calls', async () => {
+    seedNotificationEntries(1);
+    const first = refreshPendingSync();
+    const second = refreshPendingSync();
+    await Promise.all([first, second]);
+    expect(getPendingSyncSnapshot().notificationEntries).toHaveLength(1);
+    // Preferences.get is called once per key per refresh; 6 keys × 1 refresh = 6.
+    expect(vi.mocked(Preferences.get)).toHaveBeenCalledTimes(6);
+  });
+});
+
+async function settle(): Promise<void> {
+  // Drain microtasks enough for Promise.all over 6 mocked Preferences.get calls
+  // + the doRefresh .finally + the listener emit to all flush through.
+  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+}
+
+describe('subscribePendingSync', () => {
+  it('fires the listener on initial wire and on each flushDetail emission', async () => {
+    seedNotificationEntries(1);
+    const listener = vi.fn();
+    const unsubscribe = subscribePendingSync(listener);
+    await settle();
+    expect(listener).toHaveBeenCalled();
+    listener.mockClear();
+    emitFlushDetail({
+      status: 'flushing',
+      queueKey: WRITE_QUEUE_KEY,
+      nextRetryAt: null,
+    });
+    await settle();
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('records lastAttemptAt when a flushing transition arrives', async () => {
+    seedHabitEntries(1);
+    const before = Date.now();
+    const unsubscribe = subscribePendingSync(() => undefined);
+    await settle();
+    expect(getPendingSyncSnapshot().lastAttemptAt).toBeNull();
+    emitFlushDetail({
+      status: 'flushing',
+      queueKey: HABIT_COMPLETIONS_KEY,
+      nextRetryAt: null,
+    });
+    await settle();
+    const after = Date.now();
+    const recorded = getPendingSyncSnapshot().lastAttemptAt;
+    expect(recorded).not.toBeNull();
+    expect(recorded!).toBeGreaterThanOrEqual(before);
+    expect(recorded!).toBeLessThanOrEqual(after);
+    unsubscribe();
+  });
+
+  it('does not record lastAttemptAt for non-flushing transitions', async () => {
+    seedHabitEntries(1);
+    const unsubscribe = subscribePendingSync(() => undefined);
+    await settle();
+    emitFlushDetail({
+      status: 'idle',
+      queueKey: HABIT_COMPLETIONS_KEY,
+      nextRetryAt: null,
+    });
+    emitFlushDetail({
+      status: 'backoff',
+      queueKey: HABIT_COMPLETIONS_KEY,
+      nextRetryAt: Date.now() + 30_000,
+    });
+    await settle();
+    expect(getPendingSyncSnapshot().lastAttemptAt).toBeNull();
+    unsubscribe();
+  });
+});

--- a/src/lib/pendingSync.ts
+++ b/src/lib/pendingSync.ts
@@ -1,0 +1,216 @@
+/**
+ * [2C-30] read-side aggregator backing the Settings → Pending sync surface.
+ *
+ * Reads three live queues + their three failures logs from
+ * `@capacitor/preferences` and exposes a single snapshot covering all of
+ * them. Subscribes to `[2C-29]`'s `subscribeFlushDetail` so a flush
+ * transition (`flushing → idle/backoff`) refreshes the snapshot and a
+ * `flushing` transition records the `lastAttemptAt` timestamp that drives
+ * the row's "last attempt Xm ago" copy.
+ *
+ * Refresh triggers:
+ * - Initial read on first subscribe (lazy).
+ * - Every `subscribeFlushDetail` emission (covers permanent-failure drops
+ *   too, since those are recorded inside the flush loop before the
+ *   `idle`/`backoff` transition fires).
+ * - `document.visibilitychange` foreground per Pass 5 Summary §3 [2C-30].
+ *
+ * `lastAttemptAt` is tracked in-memory only; on cold start the value is
+ * `null` until the first flush fires. In practice `initWriteQueue` /
+ * `initCompletionQueues` trigger a flush near-instantly on mount, so the
+ * gap before the row shows the suffix is brief. Persisting across launches
+ * would require a fourth Preferences key for marginal benefit.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import {
+  WRITE_QUEUE_KEY,
+  readFailures,
+  type PermanentFailureRecord,
+  type WriteQueueEntry,
+} from './writeQueue';
+import {
+  HABIT_COMPLETIONS_KEY,
+  ROUTINE_COMPLETIONS_KEY,
+  type HabitCompletionEntry,
+  type RoutineCompletionEntry,
+} from './completionQueues';
+import { subscribeFlushDetail } from './connection/writeQueueFlushState';
+
+export interface PendingSyncFailures {
+  notifications: PermanentFailureRecord<WriteQueueEntry>[];
+  habits: PermanentFailureRecord<HabitCompletionEntry>[];
+  routines: PermanentFailureRecord<RoutineCompletionEntry>[];
+}
+
+export interface PendingSyncSnapshot {
+  notificationEntries: WriteQueueEntry[];
+  habitEntries: HabitCompletionEntry[];
+  routineEntries: RoutineCompletionEntry[];
+  failures: PendingSyncFailures;
+  /** Epoch-millis of the last observed `flushing` transition, or null. */
+  lastAttemptAt: number | null;
+}
+
+type Listener = () => void;
+
+const EMPTY_SNAPSHOT: PendingSyncSnapshot = {
+  notificationEntries: [],
+  habitEntries: [],
+  routineEntries: [],
+  failures: { notifications: [], habits: [], routines: [] },
+  lastAttemptAt: null,
+};
+
+let snapshot: PendingSyncSnapshot = EMPTY_SNAPSHOT;
+let lastAttemptAt: number | null = null;
+const listeners = new Set<Listener>();
+let wired = false;
+let pendingRefresh: Promise<void> | null = null;
+let flushDetailUnsubscribe: (() => void) | null = null;
+let visibilityHandler: (() => void) | null = null;
+
+async function readQueue<T>(key: string): Promise<T[]> {
+  const { value } = await Preferences.get({ key });
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+async function doRefresh(): Promise<void> {
+  const [
+    notificationEntries,
+    habitEntries,
+    routineEntries,
+    notificationFailures,
+    habitFailures,
+    routineFailures,
+  ] = await Promise.all([
+    readQueue<WriteQueueEntry>(WRITE_QUEUE_KEY),
+    readQueue<HabitCompletionEntry>(HABIT_COMPLETIONS_KEY),
+    readQueue<RoutineCompletionEntry>(ROUTINE_COMPLETIONS_KEY),
+    readFailures<WriteQueueEntry>(WRITE_QUEUE_KEY),
+    readFailures<HabitCompletionEntry>(HABIT_COMPLETIONS_KEY),
+    readFailures<RoutineCompletionEntry>(ROUTINE_COMPLETIONS_KEY),
+  ]);
+  snapshot = {
+    notificationEntries,
+    habitEntries,
+    routineEntries,
+    failures: {
+      notifications: notificationFailures,
+      habits: habitFailures,
+      routines: routineFailures,
+    },
+    lastAttemptAt,
+  };
+  emit();
+}
+
+/**
+ * Read all six Preferences keys and replace the in-memory snapshot.
+ * Concurrent calls coalesce — a second call while one is in flight awaits
+ * the in-flight refresh rather than racing it.
+ */
+export function refreshPendingSync(): Promise<void> {
+  if (pendingRefresh) return pendingRefresh;
+  pendingRefresh = doRefresh().finally(() => {
+    pendingRefresh = null;
+  });
+  return pendingRefresh;
+}
+
+function wireListeners(): void {
+  if (wired) return;
+  wired = true;
+  flushDetailUnsubscribe = subscribeFlushDetail((detail) => {
+    if (detail.status === 'flushing') {
+      lastAttemptAt = Date.now();
+    }
+    void refreshPendingSync();
+  });
+  if (typeof document !== 'undefined') {
+    visibilityHandler = (): void => {
+      if (document.visibilityState === 'visible') {
+        void refreshPendingSync();
+      }
+    };
+    document.addEventListener('visibilitychange', visibilityHandler);
+  }
+}
+
+function unwireListeners(): void {
+  if (!wired) return;
+  wired = false;
+  flushDetailUnsubscribe?.();
+  flushDetailUnsubscribe = null;
+  if (visibilityHandler !== null && typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', visibilityHandler);
+  }
+  visibilityHandler = null;
+}
+
+/**
+ * Subscribe to snapshot changes. The first subscribe wires the flush-detail
+ * + visibility listeners and kicks off an initial read; the last
+ * unsubscribe tears them down so tests can reset cleanly.
+ */
+export function subscribePendingSync(listener: Listener): () => void {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    wireListeners();
+    void refreshPendingSync();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      unwireListeners();
+    }
+  };
+}
+
+/**
+ * Synchronous read of the current snapshot. Returns a stable reference
+ * between updates so `useSyncExternalStore` does not re-render unnecessarily.
+ */
+export function getPendingSyncSnapshot(): PendingSyncSnapshot {
+  return snapshot;
+}
+
+export function getServerSnapshot(): PendingSyncSnapshot {
+  return EMPTY_SNAPSHOT;
+}
+
+/** Total pending writes across all three queues. */
+export function countPending(snap: PendingSyncSnapshot): number {
+  return (
+    snap.notificationEntries.length +
+    snap.habitEntries.length +
+    snap.routineEntries.length
+  );
+}
+
+/** Total recorded failures across all three queues. */
+export function countFailures(snap: PendingSyncSnapshot): number {
+  return (
+    snap.failures.notifications.length +
+    snap.failures.habits.length +
+    snap.failures.routines.length
+  );
+}
+
+export function __resetPendingSyncForTests(): void {
+  unwireListeners();
+  listeners.clear();
+  snapshot = EMPTY_SNAPSHOT;
+  lastAttemptAt = null;
+  pendingRefresh = null;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -30,6 +30,8 @@ import {
   type RegistrationStatus,
 } from '../lib/device-registration';
 import ConnectionIndicator from '../components/ConnectionIndicator';
+import PendingSyncSection from '../components/PendingSyncSection';
+import ClearLocalCacheSection from '../components/ClearLocalCacheSection';
 
 const MIN_TOKEN_LENGTH = 8;
 
@@ -234,6 +236,10 @@ const SettingsPage: React.FC = () => {
                 Re-register
               </IonButton>
             </section>
+
+            <PendingSyncSection />
+
+            <ClearLocalCacheSection />
           </section>
         ) : (
           <section aria-label="Pairing form">


### PR DESCRIPTION
## Verification

- ✅ `npm run lint` — clean (no output, exit 0)
- ✅ `npx tsc --noEmit` — clean (no output, exit 0)
- ✅ `npm run test.unit -- --run` — **422 passed (41 files)**, including 22 new tests across `pendingSync.test.ts` (7), `clearLocalCache.test.ts` (5), `PendingSyncSection.test.tsx` (7), `ClearLocalCacheSection.test.tsx` (3)
- ✅ Local `origin/develop` HEAD at branch base: `ffd3d25` (Merge PR #73, [2C-28] staleness-banner)
- ✅ No new Capacitor plugin imports — `npm run android:sync` would be a no-op; Android Sync Structural Guard not triggered

## Summary

- Adds a read-only "Pending sync" disclosure row under the paired Settings view that surfaces the three offline write queues (`brain.writeQueue`, `brain.writeQueue.habitCompletions`, `brain.writeQueue.routineCompletions`) and the permanent-failure log from [2C-29]. Hidden on a clean state.
- Adds a "Clear local cache" destructive action at the bottom of paired Settings that wipes every `brain.cache.*` key and the TanStack Query cache while preserving `brain.writeQueue*` keys (pending writes survive the clear).

## Changes

**Aggregator (`src/lib/pendingSync.ts`)**: single read-aggregator over six Preferences keys (three live queues + three failure logs). Subscribes to `subscribeFlushDetail` and records `lastAttemptAt = Date.now()` on each `flushing` transition; subscribes to `document.visibilitychange` so the row refreshes on foreground per Pass 5 Summary §3 [2C-30]. Concurrent `refreshPendingSync()` calls coalesce. `__resetPendingSyncForTests` for test hygiene.

**Disclosure UI (`src/components/PendingSyncSection.tsx`)**: `useSyncExternalStore` over the aggregator. Hidden when `pending === 0 && failures === 0`. Collapsed summary: `Pending sync: N writes` plus `, last attempt Xm ago` once a `flushing` transition has been observed (omitted on first render of a cold start). Expanded view renders four sections: Notification responses, Habit completions, Routine completions, Recent failures. Titles for habit/routine entries resolve from the TanStack Query caches at `['habits', 'active']` and `['routines', 'active']`; fallback is the first 8 characters of the ID. Failure rows render a red HTTP-status pill + truncated server message + relative `dropped_at`.

**Cache-clear action (`src/lib/clearLocalCache.ts`)**: `Preferences.keys()` → filter `brain.cache.` prefix → per-key `Preferences.remove()` → `queryClient.clear()`. The prefix filter is the load-bearing piece: it excludes `brain.writeQueue*` (live queues + failures log + drop counters), `brain.pairing.*`, and `brain.deviceRegistration.*` from the wipe.

**Cache-clear UI (`src/components/ClearLocalCacheSection.tsx`)**: outline-danger button at the bottom of paired Settings, separated by 2rem margin per spec's "slight margin to discourage accidental tap." `IonAlert` confirm with the spec's exact copy: `Clear all cached data? Pending sync items are NOT cleared. The app will refetch when online.` On confirm, calls `clearLocalCache(queryClient)` and shows the `Local cache cleared.` toast.

**Settings wiring (`src/pages/SettingsPage.tsx`)**: imports both sections and renders them inside the post-pair branch — `PendingSyncSection` after the Device block, `ClearLocalCacheSection` at the bottom. Unpaired-state UI is untouched; the pre-pair form ([2C-12]) and validation ping flow ([2C-13]) do not regress.

## How to Verify

1. Pair the device on a working network.
2. Enable airplane mode, then queue: 2 notification responses, 1 habit completion, 1 routine completion.
3. Open Settings — confirm the `Pending sync: 4 writes` row appears below the Device section. After the first flush attempt fires, the `, last attempt Xm ago` suffix appears.
4. Tap the row to expand — confirm three sections render with the queued entries; habit and routine titles resolve from cache.
5. Re-enable network, wait for queues to drain, return to Settings — confirm the row hides.
6. Force a permanent failure (server returns 422 — see [2C-29] MV step 3) — confirm `Recent failures` section appears with a red 422 pill.
7. Tap `Clear local cache` — confirm the modal copy matches the spec — tap `Confirm` — confirm: any open list refetches on return, and the Pending sync row remains visible with the same entries (live queue + failures preserved). Toast reads `Local cache cleared.`

Manual on-device sequence is the canonical procedure; the integration tests exercise the same flow through mocked Preferences.

## Deviations

**#1 — Test files co-located instead of placed under `tests/integration/`.** The issue spec names `tests/integration/settingsPendingSync.spec.tsx` and `tests/integration/settingsClearCache.spec.tsx`. The repo's `tests/integration/` directory does not exist, and `brain3-companion` CLAUDE.md v3 codifies test co-location ("Tests are co-located with the module they test. Pattern: `src/lib/foo.ts` → `src/lib/foo.test.ts`"). [2C-28] PR #73 set the same precedent — its spec also named `tests/integration/` paths and the merged PR co-located everything. Following [2C-28]: `pendingSync.test.ts` + `clearLocalCache.test.ts` next to their modules in `src/lib/`; the two `*Section.test.tsx` files next to their components in `src/components/`. Each test file's header docstring notes the deviation and points at this PR.

**#2 — `lastAttemptAt` is tracked in-memory only, not persisted across app launches.** The spec text `Pending sync: N writes, last attempt Xm ago` is unconditional, but the underlying state was implemented as session-scoped state rather than a fourth Preferences key. The aggregator therefore renders the collapsed copy as `Pending sync: N writes` without the suffix until the first `flushing` transition fires after mount; once observed, the suffix appears. In practice `initWriteQueue` / `initCompletionQueues` trigger a flush near-instantly on app foreground, so the gap is brief. Persisting would cost a fourth key (`brain.writeQueue.lastAttemptAt`) for marginal user value; flagged here so the call can be revisited in a follow-up if MV step 1 wants the suffix immediate.

**#3 — `now` parameter dropped from row sub-components.** Initial draft passed a shared `now = Date.now()` to each row for consistency under fake timers in tests; eslint flagged it as unused since `formatDistanceToNowStrict` reads `Date.now()` internally. Removed the parameter and let date-fns own the timestamp source. No functional change.

## Test Results

```
> brain3-companion@0.0.1 test.unit
> vitest --run

 Test Files  41 passed (41)
      Tests  422 passed (422)
```

New tests:
- `pendingSync.test.ts` — 7 tests: reads all six keys, returns empty on absence, tolerates malformed JSON, coalesces concurrent refreshes, fires listener on subscribe + flushDetail emission, records `lastAttemptAt` only on `flushing` transitions.
- `clearLocalCache.test.ts` — 5 tests: removes all `brain.cache.*` keys, preserves `brain.writeQueue*` (including failure log + counters), preserves pairing/registration keys, calls `queryClient.clear()`, no-ops on empty prefix match.
- `PendingSyncSection.test.tsx` — 7 tests: hidden on clean state, renders on failures-only state, sums all three queues in collapsed copy, omits `last attempt` suffix initially, includes it after a `flushing` emission, expanded sections + title-resolution + ID-prefix fallback, failure pill renders red with HTTP status.
- `ClearLocalCacheSection.test.tsx` — 3 tests: modal opens with spec copy, cancel preserves all state, confirm wipes `brain.cache.*` + `queryClient.clear()` + preserves `brain.writeQueue*` and pairing + toast shows.

## Acceptance Checklist

- [x] `tests/integration/settingsPendingSync.spec.tsx` covers — co-located as `PendingSyncSection.test.tsx` per Deviation #1: hidden state when both queues + failures are empty
- [x] Collapsed copy verified
- [x] Expanded sections render queue entries
- [x] Failure section renders with red pill
- [x] Title resolution falls back gracefully when habit/routine not in cache
- [x] `tests/integration/settingsClearCache.spec.tsx` covers — co-located as `ClearLocalCacheSection.test.tsx` per Deviation #1: confirm-modal flow
- [x] Preferences keys with `brain.cache.*` prefix removed
- [x] `brain.writeQueue*` keys preserved
- [x] TanStack Query cache cleared
- [x] Settings UI does not regress [2C-12] URL/token entry or [2C-13] validation ping behavior (pre-pair branch untouched)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
