### PR TITLE
[2C-Gap-02]: capacitor-device plugin missing from android gradle sync since [2C-05]

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-device')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-network')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-device'
+project(':capacitor-device').projectDir = new File('../node_modules/@capacitor/device/android')
+
 include ':capacitor-haptics'
 project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/haptics/android')
 


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (no errors)
- `npx tsc --noEmit` — ✅ Pass (no errors)
- `npm run test.unit` — ✅ Pass (45 files, 456 tests passed)
- `npm run android:sync` post-commit idempotency check (`git diff --exit-code android/`) — ✅ Pass (exit 0, zero diff)

Ran locally against develop HEAD at `eb18ab0` immediately before opening this PR.

## Summary

Commits the two `android/` gradle artifacts that `npm run android:sync` regenerates from `@capacitor/device@6.0.3`'s `node_modules` shim. The plugin has been registered in `package.json` since [2C-05] commit `3d6ef44` but the corresponding sync was never run, so develop's `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle` have been silently drifting from `cap sync android`'s output ever since. No code logic, no `package.json` changes, no workflow changes — purely the missing regenerated gradle wiring.

## Changes

- `android/app/capacitor.build.gradle` — adds `implementation project(':capacitor-device')` to the `dependencies { }` block (+1 line).
- `android/capacitor.settings.gradle` — adds `include ':capacitor-device'` and the matching `project(':capacitor-device').projectDir = new File('../node_modules/@capacitor/device/android')` (+3 lines).

Total: 2 files changed, 4 insertions(+). Both files are Capacitor-managed regenerated artifacts; the diff matches the two-file delta documented in #49's body byte-for-byte. The convention codified in repo CLAUDE.md §"Android Sync Structural Guard" (the rule this PR enforces by hand, and that #54 will enforce in CI going forward) explicitly puts the regenerated `android/` artifacts in the same commit as the source-side change — that boat sailed when [2C-05] merged without running sync, so this is the retroactive close.

## How to Verify

1. Check out the merge commit on develop locally.
2. `npm ci` to install dependencies cleanly.
3. `npm run android:sync` (resolves to `npm run build && npx cap sync android`).
4. `git diff --exit-code android/` — expect zero diff (exit 0). Before this PR, the same command produced the documented two-file delta.

## Deviations

None. Brief scope (`e0119685-54d6-4f86-9704-8dcdf6bd356a`) is the two-file commit and post-commit idempotency confirmation — both delivered. No bundling of #54 per the split ruling.

## Test Results

```
$ npm run lint
> eslint
(exit 0, no output)

$ npx tsc --noEmit
(exit 0, no output)

$ npm run test.unit
 Test Files  45 passed (45)
      Tests  456 passed (456)

$ npm run android:sync   # post-commit
[info] Sync finished in 0.187s

$ git diff --exit-code android/
(exit 0, no diff)
```

The post-commit idempotency check is dispositive for the #54 Wave 3 follow-up: `cap sync android` produces zero diff against the merged state of this PR, so the guard step #54 introduces will pass on its own introduction PR (and on every unrelated PR going forward) until the next Capacitor-plugin-vs-android-gradle drift event.

## Acceptance Checklist

- [x] `npm run android:sync` against develop reproduces the documented two-file delta (pre-commit verification).
- [x] Only `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle` modified — nothing else drifts.
- [x] Post-commit, a second `npm run android:sync` produces zero `git diff` against `android/` (idempotency).
- [x] No `package.json` change, no code logic change, no CLAUDE.md edit.
- [x] Conventional commit format with `(#49)` reference.

Closes #49