### PR TITLE
[2C-Gap-04]: Android sync structural guard CI step

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,3 +46,18 @@ jobs:
         # Non-interactive after [2C-Bug-06] (#56): `test.unit` invokes
         # `vitest run`, so this step exits cleanly in CI shells.
         run: npm run test.unit
+
+      - name: Android sync structural guard
+        # Regenerates Capacitor-managed android/ artifacts from
+        # package.json plugin metadata and fails the build if any
+        # uncommitted delta surfaces. Catches the class of drift codified
+        # in repo CLAUDE.md §"Android Sync Structural Guard" (precedent:
+        # [2C-Gap-02] (#49) — @capacitor/device@6.0.3 added to package.json
+        # in [2C-05] without the paired android:sync commit). Placed last
+        # so the cheaper lint/typecheck/test gates fail fast first.
+        run: |
+          npm run android:sync
+          if ! git diff --exit-code android/; then
+            echo "::error::npm run android:sync produced uncommitted changes in android/. See repo CLAUDE.md 'Android Sync Structural Guard' for the convention. Run 'npm run android:sync' locally and commit the regenerated android/ artifacts."
+            exit 1
+          fi


### PR DESCRIPTION
## Verification

- `npm run lint` — ✅ Pass (exit 0, no errors)
- `npx tsc --noEmit` — ✅ Pass (exit 0, no errors)
- `npm run test.unit` — ✅ Pass (45 files, 456 tests passed)
- Local rehearsal of new guard step (`npm run android:sync` + `git diff --exit-code android/`) — ✅ Pass (exit 0, zero diff against develop `74d75cc`)

Ran locally against develop HEAD at `74d75cc` immediately before opening this PR. The local rehearsal is the dispositive empirical check that the guard step passes on its own introduction PR — `74d75cc` is the post-#49-merge state where develop's committed `android/` matches `cap sync android` output deterministically.

## Summary

Wave 3 of the CI hardening pass. Adds a new "Android sync structural guard" step to the existing single-job `pr-checks.yml` workflow that #77 (Wave 2, PR #81) introduced. The step regenerates Capacitor-managed `android/` artifacts via `npm run android:sync` and fails the build on any uncommitted delta in `android/`, mechanically enforcing the convention codified in repo CLAUDE.md §"Android Sync Structural Guard."

