### PR TITLE
[2C-31] App: Cache lifecycle — seed-on-pair + wipe-on-token-change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,9 @@ import {
 } from './lib/device-registration';
 import { initWriteQueue } from './lib/writeQueue';
 import { initCompletionQueues } from './lib/completionQueues';
+import { useCacheSeed } from './lib/cacheSeed';
 import { ConnectionStateProvider } from './lib/connection/ConnectionStateProvider';
+import CacheSeedOverlay from './components/CacheSeedOverlay';
 import PermanentFailureToast from './components/PermanentFailureToast';
 import {
   clearPendingIntent,
@@ -109,6 +111,17 @@ const WriteQueueRunner: React.FC = () => {
 };
 
 /**
+ * [2C-31] Mounts the cache-seed hook once at the app root. The hook
+ * subscribes to pairing events and runs the five parallel seed fetches on
+ * pairing-complete (idempotent per token hash). State flips drive
+ * {@link CacheSeedOverlay}'s "Setting up…" overlay.
+ */
+const CacheSeedRunner: React.FC = () => {
+  useCacheSeed();
+  return null;
+};
+
+/**
  * [2C-19] Bridge for native-side pending intents — the FCM "Add note" tap
  * on a `checkin_prompt` notification writes a slot via Kotlin
  * `PendingIntentStore`; this hook drains it on mount and on
@@ -152,6 +165,8 @@ const App: React.FC = () => (
       <IonApp>
         <DeviceRegistrar />
         <WriteQueueRunner />
+        <CacheSeedRunner />
+        <CacheSeedOverlay />
         <PermanentFailureToast />
         <IonReactRouter>
           <PendingIntentRunner />

--- a/src/components/CacheSeedOverlay.test.tsx
+++ b/src/components/CacheSeedOverlay.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * [2C-31] CacheSeedOverlay tests. Co-located per repo CLAUDE.md v3; spec
+ * named `tests/integration/cacheSeed.spec.tsx` — see PR body Deviation #1.
+ *
+ * Covers the "Setting up overlay appears and dismisses correctly" sub-item
+ * of Acceptance criteria #1: the overlay reads the module-level seed
+ * status and renders the loading message during a run, then hides on
+ * settle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+}));
+
+vi.mock('../lib/notifications', () => ({
+  fetchNotifications: vi.fn(),
+  writeCachedNotifications: vi.fn(),
+}));
+vi.mock('../lib/habits', () => ({
+  fetchActiveHabits: vi.fn(),
+  writeCachedHabits: vi.fn(),
+}));
+vi.mock('../lib/routines', () => ({
+  fetchActiveRoutines: vi.fn(),
+  writeCachedRoutines: vi.fn(),
+}));
+vi.mock('../lib/rules', () => ({
+  fetchRules: vi.fn(),
+  writeCachedRules: vi.fn(),
+}));
+vi.mock('../lib/checkins', () => ({
+  fetchCheckins: vi.fn(),
+  writeCachedCheckins: vi.fn(),
+}));
+
+// IonLoading uses shadow-DOM internals that jsdom does not exercise; thin
+// wrapper exposing `isOpen` + `message` via a testable element.
+vi.mock('@ionic/react', async () => {
+  const actual = await vi.importActual<typeof import('@ionic/react')>(
+    '@ionic/react',
+  );
+  interface IonLoadingProps {
+    isOpen: boolean;
+    message?: string;
+    'data-testid'?: string;
+  }
+  const IonLoading: React.FC<IonLoadingProps> = ({
+    isOpen,
+    message,
+    ...rest
+  }) =>
+    isOpen ? (
+      <div role="status" data-testid={rest['data-testid'] ?? 'loading'}>
+        {message ?? ''}
+      </div>
+    ) : null;
+  return { ...actual, IonLoading };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { fetchNotifications, writeCachedNotifications } from '../lib/notifications';
+import { fetchActiveHabits, writeCachedHabits } from '../lib/habits';
+import { fetchActiveRoutines, writeCachedRoutines } from '../lib/routines';
+import { fetchRules, writeCachedRules } from '../lib/rules';
+import { fetchCheckins, writeCachedCheckins } from '../lib/checkins';
+import CacheSeedOverlay from './CacheSeedOverlay';
+import { __resetCacheSeedForTests, runCacheSeed } from '../lib/cacheSeed';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  __resetCacheSeedForTests();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+
+  vi.mocked(fetchNotifications).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchActiveHabits).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchActiveRoutines).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchRules).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchCheckins).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(writeCachedNotifications).mockResolvedValue();
+  vi.mocked(writeCachedHabits).mockResolvedValue();
+  vi.mocked(writeCachedRoutines).mockResolvedValue();
+  vi.mocked(writeCachedRules).mockResolvedValue();
+  vi.mocked(writeCachedCheckins).mockResolvedValue();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CacheSeedOverlay', () => {
+  it('is hidden when the seed status is idle', () => {
+    render(<CacheSeedOverlay />);
+    expect(screen.queryByTestId('cache-seed-overlay')).toBeNull();
+  });
+
+  it('renders the "Setting up…" message while a seed runs, then hides on settle', async () => {
+    // Hold one fetch open so we can observe the overlay during the run.
+    const releasers: Array<() => void> = [];
+    vi.mocked(fetchActiveHabits).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releasers.push(() => resolve({ ok: true, items: [] }));
+        }),
+    );
+
+    render(<CacheSeedOverlay />);
+    expect(screen.queryByTestId('cache-seed-overlay')).toBeNull();
+
+    const work = runCacheSeed({
+      url: 'https://brain.local:8000',
+      token: 'token-AAA',
+    });
+
+    const overlay = await screen.findByTestId('cache-seed-overlay');
+    expect(overlay.textContent).toBe('Setting up…');
+
+    for (const release of releasers) release();
+    await work;
+    await waitFor(() =>
+      expect(screen.queryByTestId('cache-seed-overlay')).toBeNull(),
+    );
+  });
+});

--- a/src/components/CacheSeedOverlay.tsx
+++ b/src/components/CacheSeedOverlay.tsx
@@ -1,0 +1,37 @@
+/**
+ * [2C-31] One-time "Setting up…" overlay shown while the cache seed runs
+ * after a fresh pair (or re-pair to a different token). Dismisses on settle
+ * regardless of per-fetch success — partial failure is not a blocking state
+ * per Pass 5 Summary §3 [2C-31] Scope.
+ *
+ * Reads the seed status from {@link ../lib/cacheSeed#subscribeCacheSeedState}
+ * via `useSyncExternalStore` so the overlay reflects the module-level
+ * singleton state without coupling to the runner instance.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { IonLoading } from '@ionic/react';
+import {
+  getCacheSeedStatus,
+  subscribeCacheSeedState,
+  type CacheSeedStatus,
+} from '../lib/cacheSeed';
+
+const CacheSeedOverlay: React.FC = () => {
+  const status = useSyncExternalStore<CacheSeedStatus>(
+    subscribeCacheSeedState,
+    getCacheSeedStatus,
+    getCacheSeedStatus,
+  );
+
+  return (
+    <IonLoading
+      isOpen={status === 'seeding'}
+      message="Setting up…"
+      duration={0}
+      data-testid="cache-seed-overlay"
+    />
+  );
+};
+
+export default CacheSeedOverlay;

--- a/src/lib/cacheSeed.test.ts
+++ b/src/lib/cacheSeed.test.ts
@@ -1,0 +1,247 @@
+/**
+ * [2C-31] cacheSeed tests. Co-located per repo CLAUDE.md v3; spec named
+ * `tests/integration/cacheSeed.spec.tsx` — see PR body Deviation #1.
+ *
+ * Covers Acceptance criteria #1: pairing-complete event triggers all 5
+ * fetches in parallel, idempotency flag prevents re-seed within session,
+ * individual fetch failure does not block others, "Setting up" status flag
+ * transitions correctly (the overlay subscribes to the same state surface
+ * exercised here).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+vi.mock('./notifications', () => ({
+  fetchNotifications: vi.fn(),
+  writeCachedNotifications: vi.fn(),
+}));
+vi.mock('./habits', () => ({
+  fetchActiveHabits: vi.fn(),
+  writeCachedHabits: vi.fn(),
+}));
+vi.mock('./routines', () => ({
+  fetchActiveRoutines: vi.fn(),
+  writeCachedRoutines: vi.fn(),
+}));
+vi.mock('./rules', () => ({
+  fetchRules: vi.fn(),
+  writeCachedRules: vi.fn(),
+}));
+vi.mock('./checkins', () => ({
+  fetchCheckins: vi.fn(),
+  writeCachedCheckins: vi.fn(),
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { fetchNotifications, writeCachedNotifications } from './notifications';
+import { fetchActiveHabits, writeCachedHabits } from './habits';
+import { fetchActiveRoutines, writeCachedRoutines } from './routines';
+import { fetchRules, writeCachedRules } from './rules';
+import { fetchCheckins, writeCachedCheckins } from './checkins';
+import {
+  SEED_COMPLETE_KEY,
+  __resetCacheSeedForTests,
+  getCacheSeedStatus,
+  runCacheSeed,
+  subscribeCacheSeedState,
+} from './cacheSeed';
+import { computeTokenHash, type Pairing } from './pairing';
+
+const prefsStore = new Map<string, string>();
+
+const PAIRING: Pairing = {
+  url: 'https://brain.local:8000',
+  token: 'token-A',
+};
+
+beforeEach(() => {
+  prefsStore.clear();
+  __resetCacheSeedForTests();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+
+  vi.mocked(fetchNotifications).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchActiveHabits).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchActiveRoutines).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchRules).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(fetchCheckins).mockResolvedValue({ ok: true, items: [] });
+  vi.mocked(writeCachedNotifications).mockResolvedValue();
+  vi.mocked(writeCachedHabits).mockResolvedValue();
+  vi.mocked(writeCachedRoutines).mockResolvedValue();
+  vi.mocked(writeCachedRules).mockResolvedValue();
+  vi.mocked(writeCachedCheckins).mockResolvedValue();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runCacheSeed', () => {
+  it('fires all five fetches when no seed-complete marker is set', async () => {
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchActiveHabits)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchActiveRoutines)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchRules)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchCheckins)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledWith(PAIRING);
+    expect(vi.mocked(fetchActiveHabits)).toHaveBeenCalledWith(PAIRING);
+    expect(vi.mocked(fetchActiveRoutines)).toHaveBeenCalledWith(PAIRING);
+    expect(vi.mocked(fetchRules)).toHaveBeenCalledWith(PAIRING);
+    expect(vi.mocked(fetchCheckins)).toHaveBeenCalledWith(PAIRING);
+  });
+
+  it('runs the five fetches in parallel (none waits on another to start)', async () => {
+    let startCount = 0;
+    let peakInFlight = 0;
+    const tracker = async (): Promise<{ ok: true; items: [] }> => {
+      startCount += 1;
+      peakInFlight = Math.max(peakInFlight, startCount);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      startCount -= 1;
+      return { ok: true, items: [] };
+    };
+    vi.mocked(fetchNotifications).mockImplementation(tracker);
+    vi.mocked(fetchActiveHabits).mockImplementation(tracker);
+    vi.mocked(fetchActiveRoutines).mockImplementation(tracker);
+    vi.mocked(fetchRules).mockImplementation(tracker);
+    vi.mocked(fetchCheckins).mockImplementation(tracker);
+
+    await runCacheSeed(PAIRING);
+    expect(peakInFlight).toBe(5);
+  });
+
+  it('marks the seed complete for the current token hash on settle', async () => {
+    await runCacheSeed(PAIRING);
+    const expectedHash = await computeTokenHash(PAIRING.token);
+    expect(prefsStore.get(SEED_COMPLETE_KEY)).toBe(expectedHash);
+  });
+
+  it('skips when the seed-complete marker already matches the current token hash', async () => {
+    const hash = await computeTokenHash(PAIRING.token);
+    prefsStore.set(SEED_COMPLETE_KEY, hash);
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(fetchNotifications)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchActiveHabits)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchActiveRoutines)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchRules)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchCheckins)).not.toHaveBeenCalled();
+  });
+
+  it('runs again after the marker is cleared (post-wipe re-seed)', async () => {
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(1);
+    // Simulate the [2C-31] wipe clearing the brain.cache.* key.
+    prefsStore.delete(SEED_COMPLETE_KEY);
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs again when a different token pairs (different hash)', async () => {
+    await runCacheSeed(PAIRING);
+    await runCacheSeed({ url: PAIRING.url, token: 'token-B' });
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(2);
+  });
+
+  it('a rules-endpoint 500 does not block the other four fetches', async () => {
+    vi.mocked(fetchRules).mockResolvedValue({
+      ok: false,
+      reason: 'server',
+      statusCode: 500,
+    });
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(writeCachedNotifications)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedHabits)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedRoutines)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedRules)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeCachedCheckins)).toHaveBeenCalledTimes(1);
+    // Marker still set so the next foreground does not re-run the seed —
+    // per-surface useQuery retries on its own.
+    const expectedHash = await computeTokenHash(PAIRING.token);
+    expect(prefsStore.get(SEED_COMPLETE_KEY)).toBe(expectedHash);
+  });
+
+  it('a thrown exception in one fetch does not block the others', async () => {
+    vi.mocked(fetchActiveHabits).mockRejectedValue(new Error('boom'));
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(writeCachedNotifications)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedHabits)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeCachedRoutines)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedRules)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(writeCachedCheckins)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write to a surface cache when the fetch returns ok=false', async () => {
+    vi.mocked(fetchActiveHabits).mockResolvedValue({
+      ok: false,
+      reason: 'unauthorized',
+      statusCode: 401,
+    });
+    await runCacheSeed(PAIRING);
+    expect(vi.mocked(writeCachedHabits)).not.toHaveBeenCalled();
+  });
+
+  it('emits seeding → idle status transitions across the run', async () => {
+    const events: string[] = [];
+    const unsubscribe = subscribeCacheSeedState((next) => events.push(next));
+    expect(getCacheSeedStatus()).toBe('idle');
+    // Hold one fetch open so we can observe the intermediate `seeding`
+    // status before the run settles. Array-of-resolvers avoids the
+    // `let`/closure narrowing-to-null trap.
+    const releasers: Array<() => void> = [];
+    vi.mocked(fetchActiveHabits).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releasers.push(() => resolve({ ok: true, items: [] }));
+        }),
+    );
+    const work = runCacheSeed(PAIRING);
+    await waitFor(() => expect(getCacheSeedStatus()).toBe('seeding'));
+    for (const release of releasers) release();
+    await work;
+    expect(getCacheSeedStatus()).toBe('idle');
+    expect(events).toEqual(['seeding', 'idle']);
+    unsubscribe();
+  });
+
+  it('coalesces concurrent runs for the same token hash', async () => {
+    let resolvers: Array<() => void> = [];
+    vi.mocked(fetchNotifications).mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          resolvers.push(() => resolve({ ok: true, items: [] })),
+        ),
+    );
+    const first = runCacheSeed(PAIRING);
+    const second = runCacheSeed(PAIRING);
+    // Wait until the in-flight seed has dispatched its fetches, then assert
+    // a second call did not spawn a parallel seed.
+    await waitFor(() =>
+      expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(1),
+    );
+    for (const r of resolvers) r();
+    resolvers = [];
+    await Promise.all([first, second]);
+    expect(vi.mocked(fetchNotifications)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/cacheSeed.ts
+++ b/src/lib/cacheSeed.ts
@@ -1,0 +1,170 @@
+/**
+ * [2C-31] Cache seed on pairing-complete.
+ *
+ * Performs the five parallel fetches that the v2.0.0 app caches so a
+ * freshly-paired device renders every list surface immediately on first
+ * navigation. Idempotent per token hash via `brain.cache.seedCompleteFor`:
+ * once a seed completes for a token, the marker prevents re-runs until a
+ * different token pairs (which wipes the marker via {@link ./cacheWipe}).
+ *
+ * Failure handling: each fetch is independent (`Promise.allSettled`). One
+ * failure does NOT block the others — per Pass 5 Summary §3 [2C-31] Scope.
+ * Failed fetches retry on next foreground via the surfaces' own `useQuery`
+ * calls. The seed-complete marker is written on settle regardless of
+ * per-fetch outcomes, so a transient seed-time outage does not pin the
+ * "Setting up…" overlay on subsequent launches.
+ *
+ * The hook ({@link useCacheSeed}) is called from `App.tsx`. State transitions
+ * (`idle` → `seeding` → `idle`) are exposed via {@link subscribeCacheSeedState}
+ * so the {@link ../components/CacheSeedOverlay} can render the spinner
+ * during the work without coupling to the runner.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { Preferences } from '@capacitor/preferences';
+import { fetchCheckins, writeCachedCheckins } from './checkins';
+import { fetchActiveHabits, writeCachedHabits } from './habits';
+import { fetchNotifications, writeCachedNotifications } from './notifications';
+import { fetchActiveRoutines, writeCachedRoutines } from './routines';
+import { fetchRules, writeCachedRules } from './rules';
+import {
+  computeTokenHash,
+  loadPairing,
+  subscribePairing,
+  type Pairing,
+} from './pairing';
+
+export const SEED_COMPLETE_KEY = 'brain.cache.seedCompleteFor';
+
+export type CacheSeedStatus = 'idle' | 'seeding';
+
+type Listener = (status: CacheSeedStatus) => void;
+
+const listeners = new Set<Listener>();
+let currentStatus: CacheSeedStatus = 'idle';
+const inFlight = new Map<string, Promise<void>>();
+
+function setStatus(next: CacheSeedStatus): void {
+  if (currentStatus === next) return;
+  currentStatus = next;
+  for (const l of listeners) l(next);
+}
+
+export function getCacheSeedStatus(): CacheSeedStatus {
+  return currentStatus;
+}
+
+export function subscribeCacheSeedState(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+async function loadSeedCompleteFor(): Promise<string | null> {
+  const { value } = await Preferences.get({ key: SEED_COMPLETE_KEY });
+  return value ?? null;
+}
+
+async function markSeedComplete(tokenHash: string): Promise<void> {
+  await Preferences.set({ key: SEED_COMPLETE_KEY, value: tokenHash });
+}
+
+/**
+ * Run the five seed fetches in parallel and persist each surface's
+ * `brain.cache.*` blob. The Promise resolves once every fetch settles.
+ * Per-surface failures are swallowed — the writer is only invoked when the
+ * fetcher returns `{ ok: true, items }`, so a 5xx or network error leaves
+ * the existing cache (if any) untouched.
+ */
+async function seedSurfaces(pairing: Pairing): Promise<void> {
+  await Promise.allSettled([
+    fetchNotifications(pairing).then(async (result) => {
+      if (result.ok) await writeCachedNotifications(result.items);
+    }),
+    fetchActiveHabits(pairing).then(async (result) => {
+      if (result.ok) await writeCachedHabits(result.items);
+    }),
+    fetchActiveRoutines(pairing).then(async (result) => {
+      if (result.ok) await writeCachedRoutines(result.items);
+    }),
+    fetchRules(pairing).then(async (result) => {
+      if (result.ok) await writeCachedRules(result.items);
+    }),
+    fetchCheckins(pairing).then(async (result) => {
+      if (result.ok) await writeCachedCheckins(result.items);
+    }),
+  ]);
+}
+
+/**
+ * Seed the cache for `pairing` if the per-token idempotency flag does not
+ * already record a completed seed for the same token hash. Concurrent calls
+ * for the same token hash coalesce — the first call owns the work, the
+ * second awaits the same promise.
+ */
+export async function runCacheSeed(pairing: Pairing): Promise<void> {
+  const tokenHash = await computeTokenHash(pairing.token);
+  const seedFor = await loadSeedCompleteFor();
+  if (seedFor === tokenHash) return;
+
+  const existing = inFlight.get(tokenHash);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const work = (async (): Promise<void> => {
+    setStatus('seeding');
+    try {
+      await seedSurfaces(pairing);
+      await markSeedComplete(tokenHash);
+    } finally {
+      inFlight.delete(tokenHash);
+      if (inFlight.size === 0) setStatus('idle');
+    }
+  })();
+  inFlight.set(tokenHash, work);
+  await work;
+}
+
+/**
+ * Subscribe to pairing-complete events and run the cache seed when a pairing
+ * is present. Idempotent on remount; the per-token flag short-circuits any
+ * redundant work.
+ *
+ * Returns the current seeding status (`'idle'` or `'seeding'`) so consumers
+ * can render UI off the same state surface the overlay reads.
+ */
+export function useCacheSeed(): CacheSeedStatus {
+  const status = useSyncExternalStore<CacheSeedStatus>(
+    subscribeCacheSeedState,
+    getCacheSeedStatus,
+    getCacheSeedStatus,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void loadPairing().then((pairing) => {
+      if (cancelled || !pairing) return;
+      void runCacheSeed(pairing);
+    });
+    const unsubscribe = subscribePairing((pairing) => {
+      if (pairing) void runCacheSeed(pairing);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return status;
+}
+
+export function __resetCacheSeedForTests(): void {
+  listeners.clear();
+  currentStatus = 'idle';
+  inFlight.clear();
+}

--- a/src/lib/cacheWipe.test.ts
+++ b/src/lib/cacheWipe.test.ts
@@ -1,0 +1,127 @@
+/**
+ * [2C-31] cacheWipe tests. Co-located per repo CLAUDE.md v3; spec named
+ * `tests/integration/cacheWipeOnTokenChange.spec.tsx` — see PR body
+ * Deviation #1.
+ *
+ * Covers the wipe filter shape (Acceptance criteria #2 sub-item "queue keys
+ * included in wipe set"). The full token-change flow (gating on
+ * pingHealth, modal flow, post-wipe re-seed) is exercised end-to-end in
+ * `src/pages/SettingsPage.cacheLifecycle.test.tsx`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+import { Preferences } from '@capacitor/preferences';
+import { QueryClient } from '@tanstack/react-query';
+import { wipeCacheAndQueueForPairingChange } from './cacheWipe';
+
+const prefsStore = new Map<string, string>();
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.keys).mockReset();
+  vi.mocked(Preferences.keys).mockImplementation(async () => ({
+    keys: Array.from(prefsStore.keys()),
+  }));
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('wipeCacheAndQueueForPairingChange', () => {
+  it('removes every brain.cache.* key', async () => {
+    prefsStore.set('brain.cache.habits.active', '[]');
+    prefsStore.set('brain.cache.routines.active', '[]');
+    prefsStore.set('brain.cache.notifications', '[]');
+    prefsStore.set('brain.cache.rules', '[]');
+    prefsStore.set('brain.cache.checkins', '[]');
+    prefsStore.set('brain.cache.seedCompleteFor', 'abc');
+    await wipeCacheAndQueueForPairingChange(new QueryClient());
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.routines.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.notifications')).toBe(false);
+    expect(prefsStore.has('brain.cache.rules')).toBe(false);
+    expect(prefsStore.has('brain.cache.checkins')).toBe(false);
+    expect(prefsStore.has('brain.cache.seedCompleteFor')).toBe(false);
+  });
+
+  it('removes every brain.writeQueue* key (live queues + failures + counters)', async () => {
+    prefsStore.set('brain.writeQueue', '[{}]');
+    prefsStore.set('brain.writeQueue.habitCompletions', '[{}]');
+    prefsStore.set('brain.writeQueue.routineCompletions', '[]');
+    prefsStore.set('brain.writeQueue.failures.brain.writeQueue', '[{}]');
+    prefsStore.set(
+      'brain.writeQueue.failures.brain.writeQueue.habitCompletions',
+      '[]',
+    );
+    prefsStore.set('brain.writeQueue.failures.totalDropsCount', '3');
+    prefsStore.set('brain.writeQueue.failures.seenCount', '0');
+    await wipeCacheAndQueueForPairingChange(new QueryClient());
+    expect(prefsStore.has('brain.writeQueue')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue.habitCompletions')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue.routineCompletions')).toBe(false);
+    expect(
+      prefsStore.has('brain.writeQueue.failures.brain.writeQueue'),
+    ).toBe(false);
+    expect(
+      prefsStore.has('brain.writeQueue.failures.brain.writeQueue.habitCompletions'),
+    ).toBe(false);
+    expect(prefsStore.has('brain.writeQueue.failures.totalDropsCount')).toBe(
+      false,
+    );
+    expect(prefsStore.has('brain.writeQueue.failures.seenCount')).toBe(false);
+  });
+
+  it('preserves pairing identity keys and device registration marker', async () => {
+    prefsStore.set('brain.serverUrl', 'https://brain.local:8000');
+    prefsStore.set('brain.bearerToken', 'tk');
+    prefsStore.set('brain.pairing.tokenHash', 'cafef00d');
+    prefsStore.set('brain.pairing.previousUrl', 'https://brain.local:8000');
+    prefsStore.set('brain.deviceRegisteredToken', 'fcm-xyz');
+    prefsStore.set('brain.cache.habits.active', '[]');
+    await wipeCacheAndQueueForPairingChange(new QueryClient());
+    expect(prefsStore.has('brain.serverUrl')).toBe(true);
+    expect(prefsStore.has('brain.bearerToken')).toBe(true);
+    expect(prefsStore.has('brain.pairing.tokenHash')).toBe(true);
+    expect(prefsStore.has('brain.pairing.previousUrl')).toBe(true);
+    expect(prefsStore.has('brain.deviceRegisteredToken')).toBe(true);
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+  });
+
+  it('calls queryClient.clear()', async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['habits', 'active'], [{ id: 'h1', title: 't' }]);
+    queryClient.setQueryData(['routines', 'active'], [{ id: 'r1' }]);
+    await wipeCacheAndQueueForPairingChange(queryClient);
+    expect(queryClient.getQueryData(['habits', 'active'])).toBeUndefined();
+    expect(queryClient.getQueryData(['routines', 'active'])).toBeUndefined();
+  });
+
+  it('no-ops cleanly when nothing matches the wipe prefixes', async () => {
+    prefsStore.set('brain.serverUrl', 'https://x');
+    prefsStore.set('brain.pairing.tokenHash', 'cafef00d');
+    await wipeCacheAndQueueForPairingChange(new QueryClient());
+    expect(prefsStore.has('brain.serverUrl')).toBe(true);
+    expect(prefsStore.has('brain.pairing.tokenHash')).toBe(true);
+    expect(vi.mocked(Preferences.remove)).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/cacheWipe.ts
+++ b/src/lib/cacheWipe.ts
@@ -1,0 +1,51 @@
+/**
+ * [2C-31] Wipe-on-token-change operation.
+ *
+ * Stricter than [2C-30]'s `clearLocalCache` action: this wipe also drops the
+ * write-queue Preferences keys (live entries + failures log + counters)
+ * because queue entries enqueued against the previous pairing are unsafe to
+ * flush against a new server. Per Pass 5 Summary §3 [2C-31] Scope.
+ *
+ * Wipe filter prefixes:
+ * - `brain.cache.` — all entity caches plus the seed-complete marker.
+ * - `brain.writeQueue` — `brain.writeQueue` itself, the
+ *   `brain.writeQueue.habitCompletions` / `brain.writeQueue.routineCompletions`
+ *   live queues, the `brain.writeQueue.failures.*` log + counters.
+ *
+ * Pairing identity keys (`brain.serverUrl`, `brain.bearerToken`,
+ * `brain.pairing.tokenHash`, `brain.pairing.previousUrl`) and the device
+ * registration marker (`brain.deviceRegisteredToken`) are NOT touched —
+ * those represent the new pairing's identity, which is being established by
+ * the same Connect flow that invoked the wipe.
+ */
+
+import { Preferences } from '@capacitor/preferences';
+import type { QueryClient } from '@tanstack/react-query';
+
+export const CACHE_KEY_PREFIX = 'brain.cache.';
+export const WRITE_QUEUE_KEY_PREFIX = 'brain.writeQueue';
+
+function shouldWipe(key: string): boolean {
+  return (
+    key.startsWith(CACHE_KEY_PREFIX) || key.startsWith(WRITE_QUEUE_KEY_PREFIX)
+  );
+}
+
+/**
+ * Remove every Preferences key under the `brain.cache.` or `brain.writeQueue`
+ * prefix and clear the passed query client. Invoked from `[2C-12]`'s Connect
+ * handler after the user confirms the wipe modal that fires when the new
+ * pairing's token hash or URL differs from the stored markers. See
+ * {@link ./pairing#savePairing} for the markers that drive the diff and
+ * {@link ./cacheSeed#runCacheSeed} for the re-seed that follows.
+ */
+export async function wipeCacheAndQueueForPairingChange(
+  queryClient: QueryClient,
+): Promise<void> {
+  const { keys } = await Preferences.keys();
+  const targets = keys.filter(shouldWipe);
+  await Promise.all(
+    targets.map((key) => Preferences.remove({ key })),
+  );
+  queryClient.clear();
+}

--- a/src/lib/pairing.test.ts
+++ b/src/lib/pairing.test.ts
@@ -10,9 +10,14 @@ vi.mock('@capacitor/preferences', () => ({
 
 import { Preferences } from '@capacitor/preferences';
 import {
+  PAIRING_PREVIOUS_URL_KEY,
+  PAIRING_TOKEN_HASH_KEY,
   PAIRING_TOKEN_KEY,
   PAIRING_URL_KEY,
   clearPairing,
+  computeTokenHash,
+  loadPreviousPairingUrl,
+  loadStoredTokenHash,
   loadPairing,
   savePairing,
   subscribePairing,
@@ -60,6 +65,13 @@ describe('savePairing', () => {
     expect(store.has(PAIRING_URL_KEY)).toBe(false);
     expect(store.has(PAIRING_TOKEN_KEY)).toBe(false);
   });
+
+  it('[2C-31] writes the token hash and previous-URL markers alongside the pairing', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    const expectedHash = await computeTokenHash('abcdef1234');
+    expect(store.get(PAIRING_TOKEN_HASH_KEY)).toBe(expectedHash);
+    expect(store.get(PAIRING_PREVIOUS_URL_KEY)).toBe('https://brain.local:8000');
+  });
 });
 
 describe('loadPairing', () => {
@@ -93,6 +105,54 @@ describe('clearPairing', () => {
     await clearPairing();
     expect(store.has(PAIRING_URL_KEY)).toBe(false);
     expect(store.has(PAIRING_TOKEN_KEY)).toBe(false);
+  });
+
+  it('[2C-31] preserves the token hash + previous-URL markers across re-pair', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    const expectedHash = await computeTokenHash('abcdef1234');
+    await clearPairing();
+    expect(store.get(PAIRING_TOKEN_HASH_KEY)).toBe(expectedHash);
+    expect(store.get(PAIRING_PREVIOUS_URL_KEY)).toBe('https://brain.local:8000');
+  });
+});
+
+describe('[2C-31] computeTokenHash', () => {
+  it('returns a 32-character hex string (16 bytes)', async () => {
+    const hash = await computeTokenHash('abcdef1234');
+    expect(hash).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('is deterministic for identical inputs', async () => {
+    const a = await computeTokenHash('the-same-token');
+    const b = await computeTokenHash('the-same-token');
+    expect(a).toBe(b);
+  });
+
+  it('differs for different inputs (even by one character)', async () => {
+    const a = await computeTokenHash('token-one');
+    const b = await computeTokenHash('token-two');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('[2C-31] marker loaders', () => {
+  it('loadStoredTokenHash returns the hash written by savePairing', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    const expectedHash = await computeTokenHash('abcdef1234');
+    expect(await loadStoredTokenHash()).toBe(expectedHash);
+  });
+
+  it('loadStoredTokenHash returns null when no pairing has ever been saved', async () => {
+    expect(await loadStoredTokenHash()).toBeNull();
+  });
+
+  it('loadPreviousPairingUrl returns the URL written by savePairing', async () => {
+    await savePairing('https://brain.local:8000', 'abcdef1234');
+    expect(await loadPreviousPairingUrl()).toBe('https://brain.local:8000');
+  });
+
+  it('loadPreviousPairingUrl returns null when no pairing has ever been saved', async () => {
+    expect(await loadPreviousPairingUrl()).toBeNull();
   });
 });
 

--- a/src/lib/pairing.ts
+++ b/src/lib/pairing.ts
@@ -8,6 +8,16 @@ export interface Pairing {
 export const PAIRING_URL_KEY = 'brain.serverUrl';
 export const PAIRING_TOKEN_KEY = 'brain.bearerToken';
 
+/**
+ * Markers persisted alongside the pairing to drive [2C-31] cache-wipe
+ * detection. Both survive {@link clearPairing} so the next Connect can
+ * compare against the previous pairing's identity. Comparing the SHA-256
+ * hash (first 16 bytes hex) rather than the raw token keeps the token from
+ * leaking through Preferences inspection per Pass 5 Summary §3 [2C-31].
+ */
+export const PAIRING_TOKEN_HASH_KEY = 'brain.pairing.tokenHash';
+export const PAIRING_PREVIOUS_URL_KEY = 'brain.pairing.previousUrl';
+
 type Listener = (pairing: Pairing | null) => void;
 
 const listeners = new Set<Listener>();
@@ -19,10 +29,41 @@ function notify(pairing: Pairing | null): void {
 }
 
 /**
+ * SHA-256 hash of the bearer token, truncated to the first 16 bytes and
+ * hex-encoded. Used as the wipe-comparison anchor in [2C-31] and as the
+ * per-token idempotency key for the cache seed (`brain.cache.seedCompleteFor`).
+ */
+export async function computeTokenHash(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(token),
+  );
+  const bytes = new Uint8Array(digest).slice(0, 16);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function loadStoredTokenHash(): Promise<string | null> {
+  const { value } = await Preferences.get({ key: PAIRING_TOKEN_HASH_KEY });
+  return value ?? null;
+}
+
+export async function loadPreviousPairingUrl(): Promise<string | null> {
+  const { value } = await Preferences.get({ key: PAIRING_PREVIOUS_URL_KEY });
+  return value ?? null;
+}
+
+/**
  * Persist URL + token together. Pseudo-atomic: on token-write failure,
  * the URL is removed so the keys remain in a both-or-neither state.
+ *
+ * Also updates the [2C-31] wipe-comparison markers
+ * ({@link PAIRING_TOKEN_HASH_KEY}, {@link PAIRING_PREVIOUS_URL_KEY}). The
+ * markers are written after the pseudo-atomic block — a marker-write
+ * failure surfaces as a rejected promise but does not roll back the live
+ * URL+token, since the pairing IS functional even without the markers.
  */
 export async function savePairing(url: string, token: string): Promise<void> {
+  const tokenHash = await computeTokenHash(token);
   await Preferences.set({ key: PAIRING_URL_KEY, value: url });
   try {
     await Preferences.set({ key: PAIRING_TOKEN_KEY, value: token });
@@ -30,6 +71,8 @@ export async function savePairing(url: string, token: string): Promise<void> {
     await Preferences.remove({ key: PAIRING_URL_KEY });
     throw error;
   }
+  await Preferences.set({ key: PAIRING_TOKEN_HASH_KEY, value: tokenHash });
+  await Preferences.set({ key: PAIRING_PREVIOUS_URL_KEY, value: url });
   notify({ url, token });
 }
 

--- a/src/pages/SettingsPage.cacheLifecycle.test.tsx
+++ b/src/pages/SettingsPage.cacheLifecycle.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * [2C-31] Wipe-on-token-change integration tests on SettingsPage. Co-located
+ * per repo CLAUDE.md v3; spec named
+ * `tests/integration/cacheWipeOnTokenChange.spec.tsx` — see PR body
+ * Deviation #1 (precedent: [2C-28] PR #73, [2C-30] PR #74).
+ *
+ * Covers Acceptance criteria #2:
+ *   - wipe gated on successful validation (typo case does NOT wipe)
+ *   - wipe on token diff
+ *   - wipe on URL diff
+ *   - confirmation modal flow (Continue + Cancel)
+ *   - queue keys included in wipe set (live + failures + counters)
+ *
+ * Per-token idempotency + the "Setting up…" overlay state transitions are
+ * covered in `cacheSeed.test.ts`. The wipe filter contract is covered in
+ * `cacheWipe.test.ts`. This file proves the wiring through the Connect
+ * handler.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    keys: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/health', () => ({
+  pingHealth: vi.fn(),
+}));
+
+vi.mock('../lib/device-registration', () => ({
+  getRegistrationStatus: () => ({ kind: 'idle' }),
+  subscribeRegistration: () => () => undefined,
+  reRegisterDevice: vi.fn(),
+}));
+
+// Avoid the connection store side-effects (Network listener, etc.) — the
+// indicator is a header chip and not exercised by these tests.
+vi.mock('../components/ConnectionIndicator', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/PendingSyncSection', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/ClearLocalCacheSection', () => ({
+  default: () => null,
+}));
+
+// IonAlert + IonToast use shadow-DOM internals that jsdom does not
+// exercise. IonInput is a custom element whose `value` and `onIonInput`
+// don't round-trip through jsdom's native `input` event the way a plain
+// `<input>` does. Replace all three with thin wrappers exposing the same
+// prop contract via plain DOM — same pattern as
+// `ClearLocalCacheSection.test.tsx`.
+vi.mock('@ionic/react', async () => {
+  const actual = await vi.importActual<typeof import('@ionic/react')>(
+    '@ionic/react',
+  );
+  type AlertButton = {
+    text: string;
+    role?: string;
+    handler?: () => void;
+  };
+  interface IonAlertProps {
+    isOpen: boolean;
+    header?: string;
+    message?: string;
+    buttons?: AlertButton[];
+    onDidDismiss?: () => void;
+  }
+  interface IonToastProps {
+    isOpen: boolean;
+    message?: string;
+  }
+  interface IonInputProps {
+    type?: string;
+    inputMode?: string;
+    placeholder?: string;
+    value?: string | number | null;
+    onIonInput?: (event: { detail: { value: string | null } }) => void;
+    onIonBlur?: () => void;
+  }
+  interface IonButtonProps {
+    children?: React.ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }
+  const IonAlert: React.FC<IonAlertProps> = ({
+    isOpen,
+    header,
+    message,
+    buttons,
+    onDidDismiss,
+  }) =>
+    isOpen ? (
+      <div role="alertdialog" aria-label={header} data-testid="alert">
+        {header ? <h2>{header}</h2> : null}
+        {message ? <p>{message}</p> : null}
+        {(buttons ?? []).map((b, i) => (
+          <button
+            key={i}
+            type="button"
+            data-testid={`alert-button-${i}`}
+            data-role={b.role ?? 'action'}
+            onClick={() => {
+              b.handler?.();
+              onDidDismiss?.();
+            }}
+          >
+            {b.text}
+          </button>
+        ))}
+      </div>
+    ) : null;
+  const IonToast: React.FC<IonToastProps> = ({ isOpen, message }) =>
+    isOpen ? (
+      <div role="status" data-testid="toast">
+        {message ?? ''}
+      </div>
+    ) : null;
+  const IonInput: React.FC<IonInputProps> = ({
+    type,
+    placeholder,
+    value,
+    onIonInput,
+    onIonBlur,
+  }) => (
+    <input
+      type={type === 'password' ? 'password' : type ?? 'text'}
+      placeholder={placeholder}
+      value={value ?? ''}
+      onChange={(event) =>
+        onIonInput?.({ detail: { value: event.target.value } })
+      }
+      onBlur={() => onIonBlur?.()}
+    />
+  );
+  const IonButton: React.FC<IonButtonProps> = ({
+    children,
+    disabled,
+    onClick,
+  }) => (
+    <button type="button" disabled={!!disabled} onClick={() => onClick?.()}>
+      {children}
+    </button>
+  );
+  return { ...actual, IonAlert, IonToast, IonInput, IonButton };
+});
+
+import { Preferences } from '@capacitor/preferences';
+import { pingHealth } from '../lib/health';
+import {
+  PAIRING_PREVIOUS_URL_KEY,
+  PAIRING_TOKEN_HASH_KEY,
+  PAIRING_TOKEN_KEY,
+  PAIRING_URL_KEY,
+  computeTokenHash,
+} from '../lib/pairing';
+import SettingsPage from './SettingsPage';
+
+const prefsStore = new Map<string, string>();
+
+const PAIRED_URL = 'https://brain.local:8000';
+const OTHER_URL = 'https://brain.other:8000';
+
+function withProviders(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/settings']}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+async function seedMarkers(url: string, token: string): Promise<void> {
+  const hash = await computeTokenHash(token);
+  prefsStore.set(PAIRING_TOKEN_HASH_KEY, hash);
+  prefsStore.set(PAIRING_PREVIOUS_URL_KEY, url);
+}
+
+beforeEach(() => {
+  prefsStore.clear();
+  vi.mocked(Preferences.get).mockReset();
+  vi.mocked(Preferences.set).mockReset();
+  vi.mocked(Preferences.remove).mockReset();
+  vi.mocked(Preferences.keys).mockReset();
+  vi.mocked(Preferences.get).mockImplementation(async ({ key }) => ({
+    value: prefsStore.get(key) ?? null,
+  }));
+  vi.mocked(Preferences.set).mockImplementation(async ({ key, value }) => {
+    prefsStore.set(key, value);
+  });
+  vi.mocked(Preferences.remove).mockImplementation(async ({ key }) => {
+    prefsStore.delete(key);
+  });
+  vi.mocked(Preferences.keys).mockImplementation(async () => ({
+    keys: Array.from(prefsStore.keys()),
+  }));
+  vi.mocked(pingHealth).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function fillFormAndSubmit(
+  url: string,
+  token: string,
+): Promise<void> {
+  const user = userEvent.setup();
+  // Form-only mode requires loadPairing → null (no pairing keys set in
+  // prefsStore).
+  const urlInput = await screen.findByPlaceholderText('https://brain.local:8000');
+  const tokenInput = await screen.findByPlaceholderText(
+    'Paste token from brain3 token generate',
+  );
+  // The mocked IonInput is a plain `<input>` — `fireEvent.change` updates
+  // its value and fires the React `onChange` handler, which the mock
+  // forwards to `onIonInput` so the page-level state updates.
+  fireEvent.change(urlInput, { target: { value: url } });
+  fireEvent.change(tokenInput, { target: { value: token } });
+  const connectButton = screen.getByRole('button', { name: 'Connect' });
+  await user.click(connectButton);
+}
+
+describe('SettingsPage [2C-31] wipe-on-token-change', () => {
+  it('fresh pair (no markers): pingHealth.ok → no wipe modal → savePairing fires', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    const qc = new QueryClient();
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'token-AAA');
+
+    await waitFor(() => {
+      expect(prefsStore.get(PAIRING_URL_KEY)).toBe(PAIRED_URL);
+    });
+    expect(prefsStore.get(PAIRING_TOKEN_KEY)).toBe('token-AAA');
+    expect(screen.queryByTestId('alert')).toBeNull();
+  });
+
+  it('re-pair with same token + URL: pingHealth.ok → markers match → no wipe modal', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    const qc = new QueryClient();
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'token-AAA');
+
+    await waitFor(() => {
+      expect(prefsStore.get(PAIRING_TOKEN_KEY)).toBe('token-AAA');
+    });
+    expect(screen.queryByTestId('alert')).toBeNull();
+  });
+
+  it('token typo (MV step 3): pingHealth.unauthorized → no wipe modal, markers intact, cache intact', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({
+      ok: false,
+      reason: 'unauthorized',
+      statusCode: 401,
+    });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    prefsStore.set('brain.cache.habits.active', '[{"id":"h1"}]');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    const qc = new QueryClient();
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'wrongtoken');
+
+    // Wait for the error message to surface so we know the handler ran.
+    await screen.findByText('Token invalid. Check and try again.');
+    // No wipe modal.
+    expect(screen.queryByTestId('alert')).toBeNull();
+    // Markers, cache, and queue from previous pairing all intact.
+    expect(prefsStore.get(PAIRING_TOKEN_HASH_KEY)).toBe(
+      await computeTokenHash('token-AAA'),
+    );
+    expect(prefsStore.get(PAIRING_PREVIOUS_URL_KEY)).toBe(PAIRED_URL);
+    expect(prefsStore.get('brain.cache.habits.active')).toBe('[{"id":"h1"}]');
+    expect(prefsStore.get('brain.writeQueue')).toBe('[{}]');
+    // No new pairing was committed.
+    expect(prefsStore.has(PAIRING_URL_KEY)).toBe(false);
+    expect(prefsStore.has(PAIRING_TOKEN_KEY)).toBe(false);
+  });
+
+  it('token change: pingHealth.ok with different token hash → wipe modal opens', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    const qc = new QueryClient();
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'token-BBB');
+
+    expect(await screen.findByTestId('alert')).toBeDefined();
+    expect(
+      screen.getByText(/clear all cached data and any pending sync items/i),
+    ).toBeDefined();
+    // Modal is pre-commit — no pairing keys have been written yet.
+    expect(prefsStore.has(PAIRING_URL_KEY)).toBe(false);
+    expect(prefsStore.has(PAIRING_TOKEN_KEY)).toBe(false);
+  });
+
+  it('URL change with same token: pingHealth.ok with different URL → wipe modal opens', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    const qc = new QueryClient();
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(OTHER_URL, 'token-AAA');
+
+    expect(await screen.findByTestId('alert')).toBeDefined();
+  });
+
+  it('modal Confirm: wipes cache + queue keys, saves new pairing, updates markers', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    prefsStore.set('brain.cache.habits.active', '[{"id":"h1"}]');
+    prefsStore.set('brain.cache.notifications', '[]');
+    prefsStore.set('brain.cache.seedCompleteFor', 'old-hash');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    prefsStore.set('brain.writeQueue.habitCompletions', '[{}]');
+    prefsStore.set('brain.writeQueue.failures.totalDropsCount', '2');
+    prefsStore.set('brain.writeQueue.failures.seenCount', '0');
+    const qc = new QueryClient();
+    qc.setQueryData(['habits', 'active'], [{ id: 'h1' }]);
+
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'token-BBB');
+    const modal = await screen.findByTestId('alert');
+    expect(modal).toBeDefined();
+
+    const continueButton = screen.getByTestId('alert-button-1');
+    expect(continueButton.getAttribute('data-role')).toBe('destructive');
+    const user = userEvent.setup();
+    await user.click(continueButton);
+
+    await waitFor(() => {
+      expect(prefsStore.get(PAIRING_TOKEN_KEY)).toBe('token-BBB');
+    });
+    // Cache + queue keys wiped.
+    expect(prefsStore.has('brain.cache.habits.active')).toBe(false);
+    expect(prefsStore.has('brain.cache.notifications')).toBe(false);
+    expect(prefsStore.has('brain.cache.seedCompleteFor')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue.habitCompletions')).toBe(false);
+    expect(prefsStore.has('brain.writeQueue.failures.totalDropsCount')).toBe(
+      false,
+    );
+    expect(prefsStore.has('brain.writeQueue.failures.seenCount')).toBe(false);
+    // TanStack cache cleared.
+    expect(qc.getQueryData(['habits', 'active'])).toBeUndefined();
+    // New pairing committed.
+    expect(prefsStore.get(PAIRING_URL_KEY)).toBe(PAIRED_URL);
+    // Markers updated to the new token.
+    const newHash = await computeTokenHash('token-BBB');
+    expect(prefsStore.get(PAIRING_TOKEN_HASH_KEY)).toBe(newHash);
+    expect(prefsStore.get(PAIRING_PREVIOUS_URL_KEY)).toBe(PAIRED_URL);
+  });
+
+  it('modal Cancel: no wipe, no save, previous pairing data intact', async () => {
+    vi.mocked(pingHealth).mockResolvedValue({ ok: true });
+    await seedMarkers(PAIRED_URL, 'token-AAA');
+    prefsStore.set('brain.cache.habits.active', '[{"id":"h1"}]');
+    prefsStore.set('brain.writeQueue', '[{}]');
+    const qc = new QueryClient();
+    qc.setQueryData(['habits', 'active'], [{ id: 'h1' }]);
+
+    render(<SettingsPage />, { wrapper: withProviders(qc) });
+
+    await fillFormAndSubmit(PAIRED_URL, 'token-BBB');
+    await screen.findByTestId('alert');
+
+    const cancelButton = screen.getByTestId('alert-button-0');
+    expect(cancelButton.getAttribute('data-role')).toBe('cancel');
+    const user = userEvent.setup();
+    await user.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('alert')).toBeNull();
+    });
+    // No wipe, no save.
+    expect(prefsStore.get('brain.cache.habits.active')).toBe('[{"id":"h1"}]');
+    expect(prefsStore.get('brain.writeQueue')).toBe('[{}]');
+    expect(prefsStore.has(PAIRING_URL_KEY)).toBe(false);
+    expect(prefsStore.has(PAIRING_TOKEN_KEY)).toBe(false);
+    expect(prefsStore.get(PAIRING_TOKEN_HASH_KEY)).toBe(
+      await computeTokenHash('token-AAA'),
+    );
+    expect(qc.getQueryData(['habits', 'active'])).toBeDefined();
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
+  IonAlert,
   IonButton,
   IonContent,
   IonHeader,
@@ -16,9 +17,13 @@ import {
   IonToolbar,
 } from '@ionic/react';
 import { eye, eyeOff } from 'ionicons/icons';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   clearPairing,
+  computeTokenHash,
   loadPairing,
+  loadPreviousPairingUrl,
+  loadStoredTokenHash,
   savePairing,
   type Pairing,
 } from '../lib/pairing';
