### PR TITLE
[2C-Bug-06]: test.unit script enters watch mode in non-interactive shells

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test.e2e": "cypress run",
-    "test.unit": "vitest",
+    "test.unit": "vitest run",
     "lint": "eslint",
     "android:sync": "npm run build && npx cap sync android",
     "android:build:debug": "npm run android:sync && cd android && .\\gradlew.bat assembleDebug",


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npm run test.unit` — ✅ Pass (456 passed across 45 files; process exited cleanly — this is the verification that the fix works as intended)

Ran locally against develop HEAD at `50b6e6e` immediately before opening this PR.

## Summary

`npm run test.unit` previously invoked `vitest` with no subcommand, which defaults to watch mode. In interactive shells the watcher renders a TUI; in non-interactive shells (CI runs, `bash -c`, agent dispatch) the watcher blocks on stdin and the process hangs indefinitely. The fix is a one-character change to `package.json:16` — `"vitest"` → `"vitest run"` — so the canonical test command runs once, prints results, and exits with status 0/non-zero.

`vitest run` is the documented "run once, exit" subcommand form per Vitest CLI docs. The interactive watch path remains available via `npx vitest` directly, as called out in the issue body.

## Changes

- `package.json` (line 16): `"test.unit": "vitest"` → `"test.unit": "vitest run"`. Single-character edit.

No other files touched. No npm install or lockfile change. No watch-mode sibling script introduced — `npx vitest` remains the canonical interactive entry point per the issue body's "no `test.unit:watch` for now" note.

## How to Verify

1. Check out this branch.
2. From a non-interactive shell, run `npm run test.unit`.
3. Observe: Vitest runs the suite once, prints the summary, and the process exits.
4. (Optional) Run `npx vitest` interactively — the watch TUI still opens as before.

## Deviations

None. Implementation matches the issue body's Suggested Fix exactly.

## Test Results

- `npm run lint` → exit 0, no errors.
- `npm run test.unit` → `Test Files  45 passed (45)` / `Tests  456 passed (456)` / `Duration  13.16s`, process exited cleanly.

Pre-existing `offsetHeight` jsdom stderr noise in `RoutineDetailPage.test.tsx` is unchanged by this PR (Ionic component interaction with jsdom, non-fatal — all assertions pass). Not introduced or affected by this change.

## Acceptance Checklist

- [x] `npm run test.unit` runs the test suite once and exits in a non-interactive shell
- [x] No watch-mode sibling script added (per issue body — future enhancement if desirable)
- [x] No CI workflow changes (no current workflow invokes the script, per issue body verification)
- [x] Interactive `npx vitest` continues to enter watch mode (canonical interactive path preserved by leaving the binary untouched and only narrowing the npm-script invocation)

Closes #56