### PR TITLE
[2C-Gap-03]: dev-release CI workflow APK filename short-SHA embed

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -145,13 +145,28 @@ jobs:
             echo "> $(cat .commit-subject)"
           } > .release-notes
 
+      - name: Rename APK with short SHA
+        # Embed the commit short-SHA in the uploaded asset filename so
+        # provenance is mechanically verifiable from the filename alone after
+        # download — no APK Analyzer step required. Closes the recurrence
+        # vector for the [2C-Bug-05] AVD diagnostic stall, where a pre-fix
+        # APK was sideloaded in mistake for a post-fix build because the
+        # GitHub Releases visual sort was non-chronological. See [2C-Gap-03]
+        # (#53). Gated on `push` to match the publish steps below — PR runs
+        # never reach `gh release create`, so the renamed asset has no
+        # consumer on PR-triggered builds.
+        if: github.event_name == 'push'
+        run: |
+          cp android/app/build/outputs/apk/debug/app-debug.apk \
+             "android/app/build/outputs/apk/debug/brain3-companion-develop-${{ steps.meta.outputs.short_sha }}.apk"
+
       - name: Create GitHub pre-release
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.meta.outputs.tag }}" \
-            android/app/build/outputs/apk/debug/app-debug.apk \
+            "android/app/build/outputs/apk/debug/brain3-companion-develop-${{ steps.meta.outputs.short_sha }}.apk" \
             --title "${{ steps.meta.outputs.title }}" \
             --notes-file .release-notes \
             --prerelease \

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,7 +26,7 @@ GitHub Actions workflow at [`.github/workflows/dev-release.yml`](../.github/work
 7. Publishes a **pre-release** to GitHub Releases with:
    - Tag: `develop-{short-sha}` (e.g., `develop-a35e43c`)
    - Title: `Dev build {short-sha} ({yyyy-mm-dd})`
-   - Asset: `app-debug.apk`
+   - Asset: `brain3-companion-develop-{short-sha}.apk` (e.g., `brain3-companion-develop-a35e43c.apk`)
    - Notes: source commit link + commit subject
 8. Prunes older `develop-*` pre-releases, keeping only the 10 most recent
 
@@ -215,7 +215,7 @@ Both dev and release APKs sideload the same way. There is no Play Store distribu
 1. Open the GitHub Releases page on the device's browser:
    - Latest dev pre-release: <https://github.com/WilliM233/brain3-companion/releases?q=prerelease%3Atrue>
    - Latest formal release: <https://github.com/WilliM233/brain3-companion/releases/latest>
-2. Tap the `app-debug.apk` (dev) or `app-release.apk` (release) asset to download
+2. Tap the `brain3-companion-develop-{short-sha}.apk` (dev) or `app-release.apk` (release) asset to download
 3. Open the downloaded APK from notifications or the file manager
 4. Confirm install when Android prompts
 


### PR DESCRIPTION
## Verification

- `npm run lint` — Pass (eslint clean, exit 0)
- `npm run test.unit` — Pass (456 passed across 45 files, exit 0)
- YAML structure preserved (rename step is additive between existing "Compose release notes" and "Create GitHub pre-release" steps; both publish-gated steps continue to gate on `github.event_name == 'push'`)
- Downstream consumer audit re-confirmed against current `develop` HEAD: `app-debug.apk` references in repo were two — `.github/workflows/dev-release.yml` (the source) and `docs/RELEASE.md` (docs describing the same behavior). Both updated in lockstep. No other workflow or script pattern-matches the filename.

Ran locally against `develop` HEAD at `1a18a31` immediately before opening this PR.

## Summary

The dev-release CI workflow now uploads the debug APK under a provenance-bearing filename — `brain3-companion-develop-{short-sha}.apk` instead of `app-debug.apk`. After a sideload download from the GitHub Releases page, the filename alone identifies which `develop` commit the APK came from. No APK Analyzer step required for provenance confirmation.

This is the code-side half of the layered defense ratified during Stream C Group 2 close (Escalation 1, P-11 build-provenance reliability). The BRAIN-side half — the "Pre-Install APK Verification" subsection in repo CLAUDE.md instructing the APK Analyzer pre-sideload check — already landed in the v2 cleanup pass and remains in effect; this PR is additive defense, not a replacement.

## Changes

- `.github/workflows/dev-release.yml`: new "Rename APK with short SHA" step inserted between "Compose release notes" and "Create GitHub pre-release". Step is `if: github.event_name == 'push'`-gated to match the surrounding publish steps (PR-triggered runs never reach `gh release create`, so they don't need the renamed asset either). The step does a `cp` rather than a `mv` to keep the original `app-debug.apk` in place for any future local-build muscle memory — the cost of the extra copy on the CI runner is negligible.
- `.github/workflows/dev-release.yml`: the `gh release create` invocation now points at the renamed asset path instead of `app-debug.apk`.
- `docs/RELEASE.md`: two filename references updated to the new pattern — line 29 (the "what the workflow publishes" reference summary) and line 218 (the user-facing sideload instructions). Without this co-located doc update, the docs would describe the previous filename for the very behavior being changed in the same PR.

## How to Verify

1. Local: `git checkout feat/2C-Gap-03-apk-filename-sha; npm run lint; npm run test.unit` — both pass clean.
2. After merge: the next `develop` push triggers `dev-release.yml`. The resulting GitHub Release will carry a single APK asset named `brain3-companion-develop-{short-sha}.apk` matching the release tag's short SHA.
3. PR-trigger run (this PR): the rename step and the create-release step both no-op because their `if:` gate evaluates false on `pull_request`. The earlier "Build debug APK" step still runs and validates the compile path — the PR-trigger gate from #55 continues to do its job.

## Deviations

1. **Co-located documentation update.** The issue body's Downstream Consumer Audit named only workflows and scripts. `docs/RELEASE.md` references `app-debug.apk` in two places — strictly outside the audit's scope, but the docs describe the very behavior being changed in this PR. Per org CLAUDE.md "Keeping CLAUDE.md Current" / drift-prevention principles, the doc-of-the-behavior changes in lockstep with the behavior. Treated as part of the same change rather than a follow-up "Log it, don't fix it" issue.
2. **Step placement after "Compose release notes" rather than between "Build debug APK" and "Compute release metadata".** The issue body's Suggested Fix sketched insertion between Build and Compute Meta — but the rename references `steps.meta.outputs.short_sha`, which is set by the Compute Meta step. The body parenthetically acknowledged this ordering trade-off ("Requires the rename step to run after `meta` — order it accordingly, or recompute the short SHA inline."). I picked the cheaper of the two options: place the step after Compute Meta and reuse the existing output. Same end-state; no inlined short-SHA recomputation.
3. **`if: github.event_name == 'push'` gate on the rename step.** Not in the issue body's Suggested Fix because the body was authored when the workflow was push-only. After #55 merged (the Wave 1 PR-trigger ticket), the publish steps gate on `push` to avoid attempting release creation from PR runs. The rename step adopts the same gate for consistency — PR-triggered runs never reach `gh release create`, so the renamed asset would have no consumer.

## Test Results

```
$ npm run lint
> brain3-companion@0.0.1 lint
> eslint

(exit 0 — no errors)

$ npm run test.unit
 Test Files  45 passed (45)
      Tests  456 passed (456)
   Duration  13.38s
(exit 0)
```

Ran against `develop` HEAD `1a18a31` (post-#55 merge).

## Acceptance Checklist

- [x] Workflow uploads APK under `brain3-companion-develop-{short-sha}.apk` (renamed from `app-debug.apk`)
- [x] Filename embeds the same short SHA that the release tag already carries (`develop-{short-sha}`)
- [x] No other workflow step or script broken by the rename (gh release create asset path positional; prune step matches tag name, not asset filename — re-confirmed against current develop)
- [x] PR-trigger behavior preserved (rename step gated to `push`, matching surrounding publish steps)
- [x] Local verification: lint + test.unit clean against develop HEAD `1a18a31`

Closes #53