The class of drift this catches: a JS-side `npm install` adds/removes/upgrades a Capacitor plugin without `npm run android:sync` being run in the same commit, so the Android gradle config silently falls out of sync with `package.json`. The precedent is [2C-Gap-02] (#49) — `@capacitor/device@6.0.3` added in [2C-05] without the paired sync, surfaced months later during a Bug-04 fix dispatch — closed by PR #82 (the immediate fix this guard is built to prevent from recurring).

After Wave 3 merges, the CI hardening pass is complete. Per the Wave 3 brief, L moves into Group 5 Close Pass authoring next.

## Changes

- `.github/workflows/pr-checks.yml` — adds one new step (`Android sync structural guard`) at the end of the existing `checks` job. +15 lines, no other changes.

The new step's shell logic matches the pseudocode in issue #54 verbatim: `npm run android:sync`, then `if ! git diff --exit-code android/`, emit a `::error::` annotation naming the drift class and pointing at the repo CLAUDE.md convention, exit non-zero. The annotation message is on one line per repo CLAUDE.md §"GitHub Actions" preference for simple YAML forms.

### Placement decision

The guard step goes **as a step in the existing `checks` job, not as a sibling job.** Two reasons:

1. **Shares provisioning cost.** The existing job already runs `actions/checkout@v4`, `setup-node@v4` with npm cache, and `npm ci`. A sibling job would duplicate ~15-20s of setup for a step whose total work is ~10s (`npm run build` + `cap sync` + `git diff`). Net cost in-job is much lower than splitting.
2. **Issue #54 host diligence explicitly endorses both shapes.** Issue body: "The android-sync guard step runs in the same job (or as a sibling job) as lint/typecheck/test.unit." Implementer judgment landed on same-job.

### Step ordering decision

The guard is the **last step** in the job (after Unit tests) so the cheaper lint/typecheck/test gates fail fast first. Lint ~1s, typecheck ~5s, tests ~13s, sync ~10s — fail-fast order means contributors learn about lint typos in ~1s rather than after a 10s sync step they didn't need to wait for.

## How to Verify

1. Check out the merge commit on develop after this PR merges.
2. `npm ci` to install dependencies cleanly.
3. `npm run android:sync` followed by `git diff --exit-code android/` — should produce zero diff against develop's committed state (this is what the CI step runs).
4. **Intentional-drift test:** to confirm the guard fails loud, on a throwaway branch `npm install @capacitor/some-new-plugin --save` (or any package that adds an android gradle entry), then open a PR against develop. The workflow run for that PR should fail at the new step with the `::error::` annotation pointing at the CLAUDE.md convention. (Optional — not required for merge; can be exercised the next time a Capacitor plugin change comes through naturally.)

## Deviations

None. Brief scope (`9117cb99-c120-4787-b59b-a3ce1aad7abd`) was the single guard step on `pr-checks.yml`, implemented per the issue #54 pseudocode shape with the placement/ordering decisions left to implementer judgment per directive `1f57a024`. No CLAUDE.md edit per directive `4ea28266` (the Phase 5 amendment that drops the "(implementation queued in [2C-Gap-04] (#54))" hedge from the Android Sync Structural Guard section is PO's separate update after this merges, per directive `5cb98368` Shape B).

## Flagged for Phase 5 follow-up

Repo CLAUDE.md `908baa66` §"Android Sync Structural Guard" → "CI guard (deferred)" subsection currently reads:

> **CI guard (deferred):** A repo CI step that runs `npm run android:sync` and fails if `git diff --exit-code android/` produces a non-empty diff would catch this class of drift mechanically. Filed as enhancement against this convention; not yet implemented. See issue `[2C-Gap-02]` (#49) for the precedent and `[2C-Gap-04]` (#54) for the CI step implementation issue.

After this PR merges, that section is no longer accurate — the CI guard is no longer deferred. Per directive `4ea28266` (CLAUDE.md is PO-controlled, agents flag don't fix), flagging the drift for L's separate BRAIN canonical update. The corresponding update to `Pre-PR Verification Gates` item 1 hedge (which references #55, not #54, so probably unaffected) should also be reviewed.

## Test Results

```
$ npm run lint
> eslint
(exit 0)

$ npx tsc --noEmit
(exit 0)

$ npm run test.unit
 Test Files  45 passed (45)
      Tests  456 passed (456)

$ npm run android:sync && git diff --exit-code android/
[info] Sync finished in 0.191s
(exit 0, zero diff against develop 74d75cc)
```

Ran locally against develop HEAD `74d75cc` (post-#49 merge state) immediately before opening this PR. The local rehearsal output mirrors what the CI step will produce on this PR's workflow run.

## Acceptance Checklist

- [x] `.github/workflows/pr-checks.yml` gains an "Android sync structural guard" step.
- [x] Step runs `npm run android:sync` and `git diff --exit-code android/`.
- [x] On non-empty diff, step emits a `::error::` annotation naming the drift class and pointing at repo CLAUDE.md convention, then exits non-zero.
- [x] Step runs in the existing single ubuntu-latest job (implementer judgment per issue #54 host diligence and directive `1f57a024`).
- [x] Step belongs on the JS-side PR-gate workflow (`pr-checks.yml`), not on `dev-release.yml`'s Android PR-trigger (#55) heavy Gradle build path.
- [x] Local idempotency verified empirically (`npm run android:sync` twice against develop `74d75cc` produces zero diff both times).
- [x] No `package.json` change, no code logic change, no CLAUDE.md edit.

Closes #54