@@ -29,9 +34,13 @@ import {
   subscribeRegistration,
   type RegistrationStatus,
 } from '../lib/device-registration';
+import { wipeCacheAndQueueForPairingChange } from '../lib/cacheWipe';
 import ConnectionIndicator from '../components/ConnectionIndicator';
 import PendingSyncSection from '../components/PendingSyncSection';
 import ClearLocalCacheSection from '../components/ClearLocalCacheSection';
+
+const WIPE_CONFIRM_MESSAGE =
+  'This will clear all cached data and any pending sync items from the previous pairing. Continue?';
 
 const MIN_TOKEN_LENGTH = 8;
 
@@ -59,6 +68,7 @@ function fcmTokenPreview(status: RegistrationStatus): string {
 
 const SettingsPage: React.FC = () => {
   const history = useHistory();
+  const queryClient = useQueryClient();
   const [storedPairing, setStoredPairing] = useState<Pairing | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [url, setUrl] = useState('');
@@ -72,6 +82,14 @@ const SettingsPage: React.FC = () => {
   const [registration, setRegistration] = useState<RegistrationStatus>(
     getRegistrationStatus(),
   );
+  /**
+   * [2C-31] Set when pingHealth succeeds for a token+URL combination that
+   * differs from the markers persisted by the previous pairing. The
+   * confirmation modal renders off this state; commit (savePairing + wipe)
+   * runs from the `Continue` handler so cancel leaves the previous pairing
+   * intact.
+   */
+  const [pendingWipe, setPendingWipe] = useState<Pairing | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,6 +137,15 @@ const SettingsPage: React.FC = () => {
     );
   };
 
+  const commitPairing = async (
+    nextUrl: string,
+    nextToken: string,
+  ): Promise<void> => {
+    await savePairing(nextUrl, nextToken);
+    setToastMessage('Connected to BRAIN');
+    history.replace('/notifications');
+  };
+
   const handleConnect = async () => {
     if (!canConnect) return;
     setSubmitting(true);
@@ -128,9 +155,22 @@ const SettingsPage: React.FC = () => {
     try {
       const result = await pingHealth(trimmedUrl, trimmedToken);
       if (result.ok) {
-        await savePairing(trimmedUrl, trimmedToken);
-        setToastMessage('Connected to BRAIN');
-        history.replace('/notifications');
+        // [2C-31] Wipe-on-token-change: gate on successful validation. An
+        // invalid-token typo never reaches this branch, so the previous
+        // pairing's cache + queue survive a failed pingHealth (MV step 3).
+        const [storedHash, previousUrl] = await Promise.all([
+          loadStoredTokenHash(),
+          loadPreviousPairingUrl(),
+        ]);
+        const newHash = await computeTokenHash(trimmedToken);
+        const isPairingChange =
+          storedHash !== null &&
+          (newHash !== storedHash || trimmedUrl !== previousUrl);
+        if (isPairingChange) {
+          setPendingWipe({ url: trimmedUrl, token: trimmedToken });
+          return;
+        }
+        await commitPairing(trimmedUrl, trimmedToken);
         return;
       }
       switch (result.reason) {
@@ -152,6 +192,22 @@ const SettingsPage: React.FC = () => {
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleWipeConfirm = async (): Promise<void> => {
+    if (!pendingWipe) return;
+    const target = pendingWipe;
+    setPendingWipe(null);
+    try {
+      await wipeCacheAndQueueForPairingChange(queryClient);
+      await commitPairing(target.url, target.token);
+    } catch {
+      setToastMessage('Could not save pairing. Try again.');
+    }
+  };
+
+  const handleWipeCancel = (): void => {
+    setPendingWipe(null);
   };
 
   const handleRepair = async () => {
@@ -313,6 +369,31 @@ const SettingsPage: React.FC = () => {
           message={toastMessage ?? ''}
           duration={4000}
           onDidDismiss={() => setToastMessage(null)}
+        />
+
+        <IonAlert
+          isOpen={pendingWipe !== null}
+          header="Clear data from previous pairing?"
+          message={WIPE_CONFIRM_MESSAGE}
+          buttons={[
+            {
+              text: 'Cancel',
+              role: 'cancel',
+              handler: handleWipeCancel,
+            },
+            {
+              text: 'Continue',
+              role: 'destructive',
+              handler: () => {
+                void handleWipeConfirm();
+              },
+            },
+          ]}
+          onDidDismiss={() => {
+            if (pendingWipe !== null) setPendingWipe(null);
+            setSubmitting(false);
+          }}
+          data-testid="wipe-confirm-modal"
         />
       </IonContent>
     </IonPage>


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no output, exit 0)
- `npx tsc --noEmit` — ✅ Pass (no output, exit 0)
- `npm run test.unit -- --run` — ✅ Pass (**456 passed across 45 files**, +34 new tests across `pairing.test.ts` (+7), `cacheSeed.test.ts` (11), `cacheWipe.test.ts` (5), `CacheSeedOverlay.test.tsx` (2), `SettingsPage.cacheLifecycle.test.tsx` (7))
- No new Capacitor plugin imports — `npm run android:sync` would be a no-op; Android Sync Structural Guard not triggered.

Ran locally against develop HEAD at `7c0e524` (Merge PR #74, [2C-30] Settings pending-sync + clear local cache) immediately before opening this PR.

## Summary

- Cache seed on pairing-complete: five parallel fetches via `Promise.allSettled` (notifications 8-day window, active habits, active routines, rules, recent check-ins) populate the existing `brain.cache.*` Preferences blobs so a freshly-paired device renders every list surface immediately on first navigation. Idempotent per token hash via `brain.cache.seedCompleteFor`. A one-time `IonLoading` "Setting up…" overlay renders during the work and dismisses on settle.
- Cache + queue wipe on token / URL change: `SettingsPage.handleConnect` compares the new token's SHA-256 hash (first 16 bytes hex) and URL against the markers persisted by the previous pairing. On a difference, the user sees a confirmation modal pre-commit. On Continue the wipe removes every `brain.cache.*` and `brain.writeQueue*` Preferences key, clears the TanStack Query cache, then commits the new pairing — which re-runs the seed because the seed-complete marker was wiped along with the cache. **Wipe is strictly gated on `pingHealth` success** (MV step 3 token-typo path never reaches the wipe).

## Changes

**Pairing markers (`src/lib/pairing.ts`)**: `savePairing` now also writes `brain.pairing.tokenHash` (SHA-256 first 16 bytes hex) and `brain.pairing.previousUrl`. Both survive `clearPairing` so the next Connect can detect a pairing change. Marker writes follow the pseudo-atomic URL+token block; a marker-write failure surfaces as a rejected promise but does not roll back the live URL+token (the pairing is still functional). New exports: `computeTokenHash`, `loadStoredTokenHash`, `loadPreviousPairingUrl`.

**Cache seed (`src/lib/cacheSeed.ts`)**: module-level state (`'idle' | 'seeding'`) with `subscribeCacheSeedState` for the overlay + `useCacheSeed()` React hook for the runner. `runCacheSeed(pairing)` is idempotent per token hash and coalesces concurrent calls. The five surface fetchers run in parallel; each `writeCached*` is invoked only on the surface's `{ ok: true }` outcome. The seed-complete marker is written on settle regardless of per-fetch outcomes per the spec's "failed fetches retry on next foreground via the surfaces' own queries."

**Cache seed runner + overlay**: `App.tsx` mounts `<CacheSeedRunner />` (drives `useCacheSeed`) and `<CacheSeedOverlay />` (reads the same state surface and renders `IonLoading` with "Setting up…"). The overlay decouples from the runner — multiple consumers could read the singleton.

**Wipe (`src/lib/cacheWipe.ts`)**: `wipeCacheAndQueueForPairingChange(queryClient)` removes every Preferences key under the `brain.cache.` or `brain.writeQueue` prefix, then calls `queryClient.clear()`. The filter intentionally drops `brain.writeQueue*` (live queues + failures log + counters) — queue entries enqueued against the previous pairing are unsafe to flush against a new server per Pass 5 Summary §3 [2C-31].

**Settings wiring (`src/pages/SettingsPage.tsx`)**: `handleConnect` now branches after `pingHealth.ok`: compute new token hash, load the previous markers, and if they differ from the new credentials open the wipe-confirm `IonAlert` pre-commit. `handleWipeConfirm` runs the wipe + `savePairing` + navigates. `handleWipeCancel` (and `onDidDismiss`) clears the pending state so the user can edit and retry.

## How to Verify

1. **Plane-test seed-on-pair.** Fresh-install the APK on the test device. Pair using a valid URL + token. Within ~2 seconds of pairing, the "Setting up…" overlay dismisses; navigating Notifications, Habits, Routines, Rules, and Recent Check-ins each renders data immediately on first navigation (no loading spinner).
2. **Plane-test offline cold-start.** Enable airplane mode. Cold-start the app. Navigate every list surface — each renders cached content seeded in step 1.
3. **Validation-failure no-wipe (MV step 3).** Re-enable network. Open Settings → Re-pair → enter the existing URL + **an invalid token** → tap Connect. Validation fails ("Token invalid"), no wipe modal appears, the previous pairing's cache + queue remain in Preferences. Confirm via APK Analyzer's `assets/capacitor.config.json` OR by re-pairing with the original credentials and observing the original cache.
4. **Token-change wipe (MV step 4).** Generate a fresh token (`python -m scripts.generate_token` in `brain3`, env updated, server restarted). Settings → Re-pair → enter the URL + the new token → Connect. Validation succeeds → "Clear data from previous pairing?" modal appears → tap Continue. Cache + queue wipe, `IonLoading` "Setting up…" overlay shows briefly, list surfaces re-render with fresh data.
5. **Wipe with queued writes (MV step 5).** Repeat step 4 with 2 actions queued offline (queue 2 habit completions while airplane-mode is enabled, then re-enable network and re-pair to a different token). On Continue, confirm the queue is wiped along with the cache (Settings → Pending sync row should hide) — no stale POSTs hit the new server.

Full procedure is the canonical reference target for `docs/plane-test.md` (authored later in [2C-32]).

## Deviations

**#1 — Test files co-located instead of placed under `tests/integration/`.** The issue spec names `tests/integration/cacheSeed.spec.tsx` and `tests/integration/cacheWipeOnTokenChange.spec.tsx`. The repo's `tests/integration/` directory does not exist, and `brain3-companion` CLAUDE.md v3 codifies test co-location ("Tests are co-located with the module they test. Pattern: `src/lib/foo.ts` → `src/lib/foo.test.ts`"). Following the standing precedent — [2C-28] PR #73 + [2C-30] PR #74, both of which faced the same conflict and resolved by co-locating. Split across:
- `src/lib/pairing.test.ts` additions (markers + `computeTokenHash`)
- `src/lib/cacheSeed.test.ts` (11 tests covering all of AC#1 except the live overlay render)
- `src/components/CacheSeedOverlay.test.tsx` (2 tests covering "overlay appears and dismisses correctly")
- `src/lib/cacheWipe.test.ts` (5 tests covering the wipe filter — "queue keys included in wipe set")
- `src/pages/SettingsPage.cacheLifecycle.test.tsx` (7 tests covering the full Connect flow: token-typo no-wipe, token diff, URL diff, modal Confirm, modal Cancel)

**#2 — Check-ins seed uses the existing `fetchCheckins()` (logged-after 30-day window) instead of the spec's `?limit=20` query.** Spec scope says `GET /api/checkins/?limit=20` "matches `[2C-20]`," but `[2C-20]`'s actual surface (`fetchCheckins` in `src/lib/checkins.ts`) uses `?logged_after=<30-days-ago-local-midnight-UTC>`, not `?limit=20`. Calling the existing fetcher means the seed populates the exact cache the surface reads on offline launch; a literal `?limit=20` would create a divergent cache the surface would not re-use. Honoring the spec's intent ("matches [2C-20]" — i.e., align with the existing surface) over the literal query string.

**#3 — Wipe trigger fires from `handleConnect` after Re-pair clears credentials; not an edit-in-place save on paired Settings.** Spec MV step 3 ("Change the token to an invalid value and tap Save") implies an edit-in-place save flow on the paired Settings view. Spec Scope explicitly says "in `[2C-12]`'s save handler" — which is the existing `handleConnect`, the only save flow in the codebase. To preserve the wipe-detection invariant across the pre-existing Re-pair-clears-credentials UX, `brain.pairing.tokenHash` + `brain.pairing.previousUrl` are persisted by `savePairing` and survive `clearPairing`, so they remain available as comparison anchors after the user taps Re-pair → enters new credentials → Connect. "Previous pairing remains intact" in MV step 3 is interpreted as the cache + queue intact (which the validation-gating guarantees) — the credentials were already cleared by Re-pair itself, but that is pre-existing UX, not new behavior. Flagged here so L can decide whether a follow-up should add an in-place edit affordance to the paired Settings view; that work would be scope expansion to [2C-31].

**#4 — Confirmation modal copy differs slightly from the spec.** Spec literal: `"This will clear all cached data and any pending sync items from the previous pairing. Continue?"`. Used verbatim as the `IonAlert` `message`. The `header` (Ionic convention: short title) reads `"Clear data from previous pairing?"` so the user has a glanceable subject before reading the body. Buttons render as `Cancel` / `Continue` matching the spec's "Continue?" cue. No functional deviation — flagged for transparency.

## Test Results

```
> brain3-companion@0.0.1 test.unit
> vitest --run

 Test Files  45 passed (45)
      Tests  456 passed (456)
```

New tests:
- `pairing.test.ts` (+7): savePairing writes the markers; clearPairing preserves the markers across re-pair; `computeTokenHash` returns 32-hex deterministic hashes that differ per input; `loadStoredTokenHash` + `loadPreviousPairingUrl` round-trip.
- `cacheSeed.test.ts` (11): five fetches dispatched + arguments passed correctly; runs in parallel (peak in-flight = 5); marks complete on settle; skips when marker matches; runs again after marker cleared (post-wipe re-seed); runs for a different token (different hash); rules-500 doesn't block others; thrown exception doesn't block others; ok=false skips the writer; `seeding → idle` status emissions; concurrent runs coalesce.
- `cacheWipe.test.ts` (5): removes every `brain.cache.*`; removes every `brain.writeQueue*` (live + failures + counters); preserves pairing identity + device-registration keys; calls `queryClient.clear()`; no-ops when nothing matches.
- `CacheSeedOverlay.test.tsx` (2): hidden when idle; renders the "Setting up…" message during a run, then hides on settle.
- `SettingsPage.cacheLifecycle.test.tsx` (7): fresh pair (no markers) commits without a modal; same-token + same-URL re-pair commits without a modal; token typo (`pingHealth.unauthorized`) shows no modal and preserves markers + cache + queue; token-hash diff opens the modal pre-commit; URL diff opens the modal pre-commit; Continue wipes cache + queue + clears query cache + commits the new pairing + updates markers; Cancel does no wipe + no save + preserves cache + queue + markers.

## Acceptance Checklist

- [x] `tests/integration/cacheSeed.spec.tsx` covers — co-located per Deviation #1: pairing-complete event triggers all 5 fetches in parallel (`cacheSeed.test.ts` "runs the five fetches in parallel")
- [x] idempotency flag prevents re-seed within session (`cacheSeed.test.ts` "skips when the seed-complete marker already matches")
- [x] individual fetch failure does not block others (`cacheSeed.test.ts` "rules-endpoint 500 does not block the other four")
- [x] "Setting up" overlay appears and dismisses correctly (`CacheSeedOverlay.test.tsx` + `cacheSeed.test.ts` status emissions)
- [x] `tests/integration/cacheWipeOnTokenChange.spec.tsx` covers — co-located per Deviation #1: token-hash comparison logic (`pairing.test.ts` `computeTokenHash` + `SettingsPage.cacheLifecycle.test.tsx`)
- [x] wipe gated on successful validation (typo case does NOT wipe) (`SettingsPage.cacheLifecycle.test.tsx` "token typo (MV step 3)")
- [x] wipe on token diff (`SettingsPage.cacheLifecycle.test.tsx` "token change")
- [x] wipe on URL diff (`SettingsPage.cacheLifecycle.test.tsx` "URL change with same token")
- [x] confirmation modal flow (`SettingsPage.cacheLifecycle.test.tsx` Confirm + Cancel cases)
- [x] queue keys included in wipe set (`cacheWipe.test.ts` "removes every brain.writeQueue* key" + Confirm case)
- [x] post-wipe re-seed runs (`cacheSeed.test.ts` "runs again after the marker is cleared (post-wipe re-seed)")
- [x] No regression in [2C-08] device registration or [2C-12] URL/token entry (full suite passes; pre-pair branch + Re-pair behavior unchanged; `pairing.test.ts` pseudo-atomic rollback still asserted)

Closes #25
