### PR TITLE
[2C-Gap-05]: Pre-PR Android build check (Dev Release workflow PR-trigger)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 permissions:
   contents: write
@@ -57,9 +60,26 @@ jobs:
         # loudly if the secret is missing or malformed — closing the silent
         # try/catch skip at android/app/build.gradle:63-70 that hid this bug
         # class on every CI build prior to [2C-Bug-05].
+        #
+        # PR-trigger handling ([2C-Gap-05]): GitHub Actions does not expose
+        # repo secrets to `pull_request` runs from forks. When the secret is
+        # empty on a PR-triggered run, skip the inject and let build.gradle's
+        # try/catch silent-skip absorb the missing plugin. The PR-trigger gate
+        # exists for compile-only verification (catching Bug-02/-03-class
+        # failures pre-merge), not push-notification correctness. `push` runs
+        # still fail loud because dev-channel pre-releases must carry working
+        # Firebase wiring.
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
         run: |
+          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "::notice::GOOGLE_SERVICES_JSON_BASE64 not available on this PR run — skipping Firebase inject. Build proceeds without push-notification wiring (see workflow comment)."
+              exit 0
+            fi
+            echo "::error::GOOGLE_SERVICES_JSON_BASE64 secret is missing on a push-triggered build."
+            exit 1
+          fi
           echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > android/app/google-services.json
           if ! grep -q '"project_id"' android/app/google-services.json; then
             echo "::error::google-services.json injection failed — file is empty or malformed."
@@ -111,6 +131,7 @@ jobs:
           git log -1 --pretty=%s "$GITHUB_SHA" > .commit-subject
 
       - name: Compose release notes
+        if: github.event_name == 'push'
         run: |
           {
             echo "Automated dev pre-release built from \`develop\`."
@@ -125,6 +146,7 @@ jobs:
           } > .release-notes
 
       - name: Create GitHub pre-release
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -136,6 +158,7 @@ jobs:
             --target "$GITHUB_SHA"
 
       - name: Prune old dev pre-releases (keep last 10)
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Wire the Dev Release workflow to run on `pull_request` events targeting `develop`, in addition to the existing `push` trigger. PR runs execute the full Android Gradle build (Node setup → JDK 17 → Android SDK → web bundle → `cap sync` → `assembleDebug`) and stop there; the three release-publish steps (compose notes, `gh release create`, prune) are gated to `push` events so opening a PR does not publish a dev pre-release. The Firebase `google-services.json` inject soft-fails on PR runs where the secret is unavailable (fork PRs don't receive repo secrets); push runs continue to fail loud.

Closes #55

## Changes

`.github/workflows/dev-release.yml`:

- **`on:` block** — adds `pull_request: { branches: [develop] }` alongside the existing `push:` trigger.
- **Inject google-services.json for Firebase** — adds a pre-decode guard. If `GOOGLE_SERVICES_JSON_BASE64` is empty:
  - On `pull_request` events: emits a `::notice` and exits 0. The `build.gradle:63-70` try/catch silent-skip then absorbs the missing plugin — the PR gate is for compile-only verification (catching Bug-02/-03-class failures pre-merge), not push-notification correctness.
  - On `push` events: emits an `::error` and exits 1 — existing behavior preserved. Dev-channel pre-releases must carry working Firebase wiring.
  - A comment block above the step documents the trade-off inline and references `[2C-Gap-05]`.
- **`Compose release notes`, `Create GitHub pre-release`, `Prune old dev pre-releases (keep last 10)`** — each gated with `if: github.event_name == 'push'`. PR runs reach these steps and skip them; push runs are unchanged.

Build steps run unchanged on both events: Node, JDK, Android SDK, `npm ci`, inject, keystore regen, web build, `cap sync`, `assembleDebug`. `Compute release metadata` is intentionally not gated — it is idempotent, its outputs are referenced only by gated steps downstream, and the issue body did not call it out among the publish-gated steps.

## How to Verify

CI-side (post-merge, on the next PR opened against `develop`):

1. **PR-trigger fires** — opening a PR against `develop` runs the workflow under the `pull_request` event. All build steps execute through `Build debug APK`. The three publish steps show as "Skipped" in the run summary. PR check passes if the build succeeds.
2. **Push behavior unchanged** — merging a PR fires the workflow under `push` to `develop`. All steps run including release publish. The dev pre-release is created and old releases are pruned, as before.
3. **Soft-fail path on PR** — if a contributor opens a PR from a fork (where `secrets.GOOGLE_SERVICES_JSON_BASE64` is unavailable), the inject step emits a `::notice` and the build proceeds. `assembleDebug` runs against a non-Firebase-wired APK — compile verification is still gated.
4. **Loud-fail path on push** — pushing to `develop` with an empty/missing secret still fails the build with `::error`.

Local-side (pre-PR, results below in Test Results):

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run test.unit` — 456 tests across 45 files passed
- `npx js-yaml .github/workflows/dev-release.yml` — parses without error

## Deviations

None. Implementation matches the issue body's Suggested Fix verbatim. The issue's "open question" about Firebase secrets on fork PRs is resolved per the issue body's own recommendation: soft-fail when the secret is unavailable on PR runs, with a comment documenting the trade-off in the workflow file.

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint
(clean — no output, exit 0)

$ npx tsc --noEmit
(clean — no output, exit 0)

$ npm run test.unit
> brain3-companion@0.0.1 test.unit
> vitest run
...
 Test Files  45 passed (45)
      Tests  456 passed (456)
   Duration  13.09s

$ npx js-yaml .github/workflows/dev-release.yml > /dev/null && echo "YAML parse OK"
YAML parse OK
```

Per the Wave 1 watch-item in the dispatch brief: no CI gates exist yet — the PR-gate workflow (#77) is gated on this wave's merge. The local verification above is the gate for this PR.

## Acceptance Checklist

- [x] `.github/workflows/dev-release.yml` `on:` block includes `pull_request: { branches: [develop] }` alongside the existing `push:` trigger.
- [x] `Compose release notes`, `Create GitHub pre-release`, and `Prune old dev pre-releases` steps gated with `if: github.event_name == 'push'`.
- [x] Build steps (Node, JDK, SDK, install, inject, keystore, web build, cap sync, assemble) run on both events.
- [x] Firebase inject soft-fails on PR runs with missing secret; trade-off documented inline in the workflow comment.
- [x] Push behavior unchanged — release publish + prune still run post-merge.
- [x] No scope expansion beyond the issue body.